### PR TITLE
Feature request: an API to register externally defined tapir target

### DIFF
--- a/llvm/include/llvm/Analysis/TargetLibraryInfo.h
+++ b/llvm/include/llvm/Analysis/TargetLibraryInfo.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_ANALYSIS_TARGETLIBRARYINFO_H
 #define LLVM_ANALYSIS_TARGETLIBRARYINFO_H
 
+#include <functional>
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/Optional.h"
 #include "llvm/ADT/Triple.h"
@@ -18,6 +19,7 @@
 #include "llvm/IR/PassManager.h"
 #include "llvm/Pass.h"
 #include "llvm/Transforms/Tapir/TapirTargetIDs.h"
+#include "llvm/Transforms/Tapir/LoweringUtils.h"
 
 namespace llvm {
 template <typename T> class ArrayRef;
@@ -37,6 +39,8 @@ struct VecDesc {
 
     NumLibFuncs
   };
+
+using TapirTargetFactory = std::function<TapirTarget *(Module &)>;
 
 /// Implementation of the target library information.
 ///
@@ -203,6 +207,8 @@ public:
   void setTapirTarget(TapirTargetID TargetID) {
     TapirTarget = TargetID;
   }
+
+  void setTapirTarget(TapirTargetFactory target);
 
   /// Return the ID of the target for Tapir lowering.
   TapirTargetID getTapirTarget() const {

--- a/llvm/include/llvm/Transforms/Tapir/LoweringUtils.h
+++ b/llvm/include/llvm/Transforms/Tapir/LoweringUtils.h
@@ -13,6 +13,7 @@
 #ifndef LOWERING_UTILS_H_
 #define LOWERING_UTILS_H_
 
+#include <functional>
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/SetVector.h"
@@ -408,6 +409,8 @@ public:
 
 /// Generate a TapirTarget object for the specified TapirTargetID.
 TapirTarget *getTapirTargetFromID(Module &M, TapirTargetID TargetID);
+
+void setCustomTapirTarget(std::function<TapirTarget *(Module &)>);
 
 /// Find all inputs to tasks within a function \p F, including nested tasks.
 TaskValueSetMap findAllTaskInputs(Function &F, const DominatorTree &DT,

--- a/llvm/include/llvm/Transforms/Tapir/TapirTargetIDs.h
+++ b/llvm/include/llvm/Transforms/Tapir/TapirTargetIDs.h
@@ -25,6 +25,7 @@ enum class TapirTargetID {
   OpenCilk, // Lower to OpenCilk ABI
   OpenMP,   // Lower to OpenMP
   Qthreads, // Lower to Qthreads
+  Custom,
   Last_TapirTargetID
 };
 

--- a/llvm/lib/Transforms/Tapir/LoweringUtils.cpp
+++ b/llvm/lib/Transforms/Tapir/LoweringUtils.cpp
@@ -36,6 +36,13 @@ using namespace llvm;
 static const char TimerGroupName[] = DEBUG_TYPE;
 static const char TimerGroupDescription[] = "Tapir lowering";
 
+static TapirTargetFactory CUSTOM_TAPIR_TARGET;
+
+void llvm::TargetLibraryInfoImpl::setTapirTarget(TapirTargetFactory target) {
+  TapirTarget = TapirTargetID::Custom;
+  CUSTOM_TAPIR_TARGET = target;
+}
+
 TapirTarget *llvm::getTapirTargetFromID(Module &M, TapirTargetID ID) {
   switch (ID) {
   case TapirTargetID::None:
@@ -53,6 +60,8 @@ TapirTarget *llvm::getTapirTargetFromID(Module &M, TapirTargetID ID) {
     return new OpenMPABI(M);
   case TapirTargetID::Qthreads:
     return new QthreadsABI(M);
+  case TapirTargetID::Custom:
+    return CUSTOM_TAPIR_TARGET(M);
   default:
     llvm_unreachable("Invalid TapirTargetID");
   }


### PR DESCRIPTION
This is a feature request/question on the API for using externally defined tapir target. IIUC, opencilk does not have an API for this. Can we have, for example, a method

```cpp
using TapirTargetFactory = std::function<TapirTarget *(Module &)>;
TargetLibraryInfoImpl::setTapirTarget(TapirTargetFactory target)
```

where `target`is a function that takes a module and return a target? [This](https://github.com/tkf/julia/blob/b136cc00c424e47fdd992a34842c3b1b7cc3d8b6/src/aotcompile.cpp#L608) is how I actually use it.

I'm not suggesting this particular API and this PR is just to concretely illustrate what functionality I'd like to access.  Also, this implementation is terrible and have to be written in such a way that you don't need to use a global variable (This patch is optimized for minimal diff ATM).  If this API is OK to add, I can try moving the state into `TargetLibraryInfoImpl`.
