### PR TITLE
Neboat/strandpure dev10

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -3539,3 +3539,9 @@ def StrandPure : InheritableAttr {
   let Subjects = SubjectList<[FunctionLike]>;
   let Documentation = [StrandPureDocs];
 }
+
+def StrandMalloc : InheritableAttr {
+  let Spellings = [Clang<"strand_malloc">];
+  let Subjects = SubjectList<[Function]>;
+  let Documentation = [StrandMallocDocs];
+}

--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -311,6 +311,7 @@ def BlocksSupported : LangOpt<"Blocks">;
 def ObjCAutoRefCount : LangOpt<"ObjCAutoRefCount">;
 def ObjCNonFragileRuntime : LangOpt<"ObjCNonFragileRuntime",
                                     "LangOpts.ObjCRuntime.allowsClassStubs()">;
+def Cilk : LangOpt<"Cilk", "LangOpts.getCilk() != LangOptions::Cilk_none">;
 
 // Language option for CMSE extensions
 def Cmse : LangOpt<"Cmse">;
@@ -3521,4 +3522,20 @@ def ReleaseHandle : InheritableParamAttr {
   let Args = [StringArgument<"HandleType">];
   let Subjects = SubjectList<[ParmVar]>;
   let Documentation = [ReleaseHandleDocs];
+}
+
+// Cilk attributes
+
+// TODO: Add docs to these attributes
+
+def Stealable : InheritableAttr {
+  let Spellings = [Clang<"stealable">];
+  let Subjects = SubjectList<[FunctionLike]>;
+  let Documentation = [StealableDocs];
+}
+
+def StrandPure : InheritableAttr {
+  let Spellings = [Clang<"strand_pure">];
+  let Subjects = SubjectList<[FunctionLike]>;
+  let Documentation = [StrandPureDocs];
 }

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -4787,3 +4787,19 @@ close the handle. It is also assumed to require an open handle to work with.
   zx_status_t zx_handle_close(zx_handle_t handle [[clang::release_handle]]);
   }];
 }
+
+def StrandPureDocs : Documentation {
+  let Category = DocCatFunction;
+  let Content = [{
+The ``strand_pure`` attribute denotes that the function acts like a pure function
+when called multiple times within the same strand.
+  }];
+}
+
+def StealableDocs : Documentation {
+  let Category = DocCatFunction;
+  let Content = [{
+The ``stealable`` attribute denotes that the function contains a continuation that
+can be stolen by a work-stealing scheduler.
+  }];
+}

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -4803,3 +4803,12 @@ The ``stealable`` attribute denotes that the function contains a continuation th
 can be stolen by a work-stealing scheduler.
   }];
 }
+
+def StrandMallocDocs : Documentation {
+  let Category = DocCatFunction;
+  let Content = [{
+The ``strand_malloc`` attribute denotes that the function pointer acts
+like a system memory allocation function from the perspective of
+memory operations within the same strand.
+}];
+}

--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -524,6 +524,7 @@ static TargetLibraryInfoImpl *createTLII(llvm::Triple &TargetTriple,
   }
 
   TLII->setTapirTarget(CodeGenOpts.getTapirTarget());
+  TLII->addTapirTargetLibraryFunctions();
 
   return TLII;
 }

