### PR TITLE
[Tapir] Update OCaml bindings.

### DIFF
--- a/llvm/bindings/ocaml/transforms/tapir_opts/llvm_tapir_opts.ml
+++ b/llvm/bindings/ocaml/transforms/tapir_opts/llvm_tapir_opts.ml
@@ -7,10 +7,9 @@
  *
  *===----------------------------------------------------------------------===*)
 
-type tapir_target
-
-(** Tapir pass to install Cilky stuff in place of detach/sync instructions. *)
-external add_lower_tapir_to_cilk :
+(** Tapir pass to install Cilky (or other target-specific) stuff in place of
+    detach/sync instructions. *)
+external add_lower_tapir_to_target :
   [ `Module ] Llvm.PassManager.t -> unit
   = "llvm_add_lower_tapir_to_target"
 

--- a/llvm/bindings/ocaml/transforms/tapir_opts/llvm_tapir_opts.ml
+++ b/llvm/bindings/ocaml/transforms/tapir_opts/llvm_tapir_opts.ml
@@ -11,10 +11,10 @@ type tapir_target
 
 (** Tapir pass to install Cilky stuff in place of detach/sync instructions. *)
 external add_lower_tapir_to_cilk :
-  [ `Module ] Llvm.PassManager.t -> tapir_target -> unit
-  = "llvm_add_lower_tapir_to_cilk"
+  [ `Module ] Llvm.PassManager.t -> unit
+  = "llvm_add_lower_tapir_to_target"
 
 (** Tapir pass to spawn loops with recursive divide-and-conquer. *)
 external add_loop_spawning :
-  [ `Module ] Llvm.PassManager.t -> tapir_target -> unit
+  [ `Module ] Llvm.PassManager.t -> unit
   = "llvm_add_loop_spawning"

--- a/llvm/bindings/ocaml/transforms/tapir_opts/llvm_tapir_opts.mli
+++ b/llvm/bindings/ocaml/transforms/tapir_opts/llvm_tapir_opts.mli
@@ -7,10 +7,9 @@
  *
  *===----------------------------------------------------------------------===*)
 
-type tapir_target
-
-(** Tapir pass to install Cilky stuff in place of detach/sync instructions. *)
-external add_lower_tapir_to_cilk :
+(** Tapir pass to install Cilky (or other target-specific) stuff in place of
+    detach/sync instructions. *)
+external add_lower_tapir_to_target :
   [ `Module ] Llvm.PassManager.t -> unit
   = "llvm_add_lower_tapir_to_target"
 

--- a/llvm/bindings/ocaml/transforms/tapir_opts/llvm_tapir_opts.mli
+++ b/llvm/bindings/ocaml/transforms/tapir_opts/llvm_tapir_opts.mli
@@ -11,10 +11,10 @@ type tapir_target
 
 (** Tapir pass to install Cilky stuff in place of detach/sync instructions. *)
 external add_lower_tapir_to_cilk :
-  [ `Module ] Llvm.PassManager.t -> tapir_target -> unit
-  = "llvm_add_lower_tapir_to_cilk"
+  [ `Module ] Llvm.PassManager.t -> unit
+  = "llvm_add_lower_tapir_to_target"
 
 (** Tapir pass to spawn loops with recursive divide-and-conquer. *)
 external add_loop_spawning :
-  [ `Module ] Llvm.PassManager.t -> tapir_target -> unit
+  [ `Module ] Llvm.PassManager.t -> unit
   = "llvm_add_loop_spawning"

--- a/llvm/bindings/ocaml/transforms/tapir_opts/tapir_opts_ocaml.c
+++ b/llvm/bindings/ocaml/transforms/tapir_opts/tapir_opts_ocaml.c
@@ -16,22 +16,18 @@
 #include "llvm-c/Transforms/PassManagerBuilder.h"
 #include "llvm-c/Transforms/Tapir.h"
 
-#define TapirTarget_val(v) (*(TapirTargetRef *)(Data_custom_val(v)))
-
 /* [`Module] Llvm.PassManager.t -> unit
  */
-CAMLprim value llvm_add_lower_tapir_to_cilk(LLVMPassManagerRef PM,
-                                            TapirTargetRef tt)
+CAMLprim value llvm_add_lower_tapir_to_target(LLVMPassManagerRef PM)
 {
-    LLVMAddLowerTapirToCilk(PM, TapirTarget_val(tt));
+    LLVMAddLowerTapirToTargetPass(PM);
     return Val_unit;
 }
 
 /* [`Module] Llvm.PassManager.t -> unit
  */
-CAMLprim value llvm_add_loop_spawning(LLVMPassManagerRef PM,
-                                      TapirTargetRef tt)
+CAMLprim value llvm_add_loop_spawning(LLVMPassManagerRef PM)
 {
-    LLVMAddLoopSpawning(PM, TapirTarget_val(tt));
+    LLVMAddLoopSpawningPass(PM);
     return Val_unit;
 }

--- a/llvm/test/Bindings/OCaml/scalar_opts.ml
+++ b/llvm/test/Bindings/OCaml/scalar_opts.ml
@@ -8,10 +8,12 @@
 
 (* Note: It takes several seconds for ocamlopt to link an executable with
          libLLVMCore.a, so it's better to write a big test than a bunch of
-         little ones. *)
+         little ones. For the same reason, the Tapir tests are added here
+         instead of in their own test suite. *)
 
 open Llvm
 open Llvm_scalar_opts
+open Llvm_tapir_opts
 open Llvm_target
 
 let context = global_context ()
@@ -79,6 +81,8 @@ let test_transforms () =
            ++ add_type_based_alias_analysis
            ++ add_scoped_no_alias_alias_analysis
            ++ add_basic_alias_analysis
+           ++ add_loop_spawning
+           ++ add_lower_tapir_to_target
            ++ PassManager.initialize
            ++ PassManager.run_function fn
            ++ PassManager.finalize


### PR DESCRIPTION
The OCaml bindings library build was out of date w.r.t. Tapir -- function names and parameters had changed. The fix is pretty trivial.