### PR TITLE
[PassBuilder][PassManagerBuilder][Tapir] Move verification of the IR …

### DIFF
--- a/llvm/lib/Passes/PassBuilder.cpp
+++ b/llvm/lib/Passes/PassBuilder.cpp
@@ -241,6 +241,11 @@ static cl::opt<bool>
     EnableCHR("enable-chr-npm", cl::init(true), cl::Hidden,
               cl::desc("Enable control height reduction optimization (CHR)"));
 
+static cl::opt<bool>
+    VerifyTapirLowering("verify-tapir-lowering-npm", cl::init(false),
+                        cl::Hidden,
+                        cl::desc("Verify IR after Tapir lowering steps"));
+
 PipelineTuningOptions::PipelineTuningOptions() {
   LoopInterleaving = EnableLoopInterleaving;
   LoopVectorization = EnableLoopVectorization;
@@ -1104,6 +1109,8 @@ PassBuilder::buildTapirLoweringPipeline(OptimizationLevel Level,
 
   // Outline Tapir loops as needed.
   MPM.addPass(LoopSpawningPass());
+  if (VerifyTapirLowering)
+    MPM.addPass(VerifierPass());
 
   // The LoopSpawning pass may leave cruft around.  Clean it up using the
   // function simplification pipeline.
@@ -1120,6 +1127,8 @@ PassBuilder::buildTapirLoweringPipeline(OptimizationLevel Level,
 
   // Lower Tapir to target runtime calls.
   MPM.addPass(TapirToTargetPass());
+  if (VerifyTapirLowering)
+    MPM.addPass(VerifierPass());
 
   // The TapirToTarget pass may leave cruft around.  Clean it up using the
   // function simplification pipeline.

--- a/llvm/lib/Transforms/IPO/PassManagerBuilder.cpp
+++ b/llvm/lib/Transforms/IPO/PassManagerBuilder.cpp
@@ -163,6 +163,10 @@ static cl::opt<bool> DisableTapirOpts(
     "disable-tapir-opts", cl::init(false), cl::Hidden,
     cl::desc("Disable Tapir optimizations by outlining Tapir tasks early"));
 
+static cl::opt<bool>
+    VerifyTapirLowering("verify-tapir-lowering", cl::init(false), cl::Hidden,
+                        cl::desc("Verify IR after Tapir lowering steps"));
+
 PassManagerBuilder::PassManagerBuilder() {
     TapirTarget = TapirTargetID::None;
     OptLevel = 2;
@@ -908,6 +912,9 @@ void PassManagerBuilder::populateModulePassManager(
     MPM.add(createLoopRotatePass(SizeLevel == 2 ? 0 : -1));
     // Outline Tapir loops as needed.
     MPM.add(createLoopSpawningTIPass());
+    if (VerifyTapirLowering)
+      // Verify the IR produced by loop spawning
+      MPM.add(createVerifierPass());
 
     // The LoopSpawning pass may leave cruft around.  Clean it up.
     MPM.add(createCFGSimplificationPass());
@@ -925,6 +932,9 @@ void PassManagerBuilder::populateModulePassManager(
     // Now lower Tapir to Target runtime calls.
     MPM.add(createTaskCanonicalizePass());
     MPM.add(createLowerTapirToTargetPass());
+    if (VerifyTapirLowering)
+      // Verify the IR produced by Tapir lowering
+      MPM.add(createVerifierPass());
     // The lowering pass introduces new functions and may leave cruft around.
     // Clean it up.
     MPM.add(createCFGSimplificationPass());

--- a/llvm/lib/Transforms/Tapir/LoopSpawningTI.cpp
+++ b/llvm/lib/Transforms/Tapir/LoopSpawningTI.cpp
@@ -1574,12 +1574,15 @@ bool LoopSpawningImpl::run() {
   // Perform any Target-dependent postprocessing of F.
   Target->postProcessFunction(F, true);
 
-#ifndef NDEBUG
-  if (verifyModule(*F.getParent(), &errs())) {
-    LLVM_DEBUG(dbgs() << "Module after loop spawning:" << *F.getParent());
-    llvm_unreachable("Loop spawning produced bad IR!");
-  }
-#endif
+  LLVM_DEBUG({
+    NamedRegionTimer NRT("verify", "Post-loop-spawning verification",
+                         TimerGroupName, TimerGroupDescription,
+                         TimePassesIsEnabled);
+    if (verifyModule(*F.getParent(), &errs())) {
+      LLVM_DEBUG(dbgs() << "Module after loop spawning:" << *F.getParent());
+      llvm_unreachable("Loop spawning produced bad IR!");
+    }
+  });
 
   return true;
 }


### PR DESCRIPTION
…after Tapir lowering steps to speed up compilation.  In particular, avoid checking the whole module after processing each function.