--- a/clang/lib/CodeGen/CGCall.cpp
+++ b/clang/lib/CodeGen/CGCall.cpp
@@ -1865,6 +1865,8 @@ void CodeGenModule::ConstructAttributeList(
       FuncAttrs.addAttribute(llvm::Attribute::NoDuplicate);
     if (TargetDecl->hasAttr<ConvergentAttr>())
       FuncAttrs.addAttribute(llvm::Attribute::Convergent);
+    if (TargetDecl->hasAttr<StealableAttr>())
+      FuncAttrs.addAttribute(llvm::Attribute::Stealable);
 
     if (const FunctionDecl *Fn = dyn_cast<FunctionDecl>(TargetDecl)) {
       AddAttributesFromFunctionProtoType(
@@ -1904,6 +1906,10 @@ void CodeGenModule::ConstructAttributeList(
       FuncAttrs.addAttribute(llvm::Attribute::NoUnwind);
     } else if (TargetDecl->hasAttr<NoAliasAttr>()) {
       FuncAttrs.addAttribute(llvm::Attribute::ArgMemOnly);
+      FuncAttrs.addAttribute(llvm::Attribute::NoUnwind);
+    } else if (TargetDecl->hasAttr<StrandPureAttr>()) {
+      FuncAttrs.addAttribute(llvm::Attribute::StrandPure);
+      FuncAttrs.addAttribute(llvm::Attribute::ReadOnly);
       FuncAttrs.addAttribute(llvm::Attribute::NoUnwind);
     }
     if (TargetDecl->hasAttr<RestrictAttr>())

--- a/clang/lib/CodeGen/CGCall.cpp
+++ b/clang/lib/CodeGen/CGCall.cpp
@@ -1914,6 +1914,8 @@ void CodeGenModule::ConstructAttributeList(
     }
     if (TargetDecl->hasAttr<RestrictAttr>())
       RetAttrs.addAttribute(llvm::Attribute::NoAlias);
+    else if (TargetDecl->hasAttr<StrandMallocAttr>())
+      RetAttrs.addAttribute(llvm::Attribute::StrandNoAlias);
     if (TargetDecl->hasAttr<ReturnsNonNullAttr>() &&
         !CodeGenOpts.NullPointerIsValid)
       RetAttrs.addAttribute(llvm::Attribute::NonNull);

--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -852,6 +852,14 @@ void CodeGenFunction::StartFunction(GlobalDecl GD, QualType RetTy,
     }
   }
 
+  // Add Cilk attributes
+  if (D && (getLangOpts().getCilk() != LangOptions::Cilk_none)) {
+    if (D->getAttr<StrandPureAttr>())
+      Fn->setStrandPure();
+    if (D->getAttr<StealableAttr>())
+      Fn->addFnAttr(llvm::Attribute::Stealable);
+  }
+
   // Add no-jump-tables value.
   Fn->addFnAttr("no-jump-tables",
                 llvm::toStringRef(CGM.getCodeGenOpts().NoUseJumpTables));

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -7462,6 +7462,9 @@ static void ProcessDeclAttribute(Sema &S, Scope *scope, Decl *D,
     break;
 
   // Cilk attributes
+  case ParsedAttr::AT_StrandMalloc:
+    handleSimpleAttribute<StrandMallocAttr>(S, D, AL);
+    break;
   case ParsedAttr::AT_StrandPure:
     handleSimpleAttribute<StrandPureAttr>(S, D, AL);
     break;

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -7460,6 +7460,14 @@ static void ProcessDeclAttribute(Sema &S, Scope *scope, Decl *D,
   case ParsedAttr::AT_UseHandle:
     handleHandleAttr<UseHandleAttr>(S, D, AL);
     break;
+
+  // Cilk attributes
+  case ParsedAttr::AT_StrandPure:
+    handleSimpleAttribute<StrandPureAttr>(S, D, AL);
+    break;
+  case ParsedAttr::AT_Stealable:
+    handleSimpleAttribute<StealableAttr>(S, D, AL);
+    break;
   }
 }
 

--- a/clang/test/Cilk/implicit-sync-scopes.cpp
+++ b/clang/test/Cilk/implicit-sync-scopes.cpp
@@ -982,8 +982,7 @@ int mix_parfor_trycatch(int a) {
 // CHECK: reattach within %[[PFORSYNCREG]], label %[[PFORINC]]
 
 // CHECK: [[PFORINC]]:
-// CHECK-O0: br i1 {{.+}}, label %{{.+}}, label %[[PFORSYNC:.+]], !llvm.loop
-// CHECK-O1: br i1 {{.+}}, label %[[PFORSYNC:.+]], label {{.+}}, !llvm.loop
+// CHECK: br i1 {{.+}}, label %{{.+}}, label %[[PFORSYNC:.+]], !llvm.loop
 
 // CHECK: [[PFORSYNC]]:
 // CHECK: sync within %[[PFORSYNCREG]], label %[[PFORSYNCCONT:.+]]
@@ -1010,7 +1009,7 @@ int mix_parfor_trycatch(int a) {
 // CHECK-O1-NEXT: landingpad
 // CHECK-O1-NEXT: cleanup
 // CHECK-O1: invoke void @llvm.detached.rethrow.sl_p0i8i32s(token %[[PFORSYNCREG]],
-// CHECK-O1-NEXT: to label %[[UNREACHABLE]] unwind label %[[PFORLPADUNW:.+]]
+// CHECK-O1-NEXT: to label %[[UNREACHABLE]] unwind label %[[PFORUNW:.+]]
 
 // CHECK-O1: [[PFORUNW]]:
 // CHECK-O1-NEXT: landingpad
@@ -1018,15 +1017,9 @@ int mix_parfor_trycatch(int a) {
 // CHECK-O1-NEXT: catch i8* bitcast (i8** @_ZTIi to i8*)
 // CHECK-O1-NEXT: br label %[[CATCHDISPATCH]]
 
-// CHECK-O1: [[PFORLPADUNW]]:
-// CHECK-O1-NEXT: landingpad
-// CHECK-O1-NEXT: cleanup
-// CHECK-O1-NEXT: catch i8* bitcast (i8** @_ZTIi to i8*)
-// CHECK-O1-NEXT: br label %[[CATCHDISPATCH]]
-
 // CHECK-O1: [[PFORSYNCCONT]]:
 // CHECK-O1-NEXT: invoke void @llvm.sync.unwind(token %[[PFORSYNCREG]])
-// CHECK-O1-NEXT: to label %[[PFORSUCONT:.+]] unwind label %[[PFORLPADUNW]]
+// CHECK-O1-NEXT: to label %[[PFORSUCONT:.+]] unwind label %[[PFORUNW]]
 
 // CHECK: [[CATCHDISPATCH]]:
 // CHECK: br i1 {{.+}}, label %[[CATCH:.+]], label %[[RESUME:.+]]
@@ -1193,8 +1186,7 @@ int mix_parfor_trycatch_destructors(int a) {
 // CHECK: reattach within %[[PFORSYNCREG]], label %[[PFORINC]]
 
 // CHECK: [[PFORINC]]:
-// CHECK-O0: br i1 {{.+}}, label %{{.+}}, label %[[PFORSYNC:.+]], !llvm.loop
-// CHECK-O1: br i1 {{.+}}, label %[[PFORSYNC:.+]], label {{.+}}, !llvm.loop
+// CHECK: br i1 {{.+}}, label %{{.+}}, label %[[PFORSYNC:.+]], !llvm.loop
 
 // CHECK: [[PFORSYNC]]:
 // CHECK: sync within %[[PFORSYNCREG]], label %[[PFORSYNCCONT:.+]]
@@ -1203,19 +1195,13 @@ int mix_parfor_trycatch_destructors(int a) {
 // CHECK-O1-NEXT: landingpad
 // CHECK-O1-NEXT: cleanup
 // CHECK-O1: invoke void @llvm.detached.rethrow.sl_p0i8i32s(token %[[PFORSYNCREG]],
-// CHECK-O1-NEXT: to label %[[UNREACHABLE]] unwind label %[[PFORLPADUNW:.+]]
+// CHECK-O1-NEXT: to label %[[UNREACHABLE]] unwind label %[[PFORUNW:.+]]
 
 // CHECK-O1: [[PFORUNW]]:
 // CHECK-O1-NEXT: landingpad
 // CHECK-O1-NEXT: cleanup
 // CHECK-O1-NEXT: catch i8* bitcast (i8** @_ZTIi to i8*)
 // CHECK-O1-NEXT: br label %[[PFORLPADJOIN:.+]]
-
-// CHECK-O1: [[PFORLPADUNW]]:
-// CHECK-O1-NEXT: landingpad
-// CHECK-O1-NEXT: cleanup
-// CHECK-O1-NEXT: catch i8* bitcast (i8** @_ZTIi to i8*)
-// CHECK-O1-NEXT: br label %[[PFORLPADJOIN]]
 
 // CHECK-O1: [[PFORLPADJOIN]]:
 // CHECK-O1: br label %[[B2CLEANUP]]
@@ -1956,8 +1942,7 @@ int parfor_trycatch(int a) {
 // CHECK: reattach within %[[PFORSYNCREG1]], label %[[PFORINC1]]
 
 // CHECK: [[PFORINC1]]:
-// CHECK-O0: br i1 {{.+}}, label {{.+}}, label %[[PFORSYNC1:.+]], !llvm.loop
-// CHECK-O1: br i1 {{.+}}, label %[[PFORSYNC1:.+]], label {{.+}}, !llvm.loop
+// CHECK: br i1 {{.+}}, label {{.+}}, label %[[PFORSYNC1:.+]], !llvm.loop
 
 // CHECK: [[PFORSYNC1]]:
 // CHECK-O0: sync within %[[PFORSYNCREG1]], label %[[PFORSYNCCONT1:.+]]
@@ -2033,8 +2018,7 @@ int parfor_trycatch(int a) {
 // CHECK: reattach within %[[PFORSYNCREG2]], label %[[PFORINC2]]
 
 // CHECK: [[PFORINC2]]:
-// CHECK-O0: br i1 {{.+}}, label {{.+}}, label %[[PFORSYNC2:.+]], !llvm.loop
-// CHECK-O1: br i1 {{.+}}, label %[[PFORSYNC2:.+]], label {{.+}}, !llvm.loop
+// CHECK: br i1 {{.+}}, label {{.+}}, label %[[PFORSYNC2:.+]], !llvm.loop
 
 // CHECK: [[PFORSYNC2]]:
 // CHECK-O0: sync within %[[PFORSYNCREG2]], label %[[PFORSYNCCONT2:.+]]
@@ -2227,8 +2211,7 @@ int parfor_trycatch_destructors(int a) {
 // CHECK: reattach within %[[PFORSYNCREG1]], label %[[PFORINC1]]
 
 // CHECK: [[PFORINC1]]:
-// CHECK-O0: br i1 {{.+}}, label {{.+}}, label %[[PFORSYNC1:.+]], !llvm.loop
-// CHECK-O1: br i1 {{.+}}, label %[[PFORSYNC1:.+]], label {{.+}}, !llvm.loop
+// CHECK: br i1 {{.+}}, label {{.+}}, label %[[PFORSYNC1:.+]], !llvm.loop
 
 // CHECK: [[PFORSYNC1]]:
 // CHECK-O0: sync within %[[PFORSYNCREG1]], label %[[PFORSYNCCONT1:.+]]
@@ -2236,17 +2219,12 @@ int parfor_trycatch_destructors(int a) {
 
 // CHECK: [[PFORCLEANUP1]]:
 // CHECK: invoke void @llvm.detached.rethrow.sl_p0i8i32s(token %[[PFORSYNCREG1]],
-// CHECK-NEXT: to label %[[UNREACHABLE]] unwind label %[[PFORDU1DR:.+]]
+// CHECK-NEXT: to label %[[UNREACHABLE]] unwind label %[[PFORDU1]]
 
 // CHECK-O1: [[PFORDU1]]:
 // CHECK-O1-NEXT: landingpad
 // CHECK-O1-NEXT: cleanup
 // CHECK-O1-NEXT: br label %[[PFORLPAD1:.+]]
-
-// CHECK-O1: [[PFORDU1DR]]:
-// CHECK-O1-NEXT: landingpad
-// CHECK-O1-NEXT: cleanup
-// CHECK-O1-NEXT: br label %[[PFORLPAD1]]
 
 // CHECK-O1: [[PFORLPAD1]]:
 // CHECK-O1: br label %[[TASKCLEANUP1]]
@@ -2328,8 +2306,7 @@ int parfor_trycatch_destructors(int a) {
 // CHECK: reattach within %[[PFORSYNCREG2]], label %[[PFORINC2]]
 
 // CHECK: [[PFORINC2]]:
-// CHECK-O0: br i1 {{.+}}, label {{.+}}, label %[[PFORSYNC2:.+]], !llvm.loop
-// CHECK-O1: br i1 {{.+}}, label %[[PFORSYNC2:.+]], label {{.+}}, !llvm.loop
+// CHECK: br i1 {{.+}}, label {{.+}}, label %[[PFORSYNC2:.+]], !llvm.loop
 
 // CHECK: [[PFORSYNC2]]:
 // CHECK-O0: sync within %[[PFORSYNCREG2]], label %[[PFORSYNCCONT2:.+]]
@@ -2338,17 +2315,12 @@ int parfor_trycatch_destructors(int a) {
 // CHECK: [[PFORCLEANUP2]]:
 // CHECK: invoke void @llvm.detached.rethrow.sl_p0i8i32s(token %[[PFORSYNCREG2]],
 // CHECK-O0-NEXT: to label %[[UNREACHABLE]] unwind label %[[PFORDU1]]
-// CHECK-O1-NEXT: to label %[[UNREACHABLE]] unwind label %[[PFORDU2DR:.+]]
+// CHECK-O1-NEXT: to label %[[UNREACHABLE]] unwind label %[[PFORDU2]]
 
 // CHECK-O1: [[PFORDU2]]:
 // CHECK-O1-NEXT: landingpad
 // CHECK-O1-NEXT: cleanup
 // CHECK-O1-NEXT: br label %[[PFORLPAD2:.+]]
-
-// CHECK-O1: [[PFORDU2DR]]:
-// CHECK-O1-NEXT: landingpad
-// CHECK-O1-NEXT: cleanup
-// CHECK-O1-NEXT: br label %[[PFORLPAD2]]
 
 // CHECK-O1: [[PFORLPAD2]]:
 // CHECK-O1: br label %[[TASKCLEANUP1]]

--- a/clang/test/CodeGenCXX/auto-var-init.cpp
+++ b/clang/test/CodeGenCXX/auto-var-init.cpp
@@ -1042,7 +1042,9 @@ TEST_UNINIT(intptr4, int*[4]);
 // CHECK:            %uninit = alloca [4 x i32*], align
 // CHECK-NEXT:       call void @{{.*}}used{{.*}}%uninit)
 // PATTERN-O1-LABEL: @test_intptr4_uninit()
-// PATTERN-O1:  call void @llvm.memset.p0i8.i64(i8* nonnull align 16  dereferenceable(32) %{{[0-9*]}}, i8 -86, i64 32, i1 false)
+// PATTERN-O1:       %0 = bitcast [4 x i32*]* %uninit to i8*
+// PATTERN-O1-NEXT:  call void @llvm.lifetime.start.p0i8(i64 32, i8* nonnull %0)
+// PATTERN-O1-NEXT:  call void @llvm.memset.p0i8.i64(i8* nonnull align 16  dereferenceable(32) %0, i8 -86, i64 32, i1 false)
 // ZERO-LABEL:       @test_intptr4_uninit()
 // ZERO:             call void @llvm.memset{{.*}}, i8 0,
 

--- a/clang/test/Misc/pragma-attribute-supported-attributes-list.test
+++ b/clang/test/Misc/pragma-attribute-supported-attributes-list.test
@@ -142,6 +142,7 @@
 // CHECK-NEXT: SetTypestate (SubjectMatchRule_function_is_member)
 // CHECK-NEXT: SpeculativeLoadHardening (SubjectMatchRule_function, SubjectMatchRule_objc_method)
 // CHECK-NEXT: Stealable (SubjectMatchRule_hasType_functionType)
+// CHECK-NEXT: StrandMalloc (SubjectMatchRule_function)
 // CHECK-NEXT: StrandPure (SubjectMatchRule_hasType_functionType)
 // CHECK-NEXT: SwiftContext (SubjectMatchRule_variable_is_parameter)
 // CHECK-NEXT: SwiftErrorResult (SubjectMatchRule_variable_is_parameter)

--- a/clang/test/Misc/pragma-attribute-supported-attributes-list.test
+++ b/clang/test/Misc/pragma-attribute-supported-attributes-list.test
@@ -141,6 +141,8 @@
 // CHECK-NEXT: Section (SubjectMatchRule_function, SubjectMatchRule_variable_is_global, SubjectMatchRule_objc_method, SubjectMatchRule_objc_property)
 // CHECK-NEXT: SetTypestate (SubjectMatchRule_function_is_member)
 // CHECK-NEXT: SpeculativeLoadHardening (SubjectMatchRule_function, SubjectMatchRule_objc_method)
+// CHECK-NEXT: Stealable (SubjectMatchRule_hasType_functionType)
+// CHECK-NEXT: StrandPure (SubjectMatchRule_hasType_functionType)
 // CHECK-NEXT: SwiftContext (SubjectMatchRule_variable_is_parameter)
 // CHECK-NEXT: SwiftErrorResult (SubjectMatchRule_variable_is_parameter)
 // CHECK-NEXT: SwiftIndirectResult (SubjectMatchRule_variable_is_parameter)

--- a/llvm/include/llvm/Analysis/AliasAnalysis.h
+++ b/llvm/include/llvm/Analysis/AliasAnalysis.h
@@ -303,7 +303,9 @@ public:
   using IsCapturedCacheT = SmallDenseMap<const Value *, bool, 8>;
   IsCapturedCacheT IsCapturedCache;
 
-  AAQueryInfo() : AliasCache(), IsCapturedCache() {}
+  bool AssumeSameSpindle;
+
+  AAQueryInfo() : AliasCache(), IsCapturedCache(), AssumeSameSpindle(false) {}
 };
 
 class BatchAAResults;
@@ -347,6 +349,11 @@ public:
   /// each other. This is the interface that must be implemented by specific
   /// alias analysis implementations.
   AliasResult alias(const MemoryLocation &LocA, const MemoryLocation &LocB);
+
+  /// Version of alias() method where the assumption is explicitly stated of
+  /// whether the query applies to operations within the same spindle.
+  AliasResult alias(const MemoryLocation &LocA, const MemoryLocation &LocB,
+                    bool AssumeSameSpindle);
 
   /// A convenience wrapper around the primary \c alias interface.
   AliasResult alias(const Value *V1, LocationSize V1Size, const Value *V2,
@@ -527,6 +534,17 @@ public:
 
   /// getModRefInfo (for call sites) - Return information about whether
   /// a particular call site modifies or reads the specified memory location.
+  ModRefInfo getModRefInfo(const CallBase *Call, const MemoryLocation &Loc,
+                           bool SameSpindle);
+
+  /// getModRefInfo (for call sites) - A convenience wrapper.
+  ModRefInfo getModRefInfo(const CallBase *Call, const Value *P,
+                           LocationSize Size, bool SameSpindle) {
+    return getModRefInfo(Call, MemoryLocation(P, Size), SameSpindle);
+  }
+
+  /// getModRefInfo (for call sites) - Return information about whether
+  /// a particular call site modifies or reads the specified memory location.
   ModRefInfo getModRefInfo(const CallBase *Call, const MemoryLocation &Loc);
 
   /// getModRefInfo (for call sites) - A convenience wrapper.
@@ -659,12 +677,27 @@ public:
 
   /// Return information about whether a call and an instruction may refer to
   /// the same memory locations.
-  ModRefInfo getModRefInfo(Instruction *I, const CallBase *Call);
+  ModRefInfo getModRefInfo(Instruction *I, const CallBase *Call) {
+    return getModRefInfo(I, Call, /*AssumeSameSpindle*/ false);
+  }
 
   /// Return information about whether two call sites may refer to the same set
   /// of memory locations. See the AA documentation for details:
   ///   http://llvm.org/docs/AliasAnalysis.html#ModRefInfo
-  ModRefInfo getModRefInfo(const CallBase *Call1, const CallBase *Call2);
+  ModRefInfo getModRefInfo(const CallBase *Call1, const CallBase *Call2) {
+    return getModRefInfo(Call1, Call2, /*AssumeSameSpindle*/ false);
+  }
+
+  /// Return information about whether a call and an instruction may refer to
+  /// the same memory locations.
+  ModRefInfo getModRefInfo(Instruction *I, const CallBase *Call,
+                           bool AssumeSameSpindle);
+
+  /// Return information about whether two call sites may refer to the same set
+  /// of memory locations. See the AA documentation for details:
+  ///   http://llvm.org/docs/AliasAnalysis.html#ModRefInfo
+  ModRefInfo getModRefInfo(const CallBase *Call1, const CallBase *Call2,
+                           bool AssumeSameSpindle);
 
   /// Return information about whether a particular call site modifies
   /// or reads the specified memory location \p MemLoc before instruction \p I
@@ -828,12 +861,28 @@ public:
   ModRefInfo getModRefInfo(const CallBase *Call1, const CallBase *Call2) {
     return AA.getModRefInfo(Call1, Call2, AAQI);
   }
+  ModRefInfo getModRefInfo(const CallBase *Call1, const CallBase *Call2,
+                           bool AssumeSameSpindle) {
+    bool OldAssumeSameSpindle = AAQI.AssumeSameSpindle;
+    AAQI.AssumeSameSpindle = AssumeSameSpindle;
+    auto Result = AA.getModRefInfo(Call1, Call2, AAQI);
+    AAQI.AssumeSameSpindle = OldAssumeSameSpindle;
+    return Result;
+  }
   ModRefInfo getModRefInfo(const Instruction *I,
                            const Optional<MemoryLocation> &OptLoc) {
     return AA.getModRefInfo(I, OptLoc, AAQI);
   }
   ModRefInfo getModRefInfo(Instruction *I, const CallBase *Call2) {
     return AA.getModRefInfo(I, Call2, AAQI);
+  }
+  ModRefInfo getModRefInfo(Instruction *I, const CallBase *Call2,
+                           bool AssumeSameSpindle) {
+    bool OldAssumeSameSpindle = AAQI.AssumeSameSpindle;
+    AAQI.AssumeSameSpindle = AssumeSameSpindle;
+    auto Result = AA.getModRefInfo(I, Call2, AAQI);
+    AAQI.AssumeSameSpindle = OldAssumeSameSpindle;
+    return Result;
   }
   ModRefInfo getArgModRefInfo(const CallBase *Call, unsigned ArgIdx) {
     return AA.getArgModRefInfo(Call, ArgIdx);
@@ -1101,6 +1150,11 @@ public:
 /// Return true if this pointer is returned by a noalias function.
 bool isNoAliasCall(const Value *V);
 
+/// Return true if this pointer is returned by a noalias function or, if one
+/// assumes the query pertains to operations in the same spindle, a
+/// strand_noalias function.
+bool isNoAliasCallInSameSpindle(const Value *V);
+
 /// Return true if this is an argument with the noalias attribute.
 bool isNoAliasArgument(const Value *V);
 
@@ -1112,6 +1166,14 @@ bool isNoAliasArgument(const Value *V);
 ///    NoAlias returns (e.g. calls to malloc)
 ///
 bool isIdentifiedObject(const Value *V);
+
+/// Return true if this pointer refers to a distinct and identifiable object
+/// when the query occurs between operations in the same spindle.
+/// This returns true for:
+///    Every value for which isIdentifiedObject(V) returns true
+///    StrandNoAlias returns
+///
+bool isIdentifiedObjectInSameSpindle(const Value *V);
 
 /// Return true if V is umabigously identified at the function-level.
 /// Different IdentifiedFunctionLocals can't alias.

--- a/llvm/include/llvm/Analysis/TapirTargetFuncs.def
+++ b/llvm/include/llvm/Analysis/TapirTargetFuncs.def
@@ -1,0 +1,25 @@
+//===-- TapirTargetFuncs.def - Library information ----*- C++ -*-----------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// This .def file will either fill in the enum definition or fill in the
+// string representation array definition for TargetLibraryInfo.
+// Which is defined depends on whether TLI_DEFINE_ENUM is defined or
+// TLI_DEFINE_STRING is defined. Only one should be defined at a time.
+
+#define TLI_DEFINE_STRING_INTERNAL(string_repr) string_repr,
+
+#if defined(TLI_DEFINE_CILK_LIBS)
+/// unsigned __cilkrts_get_nworkers(void);
+TLI_DEFINE_STRING_INTERNAL("__cilkrts_get_nworkers")
+/// unsigned __cilkrts_get_worker_number(void);
+TLI_DEFINE_STRING_INTERNAL("__cilkrts_get_worker_number")
+/// void *__cilkrts_hyper_lookup(__cilkrts_hyperobject_base *key);
+TLI_DEFINE_STRING_INTERNAL("__cilkrts_hyper_lookup")
+#endif
+
+#undef TLI_DEFINE_STRING_INTERNAL

--- a/llvm/include/llvm/Analysis/TargetLibraryInfo.h
+++ b/llvm/include/llvm/Analysis/TargetLibraryInfo.h
@@ -74,6 +74,9 @@ class TargetLibraryInfoImpl {
   /// on VectorFnName rather than ScalarFnName.
   std::vector<VecDesc> ScalarDescs;
 
+  /// Tapir target standard functions
+  std::vector<StringLiteral> TapirTargetFuncs;
+
   /// Return true if the function type FTy is valid for the library function
   /// F, regardless of whether the function is available.
   bool isValidProtoForLibFunc(const FunctionType &FTy, LibFunc F,
@@ -220,6 +223,21 @@ public:
     return (TapirTarget != TapirTargetID::Last_TapirTargetID) &&
       (TapirTarget != TapirTargetID::None);
   }
+
+  /// Records known library functions associated with the specified Tapir
+  /// target.
+  void addTapirTargetLibraryFunctions() {
+    addTapirTargetLibraryFunctions(TapirTarget);
+  }
+  void addTapirTargetLibraryFunctions(TapirTargetID TargetID);
+
+  /// Searches for a particular function name among known Tapir-target library
+  /// functions, also checking that its type is valid for the library function
+  /// matching that name.
+  ///
+  /// Return true if it is one of the known tapir-target library functions.
+  bool isTapirTargetLibFunc(StringRef funcName) const;
+  bool isTapirTargetLibFunc(const Function &FDecl) const;
 };
 
 /// Provides information about what library functions are available for
@@ -404,6 +422,14 @@ public:
   /// \copydoc TargetLibraryInfoImpl::hasTapirTarget()
   bool hasTapirTarget() const {
     return Impl->hasTapirTarget();
+  }
+
+  /// \copydoc TargetLibraryInfoImpl::isTapirTargetLibFunc()
+  bool isTapirTargetLibFunc(StringRef funcName) const {
+    return Impl->isTapirTargetLibFunc(funcName);
+  }
+  bool isTapirTargetLibFunc(const Function &FDecl) const {
+    return Impl->isTapirTargetLibFunc(FDecl);
   }
 
   /// Handle invalidation from the pass manager.

--- a/llvm/include/llvm/Bitcode/LLVMBitCodes.h
+++ b/llvm/include/llvm/Bitcode/LLVMBitCodes.h
@@ -638,6 +638,7 @@ enum AttributeKindCodes {
   ATTR_KIND_SANITIZE_MEMTAG = 64,
   ATTR_KIND_SANITIZE_CILK = 65,
   ATTR_KIND_STEALABLE = 66,
+  ATTR_KIND_STRAND_PURE = 67,
 };
 
 enum ComdatSelectionKindCodes {

--- a/llvm/include/llvm/Bitcode/LLVMBitCodes.h
+++ b/llvm/include/llvm/Bitcode/LLVMBitCodes.h
@@ -639,6 +639,7 @@ enum AttributeKindCodes {
   ATTR_KIND_SANITIZE_CILK = 65,
   ATTR_KIND_STEALABLE = 66,
   ATTR_KIND_STRAND_PURE = 67,
+  ATTR_KIND_STRAND_NO_ALIAS = 68,
 };
 
 enum ComdatSelectionKindCodes {

--- a/llvm/include/llvm/IR/Attributes.td
+++ b/llvm/include/llvm/IR/Attributes.td
@@ -170,6 +170,10 @@ def StackProtectStrong : EnumAttr<"sspstrong">;
 /// Multiple calls to this function in a strand return the same result.
 def StrandPure : EnumAttr<"strand_pure">;
 
+/// This function acts like a system memory allocation function from
+/// the perspective of memory accesses within the same strand.
+def StrandNoAlias : EnumAttr<"strand_noalias">;
+
 /// Function was called in a scope requiring strict floating point semantics.
 def StrictFP : EnumAttr<"strictfp">;
 

--- a/llvm/include/llvm/IR/Attributes.td
+++ b/llvm/include/llvm/IR/Attributes.td
@@ -167,6 +167,9 @@ def StackProtectReq : EnumAttr<"sspreq">;
 /// Strong Stack protection.
 def StackProtectStrong : EnumAttr<"sspstrong">;
 
+/// Multiple calls to this function in a strand return the same result.
+def StrandPure : EnumAttr<"strand_pure">;
+
 /// Function was called in a scope requiring strict floating point semantics.
 def StrictFP : EnumAttr<"strictfp">;
 

--- a/llvm/include/llvm/IR/Function.h
+++ b/llvm/include/llvm/IR/Function.h
@@ -575,6 +575,14 @@ public:
     addFnAttr(Attribute::Speculatable);
   }
 
+  /// Determine if the call is pure within a strand.
+  bool isStrandPure() const {
+    return hasFnAttribute(Attribute::StrandPure);
+  }
+  void setStrandPure() {
+    addFnAttr(Attribute::StrandPure);
+  }
+
   /// Determine if the call might deallocate memory.
   bool doesNotFreeMemory() const {
     return onlyReadsMemory() || hasFnAttribute(Attribute::NoFree);

--- a/llvm/include/llvm/IR/InstrTypes.h
+++ b/llvm/include/llvm/IR/InstrTypes.h
@@ -1736,6 +1736,15 @@ public:
     removeAttribute(AttributeList::FunctionIndex, Attribute::Convergent);
   }
 
+  /// Determine if the call or invoke is strand-pure.
+  bool isStrandPure() const { return hasFnAttr(Attribute::StrandPure); }
+  void setStrandPure() {
+    addAttribute(AttributeList::FunctionIndex, Attribute::StrandPure);
+  }
+  void setNotStrandPure() {
+    removeAttribute(AttributeList::FunctionIndex, Attribute::StrandPure);
+  }
+
   /// Determine if the call returns a structure through first
   /// pointer argument.
   bool hasStructRetAttr() const {

--- a/llvm/include/llvm/module.modulemap
+++ b/llvm/include/llvm/module.modulemap
@@ -6,6 +6,7 @@ module LLVM_Analysis {
   // This is intended for (repeated) textual inclusion.
   textual header "Analysis/TargetLibraryInfo.def"
   textual header "Analysis/VecFuncs.def"
+  textual header "Analysis/TapirTargetFuncs.def"
 }
 
 module LLVM_AsmParser {

--- a/llvm/lib/Analysis/AliasSetTracker.cpp
+++ b/llvm/lib/Analysis/AliasSetTracker.cpp
@@ -487,7 +487,7 @@ void AliasSetTracker::add(Instruction *I) {
 
   // Handle all calls with known mod/ref sets genericall
   if (auto *Call = dyn_cast<CallBase>(I))
-    if (Call->onlyAccessesArgMemory()) {
+    if (Call->onlyAccessesArgMemory() || Call->isStrandPure()) {
       auto getAccessFromModRef = [](ModRefInfo MRI) {
         if (isRefSet(MRI) && isModSet(MRI))
           return AliasSet::ModRefAccess;

--- a/llvm/lib/Analysis/BasicAliasAnalysis.cpp
+++ b/llvm/lib/Analysis/BasicAliasAnalysis.cpp
@@ -1780,8 +1780,14 @@ AliasResult BasicAAResult::aliasCheck(const Value *V1, LocationSize V1Size,
 
   if (O1 != O2) {
     // If V1/V2 point to two different objects, we know that we have no alias.
-    if (isIdentifiedObject(O1) && isIdentifiedObject(O2))
-      return NoAlias;
+    if (AAQI.AssumeSameSpindle) {
+      if (isIdentifiedObjectInSameSpindle(O1) &&
+          isIdentifiedObjectInSameSpindle(O2))
+        return NoAlias;
+    } else {
+      if (isIdentifiedObject(O1) && isIdentifiedObject(O2))
+        return NoAlias;
+    }
 
     // Constant pointers can't alias with non-const isIdentifiedObject objects.
     if ((isa<Constant>(O1) && isIdentifiedObject(O2) && !isa<Constant>(O2)) ||

--- a/llvm/lib/Analysis/CodeMetrics.cpp
+++ b/llvm/lib/Analysis/CodeMetrics.cpp
@@ -150,6 +150,10 @@ void CodeMetrics::analyzeBasicBlock(const BasicBlock *BB,
         if (TLI && TLI->getLibFunc(*F, LF))
           ++NumBuiltinCalls;
 
+        // Check for a call to a Tapir-target library function.
+        if (TLI && TLI->isTapirTargetLibFunc(*F))
+          ++NumBuiltinCalls;
+
       } else {
         // We don't want inline asm to count as a call - that would prevent loop
         // unrolling. The argument setup cost is still real, though.

--- a/llvm/lib/Analysis/TargetLibraryInfo.cpp
+++ b/llvm/lib/Analysis/TargetLibraryInfo.cpp
@@ -31,7 +31,7 @@ static cl::opt<TargetLibraryInfoImpl::VectorLibrary> ClVectorLibrary(
 
 static cl::opt<TapirTargetID> ClTapirTarget(
     "tapir-target", cl::Hidden, cl::desc("Target runtime for Tapir"),
-    cl::init(TapirTargetID::Cilk),
+    cl::init(TapirTargetID::OpenCilk),
     cl::values(clEnumValN(TapirTargetID::None,
                           "none", "None"),
                clEnumValN(TapirTargetID::Serial,
@@ -571,6 +571,7 @@ static void initialize(TargetLibraryInfoImpl &TLI, const Triple &T,
   TLI.addVectorizableFunctionsFromVecLib(ClVectorLibrary);
 
   TLI.setTapirTarget(ClTapirTarget);
+  TLI.addTapirTargetLibraryFunctions(ClTapirTarget);
 }
 
 TargetLibraryInfoImpl::TargetLibraryInfoImpl() {
@@ -595,6 +596,7 @@ TargetLibraryInfoImpl::TargetLibraryInfoImpl(const TargetLibraryInfoImpl &TLI)
   memcpy(AvailableArray, TLI.AvailableArray, sizeof(AvailableArray));
   VectorDescs = TLI.VectorDescs;
   ScalarDescs = TLI.ScalarDescs;
+  TapirTargetFuncs = TLI.TapirTargetFuncs;
 }
 
 TargetLibraryInfoImpl::TargetLibraryInfoImpl(TargetLibraryInfoImpl &&TLI)
@@ -607,6 +609,7 @@ TargetLibraryInfoImpl::TargetLibraryInfoImpl(TargetLibraryInfoImpl &&TLI)
             AvailableArray);
   VectorDescs = TLI.VectorDescs;
   ScalarDescs = TLI.ScalarDescs;
+  TapirTargetFuncs = TLI.TapirTargetFuncs;
 }
 
 TargetLibraryInfoImpl &TargetLibraryInfoImpl::operator=(const TargetLibraryInfoImpl &TLI) {
@@ -1575,6 +1578,60 @@ void TargetLibraryInfoImpl::addVectorizableFunctionsFromVecLib(
   case NoLibrary:
     break;
   }
+}
+
+void TargetLibraryInfoImpl::addTapirTargetLibraryFunctions(
+    TapirTargetID TargetID) {
+  switch (TargetID) {
+  case TapirTargetID::Cilk:
+  case TapirTargetID::OpenCilk: {
+    const StringLiteral TTFuncs[] = {
+    #define TLI_DEFINE_CILK_LIBS
+    #include "llvm/Analysis/TapirTargetFuncs.def"
+    };
+    TapirTargetFuncs.insert(TapirTargetFuncs.end(), std::begin(TTFuncs),
+                            std::end(TTFuncs));
+    break;
+  }
+  case TapirTargetID::None:
+  case TapirTargetID::Serial:
+  case TapirTargetID::Cheetah:
+  case TapirTargetID::CilkR:
+  case TapirTargetID::Cuda:
+  case TapirTargetID::OpenMP:
+  case TapirTargetID::Qthreads:
+  case TapirTargetID::Last_TapirTargetID:
+    break;
+  }
+
+  // Ensure that the collected Tapir-target functions are in sorted order.
+  llvm::sort(TapirTargetFuncs);
+}
+
+bool TargetLibraryInfoImpl::isTapirTargetLibFunc(StringRef funcName) const {
+  funcName = sanitizeFunctionName(funcName);
+  if (funcName.empty())
+    return false;
+
+  const auto Start = TapirTargetFuncs.begin();
+  const auto End = TapirTargetFuncs.end();
+  const auto I = std::lower_bound(Start, End, funcName);
+  if (I != End && *I == funcName)
+    return true;
+  return false;
+}
+
+bool TargetLibraryInfoImpl::isTapirTargetLibFunc(
+    const Function &FDecl) const {
+  // Intrinsics don't overlap w/libcalls; if our module has a large number of
+  // intrinsics, this ends up being an interesting compile time win since we
+  // avoid string normalization and comparison.
+  if (FDecl.isIntrinsic()) return false;
+
+  // TODO: Check the function prototype of the Tapir-target library function to
+  // ensure a match.  This change may require building more detailed knowledge
+  // of these functions into TargetLibraryInfo.
+  return isTapirTargetLibFunc(FDecl.getName());
 }
 
 bool TargetLibraryInfoImpl::isFunctionVectorizable(StringRef funcName) const {

--- a/llvm/lib/AsmParser/LLLexer.cpp
+++ b/llvm/lib/AsmParser/LLLexer.cpp
@@ -688,6 +688,7 @@ lltok::Kind LLLexer::LexIdentifier() {
   KEYWORD(sanitize_memory);
   KEYWORD(speculative_load_hardening);
   KEYWORD(stealable);
+  KEYWORD(strand_noalias);
   KEYWORD(strand_pure);
   KEYWORD(swifterror);
   KEYWORD(swiftself);

--- a/llvm/lib/AsmParser/LLLexer.cpp
+++ b/llvm/lib/AsmParser/LLLexer.cpp
@@ -688,6 +688,7 @@ lltok::Kind LLLexer::LexIdentifier() {
   KEYWORD(sanitize_memory);
   KEYWORD(speculative_load_hardening);
   KEYWORD(stealable);
+  KEYWORD(strand_pure);
   KEYWORD(swifterror);
   KEYWORD(swiftself);
   KEYWORD(uwtable);

--- a/llvm/lib/AsmParser/LLParser.cpp
+++ b/llvm/lib/AsmParser/LLParser.cpp
@@ -1324,6 +1324,9 @@ bool LLParser::ParseFnAttributeValuePairs(AttrBuilder &B,
       B.addAttribute(Attribute::SpeculativeLoadHardening);
       break;
     case lltok::kw_stealable: B.addAttribute(Attribute::Stealable); break;
+    case lltok::kw_strand_pure:
+      B.addAttribute(Attribute::StrandPure);
+      break;
     case lltok::kw_strictfp: B.addAttribute(Attribute::StrictFP); break;
     case lltok::kw_uwtable: B.addAttribute(Attribute::UWTable); break;
     case lltok::kw_willreturn: B.addAttribute(Attribute::WillReturn); break;
@@ -1686,6 +1689,7 @@ bool LLParser::ParseOptionalParamAttrs(AttrBuilder &B) {
     case lltok::kw_safestack:
     case lltok::kw_shadowcallstack:
     case lltok::kw_stealable:
+    case lltok::kw_strand_pure:
     case lltok::kw_strictfp:
     case lltok::kw_uwtable:
       HaveError |= Error(Lex.getLoc(), "invalid use of function-only attribute");
@@ -1787,6 +1791,7 @@ bool LLParser::ParseOptionalReturnAttrs(AttrBuilder &B) {
     case lltok::kw_safestack:
     case lltok::kw_shadowcallstack:
     case lltok::kw_stealable:
+    case lltok::kw_strand_pure:
     case lltok::kw_strictfp:
     case lltok::kw_uwtable:
       HaveError |= Error(Lex.getLoc(), "invalid use of function-only attribute");

--- a/llvm/lib/AsmParser/LLParser.cpp
+++ b/llvm/lib/AsmParser/LLParser.cpp
@@ -1335,6 +1335,7 @@ bool LLParser::ParseFnAttributeValuePairs(AttrBuilder &B,
     // Error handling.
     case lltok::kw_inreg:
     case lltok::kw_signext:
+    case lltok::kw_strand_noalias:
     case lltok::kw_zeroext:
       HaveError |=
         Error(Lex.getLoc(),
@@ -1694,6 +1695,11 @@ bool LLParser::ParseOptionalParamAttrs(AttrBuilder &B) {
     case lltok::kw_uwtable:
       HaveError |= Error(Lex.getLoc(), "invalid use of function-only attribute");
       break;
+
+    case lltok::kw_strand_noalias:
+      HaveError |=
+          Error(Lex.getLoc(), "invalid use of function-return-only attribute");
+      break;
     }
 
     Lex.Lex();
@@ -1741,6 +1747,9 @@ bool LLParser::ParseOptionalReturnAttrs(AttrBuilder &B) {
     case lltok::kw_noalias:         B.addAttribute(Attribute::NoAlias); break;
     case lltok::kw_nonnull:         B.addAttribute(Attribute::NonNull); break;
     case lltok::kw_signext:         B.addAttribute(Attribute::SExt); break;
+    case lltok::kw_strand_noalias:
+      B.addAttribute(Attribute::StrandNoAlias);
+      break;
     case lltok::kw_zeroext:         B.addAttribute(Attribute::ZExt); break;
 
     // Error handling.

--- a/llvm/lib/AsmParser/LLToken.h
+++ b/llvm/lib/AsmParser/LLToken.h
@@ -230,6 +230,7 @@ enum Kind {
   kw_sanitize_memory,
   kw_speculative_load_hardening,
   kw_stealable,
+  kw_strand_pure,
   kw_strictfp,
   kw_swifterror,
   kw_swiftself,

--- a/llvm/lib/AsmParser/LLToken.h
+++ b/llvm/lib/AsmParser/LLToken.h
@@ -230,6 +230,7 @@ enum Kind {
   kw_sanitize_memory,
   kw_speculative_load_hardening,
   kw_stealable,
+  kw_strand_noalias,
   kw_strand_pure,
   kw_strictfp,
   kw_swifterror,

--- a/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
+++ b/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
@@ -1306,6 +1306,9 @@ static uint64_t getRawAttributeMask(Attribute::AttrKind Val) {
   case Attribute::Stealable:
     llvm_unreachable("stealable attribute not supported in raw format");
     break;
+  case Attribute::StrandPure:
+    llvm_unreachable("strand_pure attribute not supported in raw format");
+    break;
   }
   llvm_unreachable("Unsupported attribute type");
 }
@@ -1322,7 +1325,8 @@ static void addRawAttributeValue(AttrBuilder &B, uint64_t Val) {
         I == Attribute::AllocSize ||
         I == Attribute::NoSync ||
         I == Attribute::SanitizeCilk ||
-        I == Attribute::Stealable)
+        I == Attribute::Stealable ||
+        I == Attribute::StrandPure)
       continue;
     if (uint64_t A = (Val & getRawAttributeMask(I))) {
       if (I == Attribute::Alignment)
@@ -1521,6 +1525,8 @@ static Attribute::AttrKind getAttrFromCode(uint64_t Code) {
     return Attribute::ShadowCallStack;
   case bitc::ATTR_KIND_STEALABLE:
     return Attribute::Stealable;
+  case bitc::ATTR_KIND_STRAND_PURE:
+    return Attribute::StrandPure;
   case bitc::ATTR_KIND_STRICT_FP:
     return Attribute::StrictFP;
   case bitc::ATTR_KIND_STRUCT_RET:

--- a/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
+++ b/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
@@ -1309,6 +1309,9 @@ static uint64_t getRawAttributeMask(Attribute::AttrKind Val) {
   case Attribute::StrandPure:
     llvm_unreachable("strand_pure attribute not supported in raw format");
     break;
+  case Attribute::StrandNoAlias:
+    llvm_unreachable("strand_noalias attribute not supported in raw format");
+    break;
   }
   llvm_unreachable("Unsupported attribute type");
 }
@@ -1326,7 +1329,8 @@ static void addRawAttributeValue(AttrBuilder &B, uint64_t Val) {
         I == Attribute::NoSync ||
         I == Attribute::SanitizeCilk ||
         I == Attribute::Stealable ||
-        I == Attribute::StrandPure)
+        I == Attribute::StrandPure ||
+        I == Attribute::StrandNoAlias)
       continue;
     if (uint64_t A = (Val & getRawAttributeMask(I))) {
       if (I == Attribute::Alignment)
@@ -1525,6 +1529,8 @@ static Attribute::AttrKind getAttrFromCode(uint64_t Code) {
     return Attribute::ShadowCallStack;
   case bitc::ATTR_KIND_STEALABLE:
     return Attribute::Stealable;
+  case bitc::ATTR_KIND_STRAND_NO_ALIAS:
+    return Attribute::StrandNoAlias;
   case bitc::ATTR_KIND_STRAND_PURE:
     return Attribute::StrandPure;
   case bitc::ATTR_KIND_STRICT_FP:

--- a/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
+++ b/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
@@ -698,6 +698,8 @@ static uint64_t getAttrKindEncoding(Attribute::AttrKind Kind) {
     return bitc::ATTR_KIND_SHADOWCALLSTACK;
   case Attribute::Stealable:
     return bitc::ATTR_KIND_STEALABLE;
+  case Attribute::StrandPure:
+    return bitc::ATTR_KIND_STRAND_PURE;
   case Attribute::StrictFP:
     return bitc::ATTR_KIND_STRICT_FP;
   case Attribute::StructRet:

--- a/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
+++ b/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
@@ -698,6 +698,8 @@ static uint64_t getAttrKindEncoding(Attribute::AttrKind Kind) {
     return bitc::ATTR_KIND_SHADOWCALLSTACK;
   case Attribute::Stealable:
     return bitc::ATTR_KIND_STEALABLE;
+  case Attribute::StrandNoAlias:
+    return bitc::ATTR_KIND_STRAND_NO_ALIAS;
   case Attribute::StrandPure:
     return bitc::ATTR_KIND_STRAND_PURE;
   case Attribute::StrictFP:

--- a/llvm/lib/IR/Attributes.cpp
+++ b/llvm/lib/IR/Attributes.cpp
@@ -378,6 +378,8 @@ std::string Attribute::getAsString(bool InAttrGrp) const {
     return "shadowcallstack";
   if (hasAttribute(Attribute::Stealable))
     return "stealable";
+  if (hasAttribute(Attribute::StrandNoAlias))
+    return "strand_noalias";
   if (hasAttribute(Attribute::StrandPure))
     return "strand_pure";
   if (hasAttribute(Attribute::StrictFP))

--- a/llvm/lib/IR/Attributes.cpp
+++ b/llvm/lib/IR/Attributes.cpp
@@ -378,6 +378,8 @@ std::string Attribute::getAsString(bool InAttrGrp) const {
     return "shadowcallstack";
   if (hasAttribute(Attribute::Stealable))
     return "stealable";
+  if (hasAttribute(Attribute::StrandPure))
+    return "strand_pure";
   if (hasAttribute(Attribute::StrictFP))
     return "strictfp";
   if (hasAttribute(Attribute::StructRet))

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -1546,6 +1546,7 @@ static bool isFuncOnlyAttr(Attribute::AttrKind Kind) {
   case Attribute::SpeculativeLoadHardening:
   case Attribute::Speculatable:
   case Attribute::Stealable:
+  case Attribute::StrandPure:
   case Attribute::StrictFP:
     return true;
   default:

--- a/llvm/lib/Passes/PassBuilder.cpp
+++ b/llvm/lib/Passes/PassBuilder.cpp
@@ -954,8 +954,9 @@ ModulePassManager PassBuilder::buildModuleOptimizationPipeline(
     LoopPassManager LPM(DebugLogging);
     LPM.addPass(LoopSimplifyCFGPass());
     LPM.addPass(IndVarSimplifyPass());
-    OptimizePM.addPass(createFunctionToLoopPassAdaptor(std::move(LPM),
-                                                       DebugLogging));
+    LPM.addPass(LICMPass(PTO.LicmMssaOptCap, PTO.LicmMssaNoAccForPromotionCap));
+    OptimizePM.addPass(
+        createFunctionToLoopPassAdaptor(std::move(LPM), DebugLogging));
     OptimizePM.addPass(EarlyCSEPass(true /* Enable mem-ssa. */));
     OptimizePM.addPass(JumpThreadingPass());
     OptimizePM.addPass(CorrelatedValuePropagationPass());

--- a/llvm/lib/Passes/PassBuilder.cpp
+++ b/llvm/lib/Passes/PassBuilder.cpp
@@ -1003,6 +1003,8 @@ ModulePassManager PassBuilder::buildModuleOptimizationPipeline(
                                      convertSwitchToLookupTable(true).
                                      needCanonicalLoops(false).
                                      sinkCommonInsts(true)));
+  // Rerun EarlyCSE for further cleanup after the sinking transformation.
+  OptimizePM.addPass(EarlyCSEPass(true /* Enable mem-ssa. */));
 
   // Optimize parallel scalar instruction chains into SIMD instructions.
   if (PTO.SLPVectorization)

--- a/llvm/lib/Transforms/IPO/ForceFunctionAttrs.cpp
+++ b/llvm/lib/Transforms/IPO/ForceFunctionAttrs.cpp
@@ -66,6 +66,7 @@ static Attribute::AttrKind parseAttrKind(StringRef Kind) {
       .Case("sspreq", Attribute::StackProtectReq)
       .Case("sspstrong", Attribute::StackProtectStrong)
       .Case("stealable", Attribute::Stealable)
+      .Case("strand_pure", Attribute::StrandPure)
       .Case("strictfp", Attribute::StrictFP)
       .Case("uwtable", Attribute::UWTable)
       .Default(Attribute::None);

--- a/llvm/lib/Transforms/IPO/FunctionAttrs.cpp
+++ b/llvm/lib/Transforms/IPO/FunctionAttrs.cpp
@@ -406,13 +406,14 @@ static FunctionAccessKind checkFunctionAccess(Function &F, bool ThisBody,
 
       // Check whether all pointer arguments point to local memory, and
       // ignore calls that only access local memory.
-      for (const Value *Arg : CS->args()) {
+      for (auto I = CS->arg_begin(), E = CS->arg_end(); I != E; ++I) {
+        const Value *Arg = *I;
         if (!Arg->getType()->isPtrOrPtrVectorTy())
           continue;
 
-        AAMDNodes AAInfo;
-        I->getAAMetadata(AAInfo);
-        MemoryLocation Loc(Arg, MemoryLocation::UnknownSize, AAInfo);
+        unsigned ArgIdx = std::distance(CS->arg_begin(), I);
+        MemoryLocation Loc =
+            MemoryLocation::getForArgument(CS, ArgIdx, nullptr);
 
         // Skip accesses to local or constant memory as they don't impact the
         // externally visible mod/ref behavior.
@@ -429,6 +430,13 @@ static FunctionAccessKind checkFunctionAccess(Function &F, bool ThisBody,
 
           if (isa<Argument>(Obj))
             AccessKind = FunctionAccessKind(AccessKind | FAK_ArgMem);
+
+          // If the underlying object is an arbitrary instruction that is not a
+          // local allocation, then conservatively deduce that this function
+          // might access memory other than its arguments.
+          if (isa<Instruction>(Obj) &&
+              !(isa<AllocaInst>(Obj) || isNoAliasCall(Obj)))
+            AccessKind = FunctionAccessKind(AccessKind | FAK_NonArgMem);
 
           // Early exit the function once we discover this function can access
           // non-argument memory and inaccessible memory.
@@ -470,10 +478,11 @@ static FunctionAccessKind checkFunctionAccess(Function &F, bool ThisBody,
         if (isa<Argument>(Obj))
           AccessKind = FunctionAccessKind(AccessKind | FAK_ArgMem);
 
-        // If the underlying object is an arbitrary instruction, then
-        // conservatively deduce that this function might access memory other
-        // than its arguments.
-        if (isa<Instruction>(Obj))
+        // If the underlying object is an arbitrary instruction that is not a
+        // local allocation, then conservatively deduce that this function might
+        // access memory other than its arguments.
+        if (isa<Instruction>(Obj) &&
+            !(isa<AllocaInst>(Obj) || isNoAliasCall(Obj)))
           AccessKind = FunctionAccessKind(AccessKind | FAK_NonArgMem);
 
         // Early exit the function once we discover this function can access

--- a/llvm/lib/Transforms/IPO/PassManagerBuilder.cpp
+++ b/llvm/lib/Transforms/IPO/PassManagerBuilder.cpp
@@ -824,6 +824,8 @@ void PassManagerBuilder::populateModulePassManager(
   // before SLP vectorization.
   MPM.add(createTaskSimplifyPass());
   MPM.add(createCFGSimplificationPass(1, true, true, false, true));
+  // Rerun EarlyCSE for further cleanup after the sinking transformation.
+  MPM.add(createEarlyCSEPass(true /* Enable mem-ssa. */));
 
   if (SLPVectorize) {
     MPM.add(createSLPVectorizerPass()); // Vectorize parallel scalar chains.

--- a/llvm/lib/Transforms/IPO/PassManagerBuilder.cpp
+++ b/llvm/lib/Transforms/IPO/PassManagerBuilder.cpp
@@ -766,6 +766,7 @@ void PassManagerBuilder::populateModulePassManager(
     MPM.add(createTaskSimplifyPass());
     MPM.add(createLoopSimplifyCFGPass());
     MPM.add(createIndVarSimplifyPass());        // Canonicalize indvars
+    MPM.add(createLICMPass(LicmMssaOptCap, LicmMssaNoAccForPromotionCap));
     MPM.add(createEarlyCSEPass());
     MPM.add(createJumpThreadingPass());         // Thread jumps
     MPM.add(createCorrelatedValuePropagationPass());

--- a/llvm/lib/Transforms/Scalar/LICM.cpp
+++ b/llvm/lib/Transforms/Scalar/LICM.cpp
@@ -1164,7 +1164,8 @@ bool llvm::canSinkOrHoistInst(Instruction &I, AAResults *AA, DominatorTree *DT,
       // A readonly argmemonly function only reads from memory pointed to by
       // it's arguments with arbitrary offsets.  If we can prove there are no
       // writes to this memory in the loop, we can hoist or sink.
-      if (AliasAnalysis::onlyAccessesArgPointees(Behavior)) {
+      if (AliasAnalysis::onlyAccessesArgPointees(Behavior) ||
+          CI->isStrandPure()) {
         // TODO: expand to writeable arguments
         for (Value *Op : CI->arg_operands())
           if (Op->getType()->isPointerTy()) {
@@ -1732,6 +1733,14 @@ static bool isSafeToExecuteUnconditionally(Instruction &Inst,
                                            const Instruction *CtxI) {
   if (isSafeToSpeculativelyExecute(&Inst, CtxI, DT))
     return true;
+
+  if (CtxI)
+    if (const CallBase *CB = dyn_cast<CallBase>(&Inst)) {
+      const Function *Callee = CB->getCalledFunction();
+      if (Callee && Callee->isStrandPure())
+        return (TI->getSpindleFor(Inst.getParent()) ==
+                TI->getSpindleFor(CtxI->getParent()));
+    }
 
   bool GuaranteedToExecute =
       SafetyInfo->isGuaranteedToExecute(Inst, DT, TI, CurLoop);

--- a/llvm/lib/Transforms/Tapir/LoweringUtils.cpp
+++ b/llvm/lib/Transforms/Tapir/LoweringUtils.cpp
@@ -249,11 +249,11 @@ void llvm::getTaskFrameInputsOutputs(TFValueSetMap &TFInputs,
     if (T && T->contains(S))
       continue;
 
-    for (BasicBlock *BB : S->blocks()) {
-      // Skip spindles that are placeholders.
-      if (isPlaceholderSuccessor(S->getEntry()))
-        continue;
+    // Skip spindles that are placeholders.
+    if (isPlaceholderSuccessor(S->getEntry()))
+      continue;
 
+    for (BasicBlock *BB : S->blocks()) {
       for (Instruction &I : *BB) {
         // Ignore certain instructions from consideration: the taskframe.create
         // intrinsic for this taskframe, the detach instruction that spawns T,

--- a/llvm/lib/Transforms/Utils/CodeExtractor.cpp
+++ b/llvm/lib/Transforms/Utils/CodeExtractor.cpp
@@ -876,6 +876,9 @@ Function *CodeExtractor::constructFunction(const ValueSet &inputs,
       case Attribute::SExt:
       case Attribute::Speculatable:
       case Attribute::StackAlignment:
+      case Attribute::Stealable:
+      case Attribute::StrandNoAlias:
+      case Attribute::StrandPure:
       case Attribute::StructRet:
       case Attribute::SwiftError:
       case Attribute::SwiftSelf:
@@ -916,8 +919,6 @@ Function *CodeExtractor::constructFunction(const ValueSet &inputs,
       case Attribute::UWTable:
       case Attribute::NoCfCheck:
       case Attribute::SanitizeCilk:
-      case Attribute::Stealable:
-      case Attribute::StrandPure:
         break;
       }
 

--- a/llvm/lib/Transforms/Utils/CodeExtractor.cpp
+++ b/llvm/lib/Transforms/Utils/CodeExtractor.cpp
@@ -917,6 +917,7 @@ Function *CodeExtractor::constructFunction(const ValueSet &inputs,
       case Attribute::NoCfCheck:
       case Attribute::SanitizeCilk:
       case Attribute::Stealable:
+      case Attribute::StrandPure:
         break;
       }
 

--- a/llvm/lib/Transforms/Utils/LoopUtils.cpp
+++ b/llvm/lib/Transforms/Utils/LoopUtils.cpp
@@ -50,10 +50,59 @@ using namespace llvm::PatternMatch;
 static const char *LLVMLoopDisableNonforced = "llvm.loop.disable_nonforced";
 static const char *LLVMLoopDisableLICM = "llvm.licm.disable";
 
+static void GetTaskExits(BasicBlock *TaskEntry, Loop *L,
+                         SmallPtrSetImpl<BasicBlock *> &TaskExits) {
+  // Traverse the CFG to find the exit blocks from SubT.
+  SmallVector<BasicBlock *, 4> Worklist;
+  SmallPtrSet<BasicBlock *, 4> Visited;
+  Worklist.push_back(TaskEntry);
+  while (!Worklist.empty()) {
+    BasicBlock *BB = Worklist.pop_back_val();
+    if (!Visited.insert(BB).second)
+      continue;
+
+    // Record any block found in the task that is not contained in the loop
+    if (!L->contains(BB))
+      TaskExits.insert(BB);
+
+    // Stop the CFG traversal at any reattach or detached.rethrow
+    if (isa<ReattachInst>(BB->getTerminator()) ||
+        isDetachedRethrow(BB->getTerminator()))
+      continue;
+
+    // If we encounter a detach, only add its continuation and unwind
+    // destination
+    if (DetachInst *DI = dyn_cast<DetachInst>(BB->getTerminator())) {
+      Worklist.push_back(DI->getContinue());
+      if (DI->hasUnwindDest())
+        Worklist.push_back(DI->getUnwindDest());
+      continue;
+    }
+
+    // For all other basic blocks, traverse all successors
+    for (BasicBlock *Succ : successors(BB))
+      Worklist.push_back(Succ);
+  }
+}
+
 bool llvm::formDedicatedExitBlocks(Loop *L, DominatorTree *DT, LoopInfo *LI,
                                    MemorySSAUpdater *MSSAU,
                                    bool PreserveLCSSA) {
   bool Changed = false;
+
+  SmallPtrSet<BasicBlock *, 4> TaskExits;
+  {
+    SmallVector<BasicBlock *, 4> TaskEntriesToCheck;
+    for (auto *BB : L->blocks())
+      if (DetachInst *DI = dyn_cast<DetachInst>(BB->getTerminator()))
+        if (DI->hasUnwindDest())
+          if (!L->contains(DI->getUnwindDest()))
+            TaskEntriesToCheck.push_back(DI->getDetached());
+
+    // For all tasks to check, get the loop exits that are in the task.
+    for (BasicBlock *TaskEntry : TaskEntriesToCheck)
+      GetTaskExits(TaskEntry, L, TaskExits);
+  }
 
   // We re-use a vector for the in-loop predecesosrs.
   SmallVector<BasicBlock *, 4> InLoopPredecessors;
@@ -67,7 +116,7 @@ bool llvm::formDedicatedExitBlocks(Loop *L, DominatorTree *DT, LoopInfo *LI,
     // keep track of the in-loop predecessors.
     bool IsDedicatedExit = true;
     for (auto *PredBB : predecessors(BB))
-      if (L->contains(PredBB)) {
+      if (L->contains(PredBB) || TaskExits.count(PredBB)) {
         if (isa<IndirectBrInst>(PredBB->getTerminator()))
           // We cannot rewrite exiting edges from an indirectbr.
           return false;
@@ -105,7 +154,21 @@ bool llvm::formDedicatedExitBlocks(Loop *L, DominatorTree *DT, LoopInfo *LI,
   for (auto *BB : L->blocks())
     for (auto *SuccBB : successors(BB)) {
       // We're looking for exit blocks so skip in-loop successors.
-      if (L->contains(SuccBB))
+      if (L->contains(SuccBB) || TaskExits.count(SuccBB))
+        continue;
+
+      // Visit each exit block exactly once.
+      if (!Visited.insert(SuccBB).second)
+        continue;
+
+      Changed |= RewriteExit(SuccBB);
+    }
+
+  // Visit exits from tasks within the loop as well.
+  for (auto *BB : TaskExits)
+    for (auto *SuccBB : successors(BB)) {
+      // We're looking for exit blocks so skip in-loop successors.
+      if (L->contains(SuccBB) || TaskExits.count(SuccBB))
         continue;
 
       // Visit each exit block exactly once.

--- a/llvm/test/Other/new-pm-defaults.ll
+++ b/llvm/test/Other/new-pm-defaults.ll
@@ -280,6 +280,7 @@
 ; CHECK-O-NEXT: Running pass: InstCombinePass
 ; CHECK-O-NEXT: Running pass: TaskSimplifyPass
 ; CHECK-O-NEXT: Running pass: SimplifyCFGPass
+; CHECK-O-NEXT: Running pass: EarlyCSEPass
 ; CHECK-O2-NEXT: Running pass: SLPVectorizerPass
 ; CHECK-O3-NEXT: Running pass: SLPVectorizerPass
 ; CHECK-Os-NEXT: Running pass: SLPVectorizerPass

--- a/llvm/test/Other/new-pm-defaults.ll
+++ b/llvm/test/Other/new-pm-defaults.ll
@@ -248,6 +248,7 @@
 ; CHECK-O2-NEXT: Starting Loop pass manager run.
 ; CHECK-O2-NEXT: Running pass: LoopSimplifyCFGPass
 ; CHECK-O2-NEXT: Running pass: IndVarSimplifyPass
+; CHECK-O2-NEXT: Running pass: LICMPass
 ; CHECK-O2-NEXT: Finished Loop pass manager run.
 ; CHECK-O2-NEXT: Running pass: EarlyCSEPass
 ; CHECK-O2-NEXT: Running pass: JumpThreadingPass
@@ -259,6 +260,7 @@
 ; CHECK-O3-NEXT: Starting Loop pass manager run.
 ; CHECK-O3-NEXT: Running pass: LoopSimplifyCFGPass
 ; CHECK-O3-NEXT: Running pass: IndVarSimplifyPass
+; CHECK-O3-NEXT: Running pass: LICMPass
 ; CHECK-O3-NEXT: Finished Loop pass manager run.
 ; CHECK-O3-NEXT: Running pass: EarlyCSEPass
 ; CHECK-O3-NEXT: Running pass: JumpThreadingPass

--- a/llvm/test/Other/new-pm-thinlto-defaults.ll
+++ b/llvm/test/Other/new-pm-thinlto-defaults.ll
@@ -250,6 +250,7 @@
 ; CHECK-POSTLINK-O-NEXT: Running pass: InstCombinePass
 ; CHECK-POSTLINK-O-NEXT: Running pass: TaskSimplifyPass
 ; CHECK-POSTLINK-O-NEXT: Running pass: SimplifyCFGPass
+; CHECK-POSTLINK-O-NEXT: Running pass: EarlyCSEPass
 ; CHECK-POSTLINK-O2-NEXT: Running pass: SLPVectorizerPass
 ; CHECK-POSTLINK-O3-NEXT: Running pass: SLPVectorizerPass
 ; CHECK-POSTLINK-Os-NEXT: Running pass: SLPVectorizerPass

--- a/llvm/test/Other/new-pm-thinlto-defaults.ll
+++ b/llvm/test/Other/new-pm-thinlto-defaults.ll
@@ -219,6 +219,7 @@
 ; CHECK-POSTLINK-O2-NEXT: Starting Loop pass manager run.
 ; CHECK-POSTLINK-O2-NEXT: Running pass: LoopSimplifyCFGPass
 ; CHECK-POSTLINK-O2-NEXT: Running pass: IndVarSimplifyPass
+; CHECK-POSTLINK-O2-NEXT: Running pass: LICMPass
 ; CHECK-POSTLINK-O2-NEXT: Finished Loop pass manager run.
 ; CHECK-POSTLINK-O2-NEXT: Running pass: EarlyCSEPass
 ; CHECK-POSTLINK-O2-NEXT: Running pass: JumpThreadingPass
@@ -230,6 +231,7 @@
 ; CHECK-POSTLINK-O3-NEXT: Starting Loop pass manager run.
 ; CHECK-POSTLINK-O3-NEXT: Running pass: LoopSimplifyCFGPass
 ; CHECK-POSTLINK-O3-NEXT: Running pass: IndVarSimplifyPass
+; CHECK-POSTLINK-O3-NEXT: Running pass: LICMPass
 ; CHECK-POSTLINK-O3-NEXT: Finished Loop pass manager run.
 ; CHECK-POSTLINK-O3-NEXT: Running pass: EarlyCSEPass
 ; CHECK-POSTLINK-O3-NEXT: Running pass: JumpThreadingPass

--- a/llvm/test/Other/opt-O2-pipeline.ll
+++ b/llvm/test/Other/opt-O2-pipeline.ll
@@ -294,10 +294,12 @@
 ; CHECK-NEXT:       Simplify Tapir tasks
 ; CHECK-NEXT:       Simplify the CFG
 ; CHECK-NEXT:       Dominator Tree Construction
-; CHECK-NEXT:       Natural Loop Information
-; CHECK-NEXT:       Scalar Evolution Analysis
 ; CHECK-NEXT:       Basic Alias Analysis (stateless AA impl)
 ; CHECK-NEXT:       Function Alias Analysis Results
+; CHECK-NEXT:       Memory SSA
+; CHECK-NEXT:       Early CSE w/ MemorySSA
+; CHECK-NEXT:       Natural Loop Information
+; CHECK-NEXT:       Scalar Evolution Analysis
 ; CHECK-NEXT:       Demanded bits analysis
 ; CHECK-NEXT:       Lazy Branch Probability Analysis
 ; CHECK-NEXT:       Lazy Block Frequency Analysis

--- a/llvm/test/Other/opt-O2-pipeline.ll
+++ b/llvm/test/Other/opt-O2-pipeline.ll
@@ -243,6 +243,9 @@
 ; CHECK-NEXT:         Simplify loop CFG
 ; CHECK-NEXT:       Loop Pass Manager
 ; CHECK-NEXT:         Induction Variable Simplification
+; CHECK-NEXT:       Memory SSA
+; CHECK-NEXT:       Loop Pass Manager
+; CHECK-NEXT:         Loop Invariant Code Motion
 ; CHECK-NEXT:       Early CSE
 ; CHECK-NEXT:       Lazy Value Information Analysis
 ; CHECK-NEXT:       Jump Threading

--- a/llvm/test/Other/opt-O3-pipeline.ll
+++ b/llvm/test/Other/opt-O3-pipeline.ll
@@ -248,6 +248,9 @@
 ; CHECK-NEXT:         Simplify loop CFG
 ; CHECK-NEXT:       Loop Pass Manager
 ; CHECK-NEXT:         Induction Variable Simplification
+; CHECK-NEXT:       Memory SSA
+; CHECK-NEXT:       Loop Pass Manager
+; CHECK-NEXT:         Loop Invariant Code Motion
 ; CHECK-NEXT:       Early CSE
 ; CHECK-NEXT:       Lazy Value Information Analysis
 ; CHECK-NEXT:       Jump Threading

--- a/llvm/test/Other/opt-O3-pipeline.ll
+++ b/llvm/test/Other/opt-O3-pipeline.ll
@@ -299,10 +299,12 @@
 ; CHECK-NEXT:       Simplify Tapir tasks
 ; CHECK-NEXT:       Simplify the CFG
 ; CHECK-NEXT:       Dominator Tree Construction
-; CHECK-NEXT:       Natural Loop Information
-; CHECK-NEXT:       Scalar Evolution Analysis
 ; CHECK-NEXT:       Basic Alias Analysis (stateless AA impl)
 ; CHECK-NEXT:       Function Alias Analysis Results
+; CHECK-NEXT:       Memory SSA
+; CHECK-NEXT:       Early CSE w/ MemorySSA
+; CHECK-NEXT:       Natural Loop Information
+; CHECK-NEXT:       Scalar Evolution Analysis
 ; CHECK-NEXT:       Demanded bits analysis
 ; CHECK-NEXT:       Lazy Branch Probability Analysis
 ; CHECK-NEXT:       Lazy Block Frequency Analysis

--- a/llvm/test/Other/opt-Os-pipeline.ll
+++ b/llvm/test/Other/opt-Os-pipeline.ll
@@ -281,10 +281,12 @@
 ; CHECK-NEXT:       Simplify Tapir tasks
 ; CHECK-NEXT:       Simplify the CFG
 ; CHECK-NEXT:       Dominator Tree Construction
-; CHECK-NEXT:       Natural Loop Information
-; CHECK-NEXT:       Scalar Evolution Analysis
 ; CHECK-NEXT:       Basic Alias Analysis (stateless AA impl)
 ; CHECK-NEXT:       Function Alias Analysis Results
+; CHECK-NEXT:       Memory SSA
+; CHECK-NEXT:       Early CSE w/ MemorySSA
+; CHECK-NEXT:       Natural Loop Information
+; CHECK-NEXT:       Scalar Evolution Analysis
 ; CHECK-NEXT:       Demanded bits analysis
 ; CHECK-NEXT:       Lazy Branch Probability Analysis
 ; CHECK-NEXT:       Lazy Block Frequency Analysis

--- a/llvm/test/Other/opt-Os-pipeline.ll
+++ b/llvm/test/Other/opt-Os-pipeline.ll
@@ -230,6 +230,9 @@
 ; CHECK-NEXT:         Simplify loop CFG
 ; CHECK-NEXT:       Loop Pass Manager
 ; CHECK-NEXT:         Induction Variable Simplification
+; CHECK-NEXT:       Memory SSA
+; CHECK-NEXT:       Loop Pass Manager
+; CHECK-NEXT:         Loop Invariant Code Motion
 ; CHECK-NEXT:       Early CSE
 ; CHECK-NEXT:       Lazy Value Information Analysis
 ; CHECK-NEXT:       Jump Threading

--- a/llvm/test/Other/pass-pipelines.ll
+++ b/llvm/test/Other/pass-pipelines.ll
@@ -91,6 +91,8 @@
 ; CHECK-O2-NEXT: Simplify loop CFG
 ; CHECK-O2: Loop Pass Manager
 ; CHECK-O2-NEXT: Induction Variable Simplification
+; CHECK-O2: Loop Pass Manager
+; CHECK-O2-NEXT: Loop Invariant Code Motion
 ; We rotate loops prior to vectorization.
 ; CHECK-O2: Loop Pass Manager
 ; CHECK-O2-NEXT: Rotate Loops

--- a/llvm/test/Transforms/LoopRotate/pr35210.ll
+++ b/llvm/test/Transforms/LoopRotate/pr35210.ll
@@ -48,9 +48,9 @@
 ; MSSA-NEXT: Running analysis: MemorySSAAnalysis on f
 ; MSSA-NEXT: Running analysis: AAManager on f
 ; MSSA-NEXT: Running analysis: TargetLibraryAnalysis on f
+; MSSA-NEXT: Running analysis: TaskAnalysis on f
 ; MSSA-NEXT: Running analysis: ScalarEvolutionAnalysis on f
 ; MSSA-NEXT: Running analysis: TargetIRAnalysis on f
-; MSSA-NEXT: Running analysis: TaskAnalysis on f
 ; MSSA-NEXT: Running analysis: InnerAnalysisManagerProxy{{.*}} on f
 ; MSSA-NEXT: Starting Loop pass manager run.
 ; MSSA-NEXT: Running analysis: PassInstrumentationAnalysis on bb

--- a/llvm/test/Transforms/LoopVectorize/X86/metadata-enable.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/metadata-enable.ll
@@ -1856,7 +1856,7 @@ define i32 @disabled(i32* noalias nocapture %a, i32* noalias nocapture readonly 
 ; O3DEFAULT-NEXT:    [[TMP48:%.*]] = add nsw <4 x i32> [[TMP47]], [[TMP3]]
 ; O3DEFAULT-NEXT:    [[TMP49:%.*]] = bitcast i32* [[ARRAYIDX2_44]] to <4 x i32>*
 ; O3DEFAULT-NEXT:    store <4 x i32> [[TMP48]], <4 x i32>* [[TMP49]], align 4
-; O3DEFAULT-NEXT:    [[TMP50:%.*]] = load i32, i32* [[A]], align 4
+; O3DEFAULT-NEXT:    [[TMP50:%.*]] = extractelement <4 x i32> [[TMP4]], i32 0
 ; O3DEFAULT-NEXT:    ret i32 [[TMP50]]
 ;
 ; Os-LABEL: @disabled(

--- a/llvm/test/Transforms/PGOProfile/cspgo_profile_summary.ll
+++ b/llvm/test/Transforms/PGOProfile/cspgo_profile_summary.ll
@@ -66,10 +66,10 @@ for.end:
   ret void
 }
 ; PGOSUMMARY-LABEL: @bar
-; PGOSUMMARY: %odd.sink = select i1 %tobool, i32* @even, i32* @odd
+; PGOSUMMARY: %odd.sink{{[0-9]*}} = select i1 %tobool, i32* @even, i32* @odd
 ; PGOSUMMARY-SAME: !prof ![[BW_PGO_BAR:[0-9]+]]
 ; CSPGOSUMMARY-LABEL: @bar
-; CSPGOSUMMARY: %odd.sink = select i1 %tobool, i32* @even, i32* @odd
+; CSPGOSUMMARY: %odd.sink{{[0-9]*}} = select i1 %tobool, i32* @even, i32* @odd
 ; CSPGOSUMMARY-SAME: !prof ![[BW_CSPGO_BAR:[0-9]+]]
 
 define internal fastcc i32 @cond(i32 %i) {

--- a/llvm/test/Transforms/Tapir/exception-spawn-in-parfor-loop-spawning.ll
+++ b/llvm/test/Transforms/Tapir/exception-spawn-in-parfor-loop-spawning.ll
@@ -788,10 +788,10 @@ declare i32 @llvm.tapir.loop.grainsize.i32(i32) #7
 ; CHECK-NEXT: unreachable
 
 ; CHECK: [[DACLPAD]]:
-; CHECK-NEXT: landingpad
+; CHECK: landingpad
 ; CHECK-NEXT: cleanup
 ; CHECK: invoke void @llvm.detached.rethrow.sl_p0i8i32s(token %[[DACSYNCREG]],
-; CHECK-NEXT: to label %[[UNREACHABLE2:.+]] unwind label
+; CHECK-NEXT: to label %[[UNREACHABLE2:.+]] unwind label %[[DACDU]]
 
 
 ; CHECK-LABEL: define private fastcc void @_Z27parfor_trycatch_destructorsi.outline_pfor.cond.ls1(
@@ -867,10 +867,10 @@ declare i32 @llvm.tapir.loop.grainsize.i32(i32) #7
 ; CHECK-NEXT: unreachable
 
 ; CHECK: [[DACLPAD]]:
-; CHECK-NEXT: landingpad
+; CHECK: landingpad
 ; CHECK-NEXT: cleanup
 ; CHECK: invoke void @llvm.detached.rethrow.sl_p0i8i32s(token %[[DACSYNCREG]],
-; CHECK-NEXT: to label %[[UNREACHABLE2:.+]] unwind label
+; CHECK-NEXT: to label %[[UNREACHABLE2:.+]] unwind label %[[DACDU]]
 
 attributes #0 = { uwtable "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { nounwind readnone }

--- a/llvm/test/Transforms/Tapir/hyperlookup-opts.ll
+++ b/llvm/test/Transforms/Tapir/hyperlookup-opts.ll
@@ -1,0 +1,332 @@
+; RUN: opt < %s -tti -tbaa -loop-stripmine -indvars -licm -loop-vectorize -instcombine -simplifycfg -S -o - | FileCheck %s
+
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+%"class.std::vector" = type { %"struct.std::_Vector_base" }
+%"struct.std::_Vector_base" = type { %"struct.std::_Vector_base<long, std::allocator<long> >::_Vector_impl" }
+%"struct.std::_Vector_base<long, std::allocator<long> >::_Vector_impl" = type { %"struct.std::_Vector_base<long, std::allocator<long> >::_Vector_impl_data" }
+%"struct.std::_Vector_base<long, std::allocator<long> >::_Vector_impl_data" = type { i64*, i64*, i64* }
+%"class.cilk::reducer_opadd" = type { %"class.cilk::reducer.base", [56 x i8] }
+%"class.cilk::reducer.base" = type { %"class.cilk::internal::reducer_content.base" }
+%"class.cilk::internal::reducer_content.base" = type { %"class.cilk::internal::reducer_base", [56 x i8], [8 x i8] }
+%"class.cilk::internal::reducer_base" = type { %struct.__cilkrts_hyperobject_base, %"class.cilk::internal::storage_for_object", i8* }
+%struct.__cilkrts_hyperobject_base = type { %struct.cilk_c_monoid, i32, i32, i64 }
+%struct.cilk_c_monoid = type { void (i8*, i8*, i8*)*, void (i8*, i8*)*, void (i8*, i8*)*, i8* (i8*, i64)*, void (i8*, i8*)* }
+%"class.cilk::internal::storage_for_object" = type { %"class.cilk::internal::aligned_storage" }
+%"class.cilk::internal::aligned_storage" = type { [1 x i8] }
+
+$__clang_call_terminate = comdat any
+
+$_ZN4cilk8internal12reducer_baseINS_6op_addIxLb1EEEE14reduce_wrapperEPvS5_S5_ = comdat any
+
+$_ZN4cilk8internal12reducer_baseINS_6op_addIxLb1EEEE16identity_wrapperEPvS5_ = comdat any
+
+$_ZN4cilk8internal12reducer_baseINS_6op_addIxLb1EEEE15destroy_wrapperEPvS5_ = comdat any
+
+$_ZN4cilk8internal12reducer_baseINS_6op_addIxLb1EEEE16allocate_wrapperEPvm = comdat any
+
+$_ZN4cilk8internal12reducer_baseINS_6op_addIxLb1EEEE18deallocate_wrapperEPvS5_ = comdat any
+
+@.str.13 = private unnamed_addr constant [22 x i8] c"this == m_initialThis\00", align 1
+@.str.14 = private unnamed_addr constant [69 x i8] c"/data/animals/opencilk/build/lib/clang/10.0.1/include/cilk/reducer.h\00", align 1
+@__PRETTY_FUNCTION__._ZN4cilk8internal12reducer_baseINS_6op_addIxLb1EEEED2Ev = private unnamed_addr constant [119 x i8] c"cilk::internal::reducer_base<cilk::op_add<long long, true> >::~reducer_base() [Monoid = cilk::op_add<long long, true>]\00", align 1
+
+; Function Attrs: argmemonly nounwind willreturn
+declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #0
+
+declare dso_local i32 @__gxx_personality_v0(...)
+
+; Function Attrs: argmemonly nounwind willreturn
+declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #0
+
+; Function Attrs: argmemonly nounwind willreturn
+declare token @llvm.syncregion.start() #0
+
+; Function Attrs: argmemonly willreturn
+declare void @llvm.sync.unwind(token) #1
+
+; Function Attrs: uwtable
+define dso_local i64 @_Z13accum_reducerRKSt6vectorIlSaIlEE(%"class.std::vector"* nocapture readonly dereferenceable(24) %vals) local_unnamed_addr #2 personality i8* bitcast (i32 (...)* @__gxx_personality_v0 to i8*) {
+entry:
+  %sum = alloca %"class.cilk::reducer_opadd", align 64
+  %syncreg = tail call token @llvm.syncregion.start()
+  %0 = bitcast %"class.cilk::reducer_opadd"* %sum to i8*
+  call void @llvm.lifetime.start.p0i8(i64 192, i8* nonnull %0) #9
+  %1 = getelementptr inbounds %"class.cilk::reducer_opadd", %"class.cilk::reducer_opadd"* %sum, i64 0, i32 0, i32 0, i32 0
+  %m_base.i.i.i.i = getelementptr inbounds %"class.cilk::reducer_opadd", %"class.cilk::reducer_opadd"* %sum, i64 0, i32 0, i32 0, i32 0, i32 0
+  %reduce_fn.i.i.i.i = getelementptr inbounds %"class.cilk::reducer_opadd", %"class.cilk::reducer_opadd"* %sum, i64 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0
+  store void (i8*, i8*, i8*)* @_ZN4cilk8internal12reducer_baseINS_6op_addIxLb1EEEE14reduce_wrapperEPvS5_S5_, void (i8*, i8*, i8*)** %reduce_fn.i.i.i.i, align 64, !tbaa !2
+  %2 = getelementptr inbounds %"class.cilk::reducer_opadd", %"class.cilk::reducer_opadd"* %sum, i64 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 1
+  store void (i8*, i8*)* @_ZN4cilk8internal12reducer_baseINS_6op_addIxLb1EEEE16identity_wrapperEPvS5_, void (i8*, i8*)** %2, align 8, !tbaa !7
+  %3 = getelementptr inbounds %"class.cilk::reducer_opadd", %"class.cilk::reducer_opadd"* %sum, i64 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 2
+  store void (i8*, i8*)* @_ZN4cilk8internal12reducer_baseINS_6op_addIxLb1EEEE15destroy_wrapperEPvS5_, void (i8*, i8*)** %3, align 16, !tbaa !8
+  %4 = getelementptr inbounds %"class.cilk::reducer_opadd", %"class.cilk::reducer_opadd"* %sum, i64 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 3
+  store i8* (i8*, i64)* @_ZN4cilk8internal12reducer_baseINS_6op_addIxLb1EEEE16allocate_wrapperEPvm, i8* (i8*, i64)** %4, align 8, !tbaa !9
+  %5 = getelementptr inbounds %"class.cilk::reducer_opadd", %"class.cilk::reducer_opadd"* %sum, i64 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 4
+  store void (i8*, i8*)* @_ZN4cilk8internal12reducer_baseINS_6op_addIxLb1EEEE18deallocate_wrapperEPvS5_, void (i8*, i8*)** %5, align 32, !tbaa !10
+  %6 = getelementptr inbounds %"class.cilk::reducer_opadd", %"class.cilk::reducer_opadd"* %sum, i64 0, i32 0, i32 0, i32 0, i32 0, i32 1
+  store i32 0, i32* %6, align 8, !tbaa !11
+  %7 = getelementptr inbounds %"class.cilk::reducer_opadd", %"class.cilk::reducer_opadd"* %sum, i64 0, i32 0, i32 0, i32 0, i32 0, i32 2
+  store i32 128, i32* %7, align 4, !tbaa !15
+  %8 = getelementptr inbounds %"class.cilk::reducer_opadd", %"class.cilk::reducer_opadd"* %sum, i64 0, i32 0, i32 0, i32 0, i32 0, i32 3
+  store i64 8, i64* %8, align 16, !tbaa !16
+  %9 = getelementptr inbounds %"class.cilk::reducer_opadd", %"class.cilk::reducer_opadd"* %sum, i64 0, i32 0, i32 0, i32 0, i32 2
+  %10 = bitcast i8** %9 to %"class.cilk::internal::reducer_base"**
+  store %"class.cilk::internal::reducer_base"* %1, %"class.cilk::internal::reducer_base"** %10, align 64, !tbaa !17
+  call void @__cilkrts_hyper_create(%struct.__cilkrts_hyperobject_base* nonnull %m_base.i.i.i.i)
+  %11 = load i32, i32* %7, align 4, !tbaa !20
+  %idx.ext.i.i.i = zext i32 %11 to i64
+  %add.ptr.i.i.i = getelementptr inbounds i8, i8* %0, i64 %idx.ext.i.i.i
+  %m_value.i.i.i.i.i = bitcast i8* %add.ptr.i.i.i to i64*
+  store i64 0, i64* %m_value.i.i.i.i.i, align 8, !tbaa !21
+  %_M_finish.i = getelementptr inbounds %"class.std::vector", %"class.std::vector"* %vals, i64 0, i32 0, i32 0, i32 0, i32 1
+  %12 = bitcast i64** %_M_finish.i to i64*
+  %13 = load i64, i64* %12, align 8, !tbaa !24
+  %14 = bitcast %"class.std::vector"* %vals to i64*
+  %15 = load i64, i64* %14, align 8, !tbaa !26
+  %sub.ptr.sub.i = sub i64 %13, %15
+  %16 = lshr exact i64 %sub.ptr.sub.i, 3
+  %conv = trunc i64 %16 to i32
+  %cmp = icmp sgt i32 %conv, 0
+  %17 = inttoptr i64 %15 to i64*
+  br i1 %cmp, label %pfor.cond.preheader, label %invoke.cont20
+
+pfor.cond.preheader:                              ; preds = %entry
+  %wide.trip.count = and i64 %16, 4294967295
+  br label %pfor.cond
+
+pfor.cond:                                        ; preds = %pfor.inc, %pfor.cond.preheader
+  %indvars.iv = phi i64 [ 0, %pfor.cond.preheader ], [ %indvars.iv.next, %pfor.inc ]
+  %indvars.iv.next = add nuw nsw i64 %indvars.iv, 1
+  detach within %syncreg, label %invoke.cont7, label %pfor.inc
+
+invoke.cont7:                                     ; preds = %pfor.cond
+  %add.ptr.i = getelementptr inbounds i64, i64* %17, i64 %indvars.iv
+  %18 = load i64, i64* %add.ptr.i, align 8, !tbaa !27
+  %call.i.i.i = call strand_noalias i8* @__cilkrts_hyper_lookup(%struct.__cilkrts_hyperobject_base* nonnull %m_base.i.i.i.i) #10
+  %m_value.i.i = bitcast i8* %call.i.i.i to i64*
+  %19 = load i64, i64* %m_value.i.i, align 8, !tbaa !21
+  %add.i.i = add nsw i64 %19, %18
+  store i64 %add.i.i, i64* %m_value.i.i, align 8, !tbaa !21
+  reattach within %syncreg, label %pfor.inc
+
+pfor.inc:                                         ; preds = %invoke.cont7, %pfor.cond
+  %exitcond = icmp eq i64 %indvars.iv.next, %wide.trip.count
+  br i1 %exitcond, label %pfor.cond.cleanup, label %pfor.cond, !llvm.loop !28
+
+pfor.cond.cleanup:                                ; preds = %pfor.inc
+  sync within %syncreg, label %sync.continue
+
+lpad10:                                           ; preds = %sync.continue
+  %20 = landingpad { i8*, i32 }
+          cleanup
+  %21 = load i8*, i8** %9, align 64, !tbaa !17
+  %cmp.i.i = icmp eq i8* %21, %0
+  br i1 %cmp.i.i, label %cond.end.i.i, label %cond.false.i.i
+
+sync.continue:                                    ; preds = %pfor.cond.cleanup
+  invoke void @llvm.sync.unwind(token %syncreg)
+          to label %invoke.cont20 unwind label %lpad10
+
+invoke.cont20:                                    ; preds = %sync.continue, %entry
+  %call.i.i.i.i = call strand_noalias i8* @__cilkrts_hyper_lookup(%struct.__cilkrts_hyperobject_base* nonnull %m_base.i.i.i.i) #10
+  %m_value.i.i.i = bitcast i8* %call.i.i.i.i to i64*
+  %22 = load i64, i64* %m_value.i.i.i, align 8, !tbaa !30
+  %23 = load i8*, i8** %9, align 64, !tbaa !17
+  %cmp.i.i48 = icmp eq i8* %23, %0
+  br i1 %cmp.i.i48, label %cond.end.i.i51, label %cond.false.i.i49
+
+cond.false.i.i49:                                 ; preds = %invoke.cont20
+  call void @__assert_fail(i8* getelementptr inbounds ([22 x i8], [22 x i8]* @.str.13, i64 0, i64 0), i8* getelementptr inbounds ([69 x i8], [69 x i8]* @.str.14, i64 0, i64 0), i32 840, i8* getelementptr inbounds ([119 x i8], [119 x i8]* @__PRETTY_FUNCTION__._ZN4cilk8internal12reducer_baseINS_6op_addIxLb1EEEED2Ev, i64 0, i64 0)) #11
+  unreachable
+
+cond.end.i.i51:                                   ; preds = %invoke.cont20
+  invoke void @__cilkrts_hyper_destroy(%struct.__cilkrts_hyperobject_base* nonnull %m_base.i.i.i.i)
+          to label %_ZN4cilk7reducerINS_6op_addIxLb1EEEED2Ev.exit53 unwind label %terminate.lpad.i.i52
+
+terminate.lpad.i.i52:                             ; preds = %cond.end.i.i51
+  %24 = landingpad { i8*, i32 }
+          catch i8* null
+  %25 = extractvalue { i8*, i32 } %24, 0
+  call void @__clang_call_terminate(i8* %25) #11
+  unreachable
+
+_ZN4cilk7reducerINS_6op_addIxLb1EEEED2Ev.exit53:  ; preds = %cond.end.i.i51
+  call void @llvm.lifetime.end.p0i8(i64 192, i8* nonnull %0) #9
+  ret i64 %22
+
+cond.false.i.i:                                   ; preds = %lpad10
+  call void @__assert_fail(i8* getelementptr inbounds ([22 x i8], [22 x i8]* @.str.13, i64 0, i64 0), i8* getelementptr inbounds ([69 x i8], [69 x i8]* @.str.14, i64 0, i64 0), i32 840, i8* getelementptr inbounds ([119 x i8], [119 x i8]* @__PRETTY_FUNCTION__._ZN4cilk8internal12reducer_baseINS_6op_addIxLb1EEEED2Ev, i64 0, i64 0)) #11
+  unreachable
+
+cond.end.i.i:                                     ; preds = %lpad10
+  invoke void @__cilkrts_hyper_destroy(%struct.__cilkrts_hyperobject_base* nonnull %m_base.i.i.i.i)
+          to label %_ZN4cilk7reducerINS_6op_addIxLb1EEEED2Ev.exit unwind label %terminate.lpad.i.i
+
+terminate.lpad.i.i:                               ; preds = %cond.end.i.i
+  %26 = landingpad { i8*, i32 }
+          catch i8* null
+  %27 = extractvalue { i8*, i32 } %26, 0
+  call void @__clang_call_terminate(i8* %27) #11
+  unreachable
+
+_ZN4cilk7reducerINS_6op_addIxLb1EEEED2Ev.exit:    ; preds = %cond.end.i.i
+  call void @llvm.lifetime.end.p0i8(i64 192, i8* nonnull %0) #9
+  resume { i8*, i32 } %20
+}
+
+; CHECK-LABEL: define dso_local i64 @_Z13accum_reducerRKSt6vectorIlSaIlEE(
+
+; CHECK: call void @__cilkrts_hyper_create(
+
+; CHECK: detach within %syncreg, label %[[DETACHED:.+]], label %[[CONTINUE:.+]]
+
+; CHECK: [[DETACHED]]:
+; CHECK: %[[CALL:.+]] = call strand_noalias i8* @__cilkrts_hyper_lookup(
+; CHECK: %[[VIEW:.+]] = bitcast i8* %[[CALL]] to i64*
+; CHECK: br label %[[VECTOR_PH:.+]]
+
+; CHECK: [[VECTOR_PH]]:
+; CHECK: br label %[[VECTOR_BODY:.+]]
+
+; CHECK: [[VECTOR_BODY]]:
+; CHECK: phi <2 x i64>
+; CHECK: load <2 x i64>
+; CHECK: add <2 x i64>
+; CHECK: br i1 %{{.+}}, label %[[MIDDLE_BLOCK:.+]], label %[[VECTOR_BODY]], !llvm.loop
+
+; CHECK: [[MIDDLE_BLOCK]]:
+; CHECK: add <2 x i64>
+; CHECK: shufflevector <2 x i64>
+; CHECK: add <2 x i64>
+; CHECK: %[[RESULT:.+]] = extractelement <2 x i64>
+; CHECK: store i64 %[[RESULT]], i64* %[[VIEW]]
+; CHECK: reattach within %syncreg
+
+; CHECK: sync within %syncreg
+
+; CHECK: %[[CALL2:.+]] = call strand_noalias i8* @__cilkrts_hyper_lookup(
+; CHECK-NEXT: %[[VIEW2:.+]] = bitcast i8* %[[CALL2]] to i64*
+; CHECK-NEXT: %[[SUM:.+]] = load i64, i64* %[[VIEW2]]
+
+; CHECK: invoke void @__cilkrts_hyper_destroy(
+; CHECK-NEXT: to label %[[RET_BLOCK:.+]] unwind label %{{.+}}
+
+; CHECK: [[RET_BLOCK]]:
+; CHECK: ret i64 %[[SUM]]
+
+; Function Attrs: noinline noreturn nounwind
+define linkonce_odr hidden void @__clang_call_terminate(i8* %0) local_unnamed_addr #3 comdat {
+  %2 = tail call i8* @__cxa_begin_catch(i8* %0) #9
+  tail call void @_ZSt9terminatev() #11
+  unreachable
+}
+
+declare dso_local i8* @__cxa_begin_catch(i8*) local_unnamed_addr
+
+declare dso_local void @_ZSt9terminatev() local_unnamed_addr
+
+; Function Attrs: noreturn nounwind
+declare dso_local void @__assert_fail(i8*, i8*, i32, i8*) local_unnamed_addr #4
+
+declare dso_local void @__cilkrts_hyper_destroy(%struct.__cilkrts_hyperobject_base*) local_unnamed_addr #5
+
+; Function Attrs: nobuiltin nounwind
+declare dso_local void @_ZdlPv(i8*) local_unnamed_addr #6
+
+; Function Attrs: nobuiltin nofree
+declare dso_local noalias nonnull i8* @_Znwm(i64) local_unnamed_addr #7
+
+; Function Attrs: uwtable
+define linkonce_odr dso_local void @_ZN4cilk8internal12reducer_baseINS_6op_addIxLb1EEEE14reduce_wrapperEPvS5_S5_(i8* %r, i8* %lhs, i8* %rhs) #2 comdat align 2 {
+entry:
+  %m_value.i.i = bitcast i8* %rhs to i64*
+  %0 = load i64, i64* %m_value.i.i, align 8, !tbaa !21
+  %m_value2.i.i = bitcast i8* %lhs to i64*
+  %1 = load i64, i64* %m_value2.i.i, align 8, !tbaa !21
+  %add.i.i = add nsw i64 %1, %0
+  store i64 %add.i.i, i64* %m_value2.i.i, align 8, !tbaa !21
+  ret void
+}
+
+; Function Attrs: uwtable
+define linkonce_odr dso_local void @_ZN4cilk8internal12reducer_baseINS_6op_addIxLb1EEEE16identity_wrapperEPvS5_(i8* %r, i8* %view) #2 comdat align 2 {
+entry:
+  %m_value.i.i.i = bitcast i8* %view to i64*
+  store i64 0, i64* %m_value.i.i.i, align 8, !tbaa !21
+  ret void
+}
+
+; Function Attrs: uwtable
+define linkonce_odr dso_local void @_ZN4cilk8internal12reducer_baseINS_6op_addIxLb1EEEE15destroy_wrapperEPvS5_(i8* %r, i8* %view) #2 comdat align 2 {
+entry:
+  ret void
+}
+
+; Function Attrs: uwtable
+define linkonce_odr dso_local i8* @_ZN4cilk8internal12reducer_baseINS_6op_addIxLb1EEEE16allocate_wrapperEPvm(i8* %r, i64 %bytes) #2 comdat align 2 {
+entry:
+  %call.i = tail call i8* @_Znwm(i64 %bytes)
+  ret i8* %call.i
+}
+
+; Function Attrs: uwtable
+define linkonce_odr dso_local void @_ZN4cilk8internal12reducer_baseINS_6op_addIxLb1EEEE18deallocate_wrapperEPvS5_(i8* %r, i8* %view) #2 comdat align 2 {
+entry:
+  tail call void @_ZdlPv(i8* %view) #9
+  ret void
+}
+
+declare dso_local void @__cilkrts_hyper_create(%struct.__cilkrts_hyperobject_base*) local_unnamed_addr #5
+
+; Function Attrs: nounwind readonly strand_pure
+declare dso_local strand_noalias i8* @__cilkrts_hyper_lookup(%struct.__cilkrts_hyperobject_base*) local_unnamed_addr #8
+
+attributes #0 = { argmemonly nounwind willreturn }
+attributes #1 = { argmemonly willreturn }
+attributes #2 = { uwtable "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="none" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #3 = { noinline noreturn nounwind }
+attributes #4 = { noreturn nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="none" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #5 = { "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="none" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #6 = { nobuiltin nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="none" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #7 = { nobuiltin nofree "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="none" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #8 = { nounwind readonly strand_pure "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="none" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #9 = { nounwind }
+attributes #10 = { nounwind readonly strand_pure }
+attributes #11 = { noreturn nounwind }
+
+!llvm.module.flags = !{!0}
+!llvm.ident = !{!1}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{!"clang version 10.0.1 (git@github.com:OpenCilk/opencilk-project.git 9c5f1e03ba9dc39b9bee419084e1cb1c698f6fe2)"}
+!2 = !{!3, !4, i64 0}
+!3 = !{!"_ZTS13cilk_c_monoid", !4, i64 0, !4, i64 8, !4, i64 16, !4, i64 24, !4, i64 32}
+!4 = !{!"any pointer", !5, i64 0}
+!5 = !{!"omnipotent char", !6, i64 0}
+!6 = !{!"Simple C++ TBAA"}
+!7 = !{!3, !4, i64 8}
+!8 = !{!3, !4, i64 16}
+!9 = !{!3, !4, i64 24}
+!10 = !{!3, !4, i64 32}
+!11 = !{!12, !13, i64 40}
+!12 = !{!"_ZTS26__cilkrts_hyperobject_base", !3, i64 0, !13, i64 40, !13, i64 44, !14, i64 48}
+!13 = !{!"int", !5, i64 0}
+!14 = !{!"long", !5, i64 0}
+!15 = !{!12, !13, i64 44}
+!16 = !{!12, !14, i64 48}
+!17 = !{!18, !4, i64 64}
+!18 = !{!"_ZTSN4cilk8internal12reducer_baseINS_6op_addIxLb1EEEEE", !12, i64 0, !19, i64 56, !4, i64 64}
+!19 = !{!"_ZTSN4cilk8internal18storage_for_objectINS_6op_addIxLb1EEEEE"}
+!20 = !{!18, !13, i64 44}
+!21 = !{!22, !23, i64 0}
+!22 = !{!"_ZTSN4cilk11scalar_viewIxEE", !23, i64 0}
+!23 = !{!"long long", !5, i64 0}
+!24 = !{!25, !4, i64 8}
+!25 = !{!"_ZTSNSt12_Vector_baseIlSaIlEE17_Vector_impl_dataE", !4, i64 0, !4, i64 8, !4, i64 16}
+!26 = !{!25, !4, i64 0}
+!27 = !{!14, !14, i64 0}
+!28 = distinct !{!28, !29}
+!29 = !{!"tapir.loop.spawn.strategy", i32 1}
+!30 = !{!23, !23, i64 0}

--- a/llvm/test/Transforms/Tapir/nested-loop-spawning-with-exceptions.ll
+++ b/llvm/test/Transforms/Tapir/nested-loop-spawning-with-exceptions.ll
@@ -1103,10 +1103,11 @@ declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i32, i1) #1
 ; CHECK: [[DUNWIND]]:
 ; CHECK: resume
 ; CHECK: [[LSUNWIND]]:
-; CHECK-NEXT: %[[LPADVAL:.+]] = landingpad [[LPADTYPE:.+]]
+; CHECK: %[[LPADVAL:.+]] = landingpad [[LPADTYPE:.+]]
 ; CHECK-NEXT: cleanup
 ; CHECK: invoke void @llvm.detached.rethrow
 ; CHECK: (token %[[SYNCREG]], [[LPADTYPE]] %[[LPADVAL]])
+; CHECK-NEXT: to label %{{.+}} unwind label %[[DUNWIND]]
 
 ; CHECK-LABEL: define private fastcc void @_Z14func_with_sretidRSt6vectorI6paramsSaIS0_EE.outline_pfor.detach.ls1(i64
 ; CHECK: %[[SYNCREG:.+]] = tail call token @llvm.syncregion.start()
@@ -1121,10 +1122,11 @@ declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i32, i1) #1
 ; CHECK: [[DUNWIND]]:
 ; CHECK resume
 ; CHECK: [[LSUNWIND]]:
-; CHECK-NEXT: %[[LPADVAL:.+]] = landingpad [[LPADTYPE:.+]]
+; CHECK: %[[LPADVAL:.+]] = landingpad [[LPADTYPE:.+]]
 ; CHECK-NEXT: cleanup
 ; CHECK: invoke void @llvm.detached.rethrow
 ; CHECK: (token %[[SYNCREG]], [[LPADTYPE]] %[[LPADVAL]])
+; CHECK-NEXT: to label %{{.+}} unwind label %[[DUNWIND]]
 
 attributes #0 = { uwtable "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { argmemonly nounwind }

--- a/llvm/test/Transforms/Tapir/strandpure-licm.ll
+++ b/llvm/test/Transforms/Tapir/strandpure-licm.ll
@@ -1,0 +1,493 @@
+; RUN: opt < %s -licm -S -o - | FileCheck %s
+; RUN: opt < %s -aa-pipeline=basic-aa -passes='require<opt-remark-emit>,loop(licm)' -S -o - | FileCheck %s
+
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+%"class.cilk::provisional_guard" = type { %"struct.cilk::op_add"* }
+%"struct.cilk::op_add" = type { i8 }
+%"class.cilk::reducer_opadd" = type { %"class.cilk::reducer.base", [56 x i8] }
+%"class.cilk::reducer.base" = type { %"class.cilk::internal::reducer_content.base" }
+%"class.cilk::internal::reducer_content.base" = type { %"class.cilk::internal::reducer_base", [48 x i8], [8 x i8] }
+%"class.cilk::internal::reducer_base" = type { %struct.__cilkrts_hyperobject_base, %"class.cilk::internal::storage_for_object", i8* }
+%struct.__cilkrts_hyperobject_base = type { %struct.cilk_c_monoid, i32, i64, i64 }
+%struct.cilk_c_monoid = type { void (i8*, i8*, i8*)*, void (i8*, i8*)*, void (i8*, i8*)*, i8* (i8*, i64)*, void (i8*, i8*)* }
+%"class.cilk::internal::storage_for_object" = type { %"class.cilk::internal::aligned_storage" }
+%"class.cilk::internal::aligned_storage" = type { [1 x i8] }
+%"class.cilk::reducer" = type { %"class.cilk::internal::reducer_content.base", [56 x i8] }
+%"class.cilk::internal::reducer_content" = type { %"class.cilk::internal::reducer_base", [48 x i8], [8 x i8], [56 x i8] }
+%"class.cilk::op_add_view" = type { %"class.cilk::scalar_view" }
+%"class.cilk::scalar_view" = type { i64 }
+%"class.cilk::monoid_with_view" = type { i8 }
+%"class.cilk::monoid_base" = type { i8 }
+
+$_ZN4cilk8internal12reducer_baseINS_6op_addIxLb1EEEED2Ev = comdat any
+
+$__clang_call_terminate = comdat any
+
+$_ZN4cilk8internal12reducer_baseINS_6op_addIxLb1EEEE14reduce_wrapperEPvS5_S5_ = comdat any
+
+$_ZN4cilk8internal12reducer_baseINS_6op_addIxLb1EEEE16identity_wrapperEPvS5_ = comdat any
+
+$_ZN4cilk8internal12reducer_baseINS_6op_addIxLb1EEEE15destroy_wrapperEPvS5_ = comdat any
+
+$_ZN4cilk8internal12reducer_baseINS_6op_addIxLb1EEEE16allocate_wrapperEPvm = comdat any
+
+$_ZN4cilk8internal12reducer_baseINS_6op_addIxLb1EEEE18deallocate_wrapperEPvS5_ = comdat any
+
+@.str.1 = private unnamed_addr constant [140 x i8] c"reducer_is_cache_aligned() && \22Reducer should be cache aligned. Please see comments following \22 \22this assertion for explanation and fixes.\22\00", align 1
+@.str.2 = private unnamed_addr constant [80 x i8] c"/data/animals/opencilk-project/build-dbg/lib/clang/9.0.1/include/cilk/reducer.h\00", align 1
+@__PRETTY_FUNCTION__._ZN4cilk8internal15reducer_contentINS_6op_addIxLb1EEELb1EEC2Ev = private unnamed_addr constant [145 x i8] c"cilk::internal::reducer_content<cilk::op_add<long long, true>, true>::reducer_content() [Monoid = cilk::op_add<long long, true>, Aligned = true]\00", align 1
+
+; Function Attrs: uwtable
+define dso_local i64 @_Z13accum_reducerl(i64 %n) local_unnamed_addr #0 personality i8* bitcast (i32 (...)* @__gxx_personality_v0 to i8*) {
+entry:
+  %ref.tmp1.epil = alloca i64, align 8
+  %guard.i.i.i = alloca %"class.cilk::provisional_guard", align 8
+  %accum = alloca %"class.cilk::reducer_opadd", align 64
+  %ref.tmp = alloca i64, align 8
+  %syncreg = tail call token @llvm.syncregion.start()
+  %0 = bitcast %"class.cilk::reducer_opadd"* %accum to i8*
+  call void @llvm.lifetime.start.p0i8(i64 192, i8* nonnull %0) #10
+  %1 = bitcast i64* %ref.tmp to i8*
+  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %1) #10
+  store i64 0, i64* %ref.tmp, align 8, !tbaa !2
+  %2 = bitcast %"class.cilk::reducer_opadd"* %accum to %"class.cilk::reducer"*
+  %3 = bitcast %"class.cilk::reducer"* %2 to %"class.cilk::internal::reducer_content"*
+  %4 = getelementptr inbounds %"class.cilk::internal::reducer_content", %"class.cilk::internal::reducer_content"* %3, i64 0, i32 0
+  %5 = getelementptr inbounds %"class.cilk::internal::reducer_content", %"class.cilk::internal::reducer_content"* %3, i64 0, i32 2, i64 0
+  %m_base.i.i.i.i = getelementptr inbounds %"class.cilk::internal::reducer_base", %"class.cilk::internal::reducer_base"* %4, i64 0, i32 0
+  %reduce_fn.i.i.i.i = getelementptr inbounds %"class.cilk::internal::reducer_base", %"class.cilk::internal::reducer_base"* %4, i64 0, i32 0, i32 0, i32 0
+  store void (i8*, i8*, i8*)* @_ZN4cilk8internal12reducer_baseINS_6op_addIxLb1EEEE14reduce_wrapperEPvS5_S5_, void (i8*, i8*, i8*)** %reduce_fn.i.i.i.i, align 8, !tbaa !6
+  %identity_fn.i.i.i.i = getelementptr inbounds %"class.cilk::internal::reducer_base", %"class.cilk::internal::reducer_base"* %4, i64 0, i32 0, i32 0, i32 1
+  store void (i8*, i8*)* @_ZN4cilk8internal12reducer_baseINS_6op_addIxLb1EEEE16identity_wrapperEPvS5_, void (i8*, i8*)** %identity_fn.i.i.i.i, align 8, !tbaa !9
+  %destroy_fn.i.i.i.i = getelementptr inbounds %"class.cilk::internal::reducer_base", %"class.cilk::internal::reducer_base"* %4, i64 0, i32 0, i32 0, i32 2
+  store void (i8*, i8*)* @_ZN4cilk8internal12reducer_baseINS_6op_addIxLb1EEEE15destroy_wrapperEPvS5_, void (i8*, i8*)** %destroy_fn.i.i.i.i, align 8, !tbaa !10
+  %allocate_fn.i.i.i.i = getelementptr inbounds %"class.cilk::internal::reducer_base", %"class.cilk::internal::reducer_base"* %4, i64 0, i32 0, i32 0, i32 3
+  store i8* (i8*, i64)* @_ZN4cilk8internal12reducer_baseINS_6op_addIxLb1EEEE16allocate_wrapperEPvm, i8* (i8*, i64)** %allocate_fn.i.i.i.i, align 8, !tbaa !11
+  %deallocate_fn.i.i.i.i = getelementptr inbounds %"class.cilk::internal::reducer_base", %"class.cilk::internal::reducer_base"* %4, i64 0, i32 0, i32 0, i32 4
+  store void (i8*, i8*)* @_ZN4cilk8internal12reducer_baseINS_6op_addIxLb1EEEE18deallocate_wrapperEPvS5_, void (i8*, i8*)** %deallocate_fn.i.i.i.i, align 8, !tbaa !12
+  %__id_num.i.i.i.i = getelementptr inbounds %"class.cilk::internal::reducer_base", %"class.cilk::internal::reducer_base"* %4, i64 0, i32 0, i32 1
+  store i32 0, i32* %__id_num.i.i.i.i, align 8, !tbaa !13
+  %__view_offset.i.i.i.i = getelementptr inbounds %"class.cilk::internal::reducer_base", %"class.cilk::internal::reducer_base"* %4, i64 0, i32 0, i32 2
+  %sub.ptr.lhs.cast.i.i.i.i = ptrtoint i8* %5 to i64
+  %sub.ptr.rhs.cast.i.i.i.i = ptrtoint %"class.cilk::internal::reducer_base"* %4 to i64
+  store i64 128, i64* %__view_offset.i.i.i.i, align 8, !tbaa !17
+  %__view_size.i.i.i.i = getelementptr inbounds %"class.cilk::internal::reducer_base", %"class.cilk::internal::reducer_base"* %4, i64 0, i32 0, i32 3
+  store i64 8, i64* %__view_size.i.i.i.i, align 8, !tbaa !18
+  %m_initialThis.i.i.i.i = getelementptr inbounds %"class.cilk::internal::reducer_base", %"class.cilk::internal::reducer_base"* %4, i64 0, i32 2
+  %6 = bitcast i8** %m_initialThis.i.i.i.i to %"class.cilk::internal::reducer_base"**
+  store %"class.cilk::internal::reducer_base"* %4, %"class.cilk::internal::reducer_base"** %6, align 8, !tbaa !19
+  call void @__cilkrts_hyper_create(%struct.__cilkrts_hyperobject_base* %m_base.i.i.i.i)
+  %7 = ptrtoint %"class.cilk::internal::reducer_content"* %3 to i64
+  %8 = getelementptr inbounds %"class.cilk::reducer", %"class.cilk::reducer"* %2, i64 0, i32 0, i32 0
+  %m_monoid.i.i.i = getelementptr inbounds %"class.cilk::internal::reducer_base", %"class.cilk::internal::reducer_base"* %8, i64 0, i32 1
+  %9 = bitcast %"class.cilk::internal::storage_for_object"* %m_monoid.i.i.i to %"struct.cilk::op_add"*
+  %10 = bitcast %"class.cilk::internal::reducer_base"* %8 to i8*
+  %__view_offset.i.i.i = getelementptr inbounds %"class.cilk::internal::reducer_base", %"class.cilk::internal::reducer_base"* %8, i64 0, i32 0, i32 2
+  %11 = load i64, i64* %__view_offset.i.i.i, align 8, !tbaa !22
+  %add.ptr.i.i.i = getelementptr inbounds i8, i8* %10, i64 %11
+  %12 = bitcast i8* %add.ptr.i.i.i to %"class.cilk::op_add_view"*
+  %13 = bitcast %"class.cilk::provisional_guard"* %guard.i.i.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %13) #10
+  %m_ptr.i.i.i.i = getelementptr inbounds %"class.cilk::provisional_guard", %"class.cilk::provisional_guard"* %guard.i.i.i, i64 0, i32 0
+  store %"struct.cilk::op_add"* %9, %"struct.cilk::op_add"** %m_ptr.i.i.i.i, align 8, !tbaa !23
+  %14 = getelementptr inbounds %"class.cilk::op_add_view", %"class.cilk::op_add_view"* %12, i64 0, i32 0
+  %m_value.i.i.i.i.i = getelementptr inbounds %"class.cilk::scalar_view", %"class.cilk::scalar_view"* %14, i64 0, i32 0
+  %15 = load i64, i64* %ref.tmp, align 8, !tbaa !2
+  store i64 %15, i64* %m_value.i.i.i.i.i, align 8, !tbaa !25
+  %m_ptr.i1.i.i.i = getelementptr inbounds %"class.cilk::provisional_guard", %"class.cilk::provisional_guard"* %guard.i.i.i, i64 0, i32 0
+  store %"struct.cilk::op_add"* null, %"struct.cilk::op_add"** %m_ptr.i1.i.i.i, align 8, !tbaa !23
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %13) #10
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %1) #10
+  %cmp = icmp sgt i64 %n, -1
+  br i1 %cmp, label %pfor.cond.preheader, label %cleanup
+
+pfor.cond.preheader:                              ; preds = %entry
+  %xtraiter = and i64 %n, 2047
+  %16 = icmp ult i64 %n, 2047
+  br i1 %16, label %pfor.cond.cleanup.strpm-lcssa, label %pfor.cond.preheader.new
+
+pfor.cond.preheader.new:                          ; preds = %pfor.cond.preheader
+  %stripiter = udiv i64 %n, 2048
+  br label %pfor.cond.strpm.outer
+
+pfor.cond.strpm.outer:                            ; preds = %pfor.inc.strpm.outer, %pfor.cond.preheader.new
+  %niter = phi i64 [ 0, %pfor.cond.preheader.new ], [ %niter.nadd, %pfor.inc.strpm.outer ]
+  detach within %syncreg, label %pfor.body.strpm.outer, label %pfor.inc.strpm.outer unwind label %lpad5.loopexit
+
+pfor.body.strpm.outer:                            ; preds = %pfor.cond.strpm.outer
+  %ref.tmp1 = alloca i64, align 8
+  %17 = mul i64 2048, %niter
+  br label %pfor.cond
+
+pfor.cond:                                        ; preds = %pfor.body.strpm.outer, %pfor.inc
+  %__begin.0 = phi i64 [ %inc, %pfor.inc ], [ %17, %pfor.body.strpm.outer ]
+  %inneriter = phi i64 [ 2048, %pfor.body.strpm.outer ], [ %inneriter.nsub, %pfor.inc ]
+  br label %pfor.body
+
+pfor.body:                                        ; preds = %pfor.cond
+  %18 = bitcast i64* %ref.tmp1 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %18) #10
+  store i64 %__begin.0, i64* %ref.tmp1, align 8, !tbaa !2
+  %19 = bitcast %"class.cilk::reducer_opadd"* %accum to %"class.cilk::reducer"*
+  %20 = getelementptr inbounds %"class.cilk::reducer", %"class.cilk::reducer"* %19, i64 0, i32 0, i32 0
+  %m_base.i.i.i = getelementptr inbounds %"class.cilk::internal::reducer_base", %"class.cilk::internal::reducer_base"* %20, i64 0, i32 0
+  %call.i.i.i = call noalias i8* @__cilkrts_hyper_lookup(%struct.__cilkrts_hyperobject_base* %m_base.i.i.i) #11
+  %21 = bitcast i8* %call.i.i.i to %"class.cilk::op_add_view"*
+  %22 = load i64, i64* %ref.tmp1, align 8, !tbaa !2
+  %m_value.i.i = getelementptr inbounds %"class.cilk::op_add_view", %"class.cilk::op_add_view"* %21, i64 0, i32 0, i32 0
+  %23 = load i64, i64* %m_value.i.i, align 8, !tbaa !25
+  %add.i.i = add nsw i64 %23, %22
+  store i64 %add.i.i, i64* %m_value.i.i, align 8, !tbaa !25
+  br label %invoke.cont2
+
+invoke.cont2:                                     ; preds = %pfor.body
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %18) #10
+  br label %pfor.inc
+
+pfor.inc:                                         ; preds = %invoke.cont2
+  %inc = add nuw i64 %__begin.0, 1
+  %inneriter.nsub = sub nuw nsw i64 %inneriter, 1
+  %inneriter.ncmp = icmp eq i64 %inneriter.nsub, 0
+  br i1 %inneriter.ncmp, label %pfor.inc.reattach, label %pfor.cond, !llvm.loop !27
+
+; CHECK: pfor.cond.strpm.outer:
+; CHECK: call noalias i8* @__cilkrts_hyper_lookup(
+; CHECK: br label %pfor.cond
+
+; CHECK: pfor.cond:
+; CHECK: br label %pfor.body
+
+; CHECK: pfor.body:
+; CHECK-NOT: call noalias i8* @__cilkrts_hyper_lookup(
+; CHECK: br label %pfor.inc
+
+; CHECK: pfor.inc:
+; CHECK: br i1 %{{.+}}, label %{{.+}}, label %pfor.cond
+
+pfor.inc.reattach:                                ; preds = %pfor.inc
+  reattach within %syncreg, label %pfor.inc.strpm.outer
+
+pfor.inc.strpm.outer:                             ; preds = %pfor.inc.reattach, %pfor.cond.strpm.outer
+  %niter.nadd = add nuw i64 %niter, 1
+  %niter.ncmp = icmp eq i64 %niter.nadd, %stripiter
+  br i1 %niter.ncmp, label %pfor.cond.cleanup.strpm-lcssa.loopexit, label %pfor.cond.strpm.outer, !llvm.loop !29
+
+pfor.cond.cleanup.strpm-lcssa.loopexit:           ; preds = %pfor.inc.strpm.outer
+  br label %pfor.cond.cleanup.strpm-lcssa
+
+pfor.cond.cleanup.strpm-lcssa:                    ; preds = %pfor.cond.cleanup.strpm-lcssa.loopexit, %pfor.cond.preheader
+  %lcmp.mod = icmp ne i64 %xtraiter, 0
+  br i1 %lcmp.mod, label %pfor.cond.epil.preheader, label %pfor.cond.cleanup
+
+pfor.cond.epil.preheader:                         ; preds = %pfor.cond.cleanup.strpm-lcssa
+  %24 = udiv i64 %n, 2048
+  %25 = mul nuw i64 %24, 2048
+  br label %pfor.cond.epil
+
+pfor.cond.epil:                                   ; preds = %pfor.inc.epil, %pfor.cond.epil.preheader
+  %__begin.0.epil = phi i64 [ %inc.epil, %pfor.inc.epil ], [ %25, %pfor.cond.epil.preheader ]
+  %epil.iter = phi i64 [ %xtraiter, %pfor.cond.epil.preheader ], [ %epil.iter.sub, %pfor.inc.epil ]
+  br label %pfor.body.epil
+
+pfor.body.epil:                                   ; preds = %pfor.cond.epil
+  %26 = bitcast i64* %ref.tmp1.epil to i8*
+  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %26) #10
+  store i64 %__begin.0.epil, i64* %ref.tmp1.epil, align 8, !tbaa !2
+  %27 = bitcast %"class.cilk::reducer_opadd"* %accum to %"class.cilk::reducer"*
+  %28 = getelementptr inbounds %"class.cilk::reducer", %"class.cilk::reducer"* %27, i64 0, i32 0, i32 0
+  %m_base.i.i.i.epil = getelementptr inbounds %"class.cilk::internal::reducer_base", %"class.cilk::internal::reducer_base"* %28, i64 0, i32 0
+  %call.i.i.i.epil = call noalias i8* @__cilkrts_hyper_lookup(%struct.__cilkrts_hyperobject_base* %m_base.i.i.i.epil) #11
+  %29 = bitcast i8* %call.i.i.i.epil to %"class.cilk::op_add_view"*
+  %30 = load i64, i64* %ref.tmp1.epil, align 8, !tbaa !2
+  %m_value.i.i.epil = getelementptr inbounds %"class.cilk::op_add_view", %"class.cilk::op_add_view"* %29, i64 0, i32 0, i32 0
+  %31 = load i64, i64* %m_value.i.i.epil, align 8, !tbaa !25
+  %add.i.i.epil = add nsw i64 %31, %30
+  store i64 %add.i.i.epil, i64* %m_value.i.i.epil, align 8, !tbaa !25
+  br label %invoke.cont2.epil
+
+invoke.cont2.epil:                                ; preds = %pfor.body.epil
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %26) #10
+  br label %pfor.inc.epil
+
+pfor.inc.epil:                                    ; preds = %invoke.cont2.epil
+  %inc.epil = add nuw nsw i64 %__begin.0.epil, 1
+  %epil.iter.sub = sub nsw i64 %epil.iter, 1
+  %epil.iter.cmp = icmp ne i64 %epil.iter.sub, 0
+  br i1 %epil.iter.cmp, label %pfor.cond.epil, label %pfor.cond.cleanup.epilog-lcssa, !llvm.loop !32
+
+pfor.cond.cleanup.epilog-lcssa:                   ; preds = %pfor.inc.epil
+  br label %pfor.cond.cleanup
+
+pfor.cond.cleanup:                                ; preds = %pfor.cond.cleanup.strpm-lcssa, %pfor.cond.cleanup.epilog-lcssa
+  sync within %syncreg, label %sync.continue
+
+lpad:                                             ; No predecessors!
+  %32 = landingpad { i8*, i32 }
+          cleanup
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %18) #10
+  invoke void @llvm.detached.rethrow.sl_p0i8i32s(token %syncreg, { i8*, i32 } %32)
+          to label %unreachable unwind label %lpad5.loopexit.split-lp
+
+lpad5.loopexit:                                   ; preds = %pfor.cond.strpm.outer
+  %lpad.loopexit = landingpad { i8*, i32 }
+          cleanup
+  br label %ehcleanup18
+
+lpad5.loopexit.split-lp:                          ; preds = %sync.continue, %lpad
+  %lpad.loopexit.split-lp = landingpad { i8*, i32 }
+          cleanup
+  br label %ehcleanup18
+
+sync.continue:                                    ; preds = %pfor.cond.cleanup
+  invoke void @llvm.sync.unwind(token %syncreg)
+          to label %cleanup unwind label %lpad5.loopexit.split-lp
+
+cleanup:                                          ; preds = %sync.continue, %entry
+  %33 = bitcast %"class.cilk::reducer_opadd"* %accum to %"class.cilk::reducer"*
+  %34 = getelementptr inbounds %"class.cilk::reducer", %"class.cilk::reducer"* %33, i64 0, i32 0, i32 0
+  %m_base.i.i.i.i1 = getelementptr inbounds %"class.cilk::internal::reducer_base", %"class.cilk::internal::reducer_base"* %34, i64 0, i32 0
+  %call.i.i.i.i = call noalias i8* @__cilkrts_hyper_lookup(%struct.__cilkrts_hyperobject_base* %m_base.i.i.i.i1) #11
+  %35 = bitcast i8* %call.i.i.i.i to %"class.cilk::op_add_view"*
+  %36 = getelementptr inbounds %"class.cilk::op_add_view", %"class.cilk::op_add_view"* %35, i64 0, i32 0
+  %m_value.i.i.i = getelementptr inbounds %"class.cilk::scalar_view", %"class.cilk::scalar_view"* %36, i64 0, i32 0
+  br label %invoke.cont15
+
+invoke.cont15:                                    ; preds = %cleanup
+  %37 = load i64, i64* %m_value.i.i.i, align 8, !tbaa !2
+  %38 = getelementptr inbounds %"class.cilk::reducer", %"class.cilk::reducer"* %33, i64 0, i32 0, i32 0
+  %39 = bitcast %"class.cilk::internal::reducer_base"* %38 to i8*
+  %__view_offset.i.i2 = getelementptr inbounds %"class.cilk::internal::reducer_base", %"class.cilk::internal::reducer_base"* %38, i64 0, i32 0, i32 2
+  %40 = load i64, i64* %__view_offset.i.i2, align 8, !tbaa !22
+  %add.ptr.i.i3 = getelementptr inbounds i8, i8* %39, i64 %40
+  %41 = bitcast i8* %add.ptr.i.i3 to %"class.cilk::op_add_view"*
+  %m_monoid.i.i4 = getelementptr inbounds %"class.cilk::internal::reducer_base", %"class.cilk::internal::reducer_base"* %38, i64 0, i32 1
+  %42 = bitcast %"class.cilk::internal::storage_for_object"* %m_monoid.i.i4 to %"struct.cilk::op_add"*
+  %m_base.i.i5 = getelementptr inbounds %"class.cilk::internal::reducer_base", %"class.cilk::internal::reducer_base"* %38, i64 0, i32 0
+  invoke void @__cilkrts_hyper_destroy(%struct.__cilkrts_hyperobject_base* %m_base.i.i5)
+          to label %_ZN4cilk7reducerINS_6op_addIxLb1EEEED2Ev.exit7 unwind label %terminate.lpad.i.i6
+
+terminate.lpad.i.i6:                              ; preds = %invoke.cont15
+  %43 = landingpad { i8*, i32 }
+          catch i8* null
+  %44 = extractvalue { i8*, i32 } %43, 0
+  call void @__clang_call_terminate(i8* %44) #12
+  unreachable
+
+_ZN4cilk7reducerINS_6op_addIxLb1EEEED2Ev.exit7:   ; preds = %invoke.cont15
+  call void @llvm.lifetime.end.p0i8(i64 192, i8* nonnull %0) #10
+  ret i64 %37
+
+lpad14:                                           ; No predecessors!
+  %45 = landingpad { i8*, i32 }
+          cleanup
+  br label %ehcleanup18
+
+ehcleanup18:                                      ; preds = %lpad14, %lpad5.loopexit.split-lp, %lpad5.loopexit
+  %.sink40 = phi { i8*, i32 } [ %45, %lpad14 ], [ %lpad.loopexit, %lpad5.loopexit ], [ %lpad.loopexit.split-lp, %lpad5.loopexit.split-lp ]
+  %46 = bitcast %"class.cilk::reducer_opadd"* %accum to %"class.cilk::reducer"*
+  %47 = getelementptr inbounds %"class.cilk::reducer", %"class.cilk::reducer"* %46, i64 0, i32 0, i32 0
+  %48 = bitcast %"class.cilk::internal::reducer_base"* %47 to i8*
+  %__view_offset.i.i = getelementptr inbounds %"class.cilk::internal::reducer_base", %"class.cilk::internal::reducer_base"* %47, i64 0, i32 0, i32 2
+  %49 = load i64, i64* %__view_offset.i.i, align 8, !tbaa !22
+  %add.ptr.i.i = getelementptr inbounds i8, i8* %48, i64 %49
+  %50 = bitcast i8* %add.ptr.i.i to %"class.cilk::op_add_view"*
+  %m_monoid.i.i = getelementptr inbounds %"class.cilk::internal::reducer_base", %"class.cilk::internal::reducer_base"* %47, i64 0, i32 1
+  %51 = bitcast %"class.cilk::internal::storage_for_object"* %m_monoid.i.i to %"struct.cilk::op_add"*
+  %m_base.i.i = getelementptr inbounds %"class.cilk::internal::reducer_base", %"class.cilk::internal::reducer_base"* %47, i64 0, i32 0
+  invoke void @__cilkrts_hyper_destroy(%struct.__cilkrts_hyperobject_base* %m_base.i.i)
+          to label %_ZN4cilk7reducerINS_6op_addIxLb1EEEED2Ev.exit unwind label %terminate.lpad.i.i
+
+terminate.lpad.i.i:                               ; preds = %ehcleanup18
+  %52 = landingpad { i8*, i32 }
+          catch i8* null
+  %53 = extractvalue { i8*, i32 } %52, 0
+  call void @__clang_call_terminate(i8* %53) #12
+  unreachable
+
+_ZN4cilk7reducerINS_6op_addIxLb1EEEED2Ev.exit:    ; preds = %ehcleanup18
+  call void @llvm.lifetime.end.p0i8(i64 192, i8* nonnull %0) #10
+  resume { i8*, i32 } %.sink40
+
+unreachable:                                      ; preds = %lpad
+  unreachable
+}
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #1
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #1
+
+; Function Attrs: argmemonly nounwind
+declare token @llvm.syncregion.start() #1
+
+declare dso_local i32 @__gxx_personality_v0(...)
+
+; Function Attrs: argmemonly
+declare void @llvm.detached.rethrow.sl_p0i8i32s(token, { i8*, i32 }) #2
+
+; Function Attrs: argmemonly
+declare void @llvm.sync.unwind(token) #2
+
+; Function Attrs: nounwind uwtable
+define linkonce_odr dso_local void @_ZN4cilk8internal12reducer_baseINS_6op_addIxLb1EEEED2Ev(%"class.cilk::internal::reducer_base"* %this) unnamed_addr #3 comdat align 2 personality i8* bitcast (i32 (...)* @__gxx_personality_v0 to i8*) {
+entry:
+  %m_base = getelementptr inbounds %"class.cilk::internal::reducer_base", %"class.cilk::internal::reducer_base"* %this, i64 0, i32 0
+  invoke void @__cilkrts_hyper_destroy(%struct.__cilkrts_hyperobject_base* %m_base)
+          to label %invoke.cont unwind label %terminate.lpad
+
+invoke.cont:                                      ; preds = %entry
+  ret void
+
+terminate.lpad:                                   ; preds = %entry
+  %0 = landingpad { i8*, i32 }
+          catch i8* null
+  %1 = extractvalue { i8*, i32 } %0, 0
+  tail call void @__clang_call_terminate(i8* %1) #12
+  unreachable
+}
+
+; Function Attrs: noinline noreturn nounwind
+define linkonce_odr hidden void @__clang_call_terminate(i8*) local_unnamed_addr #4 comdat {
+  %2 = tail call i8* @__cxa_begin_catch(i8* %0) #10
+  tail call void @_ZSt9terminatev() #12
+  unreachable
+}
+
+declare dso_local i8* @__cxa_begin_catch(i8*) local_unnamed_addr
+
+declare dso_local void @_ZSt9terminatev() local_unnamed_addr
+
+declare dso_local void @__cilkrts_hyper_destroy(%struct.__cilkrts_hyperobject_base*) local_unnamed_addr #5
+
+; Function Attrs: noreturn nounwind
+declare dso_local void @__assert_fail(i8*, i8*, i32, i8*) local_unnamed_addr #6
+
+; Function Attrs: uwtable
+define linkonce_odr dso_local void @_ZN4cilk8internal12reducer_baseINS_6op_addIxLb1EEEE14reduce_wrapperEPvS5_S5_(i8* %r, i8* %lhs, i8* %rhs) #0 comdat align 2 {
+entry:
+  %0 = bitcast i8* %r to %"class.cilk::internal::reducer_base"*
+  %m_monoid.i = getelementptr inbounds %"class.cilk::internal::reducer_base", %"class.cilk::internal::reducer_base"* %0, i64 0, i32 1
+  %1 = bitcast %"class.cilk::internal::storage_for_object"* %m_monoid.i to %"struct.cilk::op_add"*
+  %2 = bitcast %"struct.cilk::op_add"* %1 to %"class.cilk::monoid_with_view"*
+  %3 = bitcast i8* %lhs to %"class.cilk::op_add_view"*
+  %4 = bitcast i8* %rhs to %"class.cilk::op_add_view"*
+  %m_value.i.i = getelementptr inbounds %"class.cilk::op_add_view", %"class.cilk::op_add_view"* %4, i64 0, i32 0, i32 0
+  %5 = load i64, i64* %m_value.i.i, align 8, !tbaa !25
+  %m_value2.i.i = getelementptr inbounds %"class.cilk::op_add_view", %"class.cilk::op_add_view"* %3, i64 0, i32 0, i32 0
+  %6 = load i64, i64* %m_value2.i.i, align 8, !tbaa !25
+  %add.i.i = add nsw i64 %6, %5
+  store i64 %add.i.i, i64* %m_value2.i.i, align 8, !tbaa !25
+  ret void
+}
+
+; Function Attrs: uwtable
+define linkonce_odr dso_local void @_ZN4cilk8internal12reducer_baseINS_6op_addIxLb1EEEE16identity_wrapperEPvS5_(i8* %r, i8* %view) #0 comdat align 2 {
+entry:
+  %0 = bitcast i8* %r to %"class.cilk::internal::reducer_base"*
+  %m_monoid.i = getelementptr inbounds %"class.cilk::internal::reducer_base", %"class.cilk::internal::reducer_base"* %0, i64 0, i32 1
+  %1 = bitcast %"class.cilk::internal::storage_for_object"* %m_monoid.i to %"struct.cilk::op_add"*
+  %2 = bitcast %"struct.cilk::op_add"* %1 to %"class.cilk::monoid_with_view"*
+  %3 = bitcast i8* %view to %"class.cilk::op_add_view"*
+  %4 = getelementptr inbounds %"class.cilk::op_add_view", %"class.cilk::op_add_view"* %3, i64 0, i32 0
+  %m_value.i.i.i = getelementptr inbounds %"class.cilk::scalar_view", %"class.cilk::scalar_view"* %4, i64 0, i32 0
+  store i64 0, i64* %m_value.i.i.i, align 8, !tbaa !25
+  ret void
+}
+
+; Function Attrs: uwtable
+define linkonce_odr dso_local void @_ZN4cilk8internal12reducer_baseINS_6op_addIxLb1EEEE15destroy_wrapperEPvS5_(i8* %r, i8* %view) #0 comdat align 2 {
+entry:
+  %0 = bitcast i8* %r to %"class.cilk::internal::reducer_base"*
+  %m_monoid.i = getelementptr inbounds %"class.cilk::internal::reducer_base", %"class.cilk::internal::reducer_base"* %0, i64 0, i32 1
+  %1 = bitcast %"class.cilk::internal::storage_for_object"* %m_monoid.i to %"struct.cilk::op_add"*
+  %2 = bitcast %"struct.cilk::op_add"* %1 to %"class.cilk::monoid_base"*
+  %3 = bitcast i8* %view to %"class.cilk::op_add_view"*
+  ret void
+}
+
+; Function Attrs: uwtable
+define linkonce_odr dso_local i8* @_ZN4cilk8internal12reducer_baseINS_6op_addIxLb1EEEE16allocate_wrapperEPvm(i8* %r, i64 %bytes) #0 comdat align 2 {
+entry:
+  %0 = bitcast i8* %r to %"class.cilk::internal::reducer_base"*
+  %m_monoid.i = getelementptr inbounds %"class.cilk::internal::reducer_base", %"class.cilk::internal::reducer_base"* %0, i64 0, i32 1
+  %1 = bitcast %"class.cilk::internal::storage_for_object"* %m_monoid.i to %"struct.cilk::op_add"*
+  %2 = bitcast %"struct.cilk::op_add"* %1 to %"class.cilk::monoid_base"*
+  %call.i = tail call i8* @_Znwm(i64 %bytes)
+  ret i8* %call.i
+}
+
+; Function Attrs: uwtable
+define linkonce_odr dso_local void @_ZN4cilk8internal12reducer_baseINS_6op_addIxLb1EEEE18deallocate_wrapperEPvS5_(i8* %r, i8* %view) #0 comdat align 2 {
+entry:
+  %0 = bitcast i8* %r to %"class.cilk::internal::reducer_base"*
+  %m_monoid.i = getelementptr inbounds %"class.cilk::internal::reducer_base", %"class.cilk::internal::reducer_base"* %0, i64 0, i32 1
+  %1 = bitcast %"class.cilk::internal::storage_for_object"* %m_monoid.i to %"struct.cilk::op_add"*
+  %2 = bitcast %"struct.cilk::op_add"* %1 to %"class.cilk::monoid_base"*
+  tail call void @_ZdlPv(i8* %view) #10
+  ret void
+}
+
+declare dso_local void @__cilkrts_hyper_create(%struct.__cilkrts_hyperobject_base*) local_unnamed_addr #5
+
+; Function Attrs: nobuiltin nofree
+declare dso_local noalias nonnull i8* @_Znwm(i64) local_unnamed_addr #7
+
+; Function Attrs: nobuiltin nounwind
+declare dso_local void @_ZdlPv(i8*) local_unnamed_addr #8
+
+; Function Attrs: nounwind readonly strand_pure
+declare dso_local noalias i8* @__cilkrts_hyper_lookup(%struct.__cilkrts_hyperobject_base*) local_unnamed_addr #9
+
+attributes #0 = { uwtable "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { argmemonly nounwind }
+attributes #2 = { argmemonly }
+attributes #3 = { nounwind uwtable "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #4 = { noinline noreturn nounwind }
+attributes #5 = { "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #6 = { noreturn nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #7 = { nobuiltin nofree "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #8 = { nobuiltin nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #9 = { nounwind readonly strand_pure "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #10 = { nounwind }
+attributes #11 = { nounwind readonly strand_pure }
+attributes #12 = { noreturn nounwind }
+
+!llvm.module.flags = !{!0}
+!llvm.ident = !{!1}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{!"clang version 9.0.1 (git@github.com:OpenCilk/opencilk-project.git c95bc4879b9edeebc2203b594f058b6617e529e0)"}
+!2 = !{!3, !3, i64 0}
+!3 = !{!"long long", !4, i64 0}
+!4 = !{!"omnipotent char", !5, i64 0}
+!5 = !{!"Simple C++ TBAA"}
+!6 = !{!7, !8, i64 0}
+!7 = !{!"_ZTS13cilk_c_monoid", !8, i64 0, !8, i64 8, !8, i64 16, !8, i64 24, !8, i64 32}
+!8 = !{!"any pointer", !4, i64 0}
+!9 = !{!7, !8, i64 8}
+!10 = !{!7, !8, i64 16}
+!11 = !{!7, !8, i64 24}
+!12 = !{!7, !8, i64 32}
+!13 = !{!14, !15, i64 40}
+!14 = !{!"_ZTS26__cilkrts_hyperobject_base", !7, i64 0, !15, i64 40, !16, i64 48, !16, i64 56}
+!15 = !{!"int", !4, i64 0}
+!16 = !{!"long", !4, i64 0}
+!17 = !{!14, !16, i64 48}
+!18 = !{!14, !16, i64 56}
+!19 = !{!20, !8, i64 72}
+!20 = !{!"_ZTSN4cilk8internal12reducer_baseINS_6op_addIxLb1EEEEE", !14, i64 0, !21, i64 64, !8, i64 72}
+!21 = !{!"_ZTSN4cilk8internal18storage_for_objectINS_6op_addIxLb1EEEEE"}
+!22 = !{!20, !16, i64 48}
+!23 = !{!24, !8, i64 0}
+!24 = !{!"_ZTSN4cilk17provisional_guardINS_6op_addIxLb1EEEEE", !8, i64 0}
+!25 = !{!26, !3, i64 0}
+!26 = !{!"_ZTSN4cilk11scalar_viewIxEE", !3, i64 0}
+!27 = distinct !{!27, !28}
+!28 = !{!"llvm.loop.from.tapir.loop"}
+!29 = distinct !{!29, !30, !31}
+!30 = !{!"tapir.loop.spawn.strategy", i32 1}
+!31 = !{!"tapir.loop.grainsize", i32 1}
+!32 = distinct !{!32, !28}


### PR DESCRIPTION
Updated modifications based on dev/10.x branch to add `strand_pure` and `strand_malloc` attributes for optimizing calls to `__cilkrts_hyper_lookup`.  These changes support common-subexpression elimination and loop-invariant-code motion of calls to `__cilkrts_hyper_lookup`, if the `__cilkrts_hyper_lookup` method is marked with the attributes `strand_pure` and `strand_malloc`.