### PR TITLE
[cmake] Added IRReader dependency to instrumentation component

### DIFF
--- a/llvm/lib/Transforms/Instrumentation/CMakeLists.txt
+++ b/llvm/lib/Transforms/Instrumentation/CMakeLists.txt
@@ -35,4 +35,5 @@ add_llvm_component_library(LLVMInstrumentation
   Support
   TransformUtils
   ProfileData
+  IRReader
   )


### PR DESCRIPTION
This fixes a linking error due to a call to `parseIRFile` in `ComprehensiveStaticInstrumentation.cpp`.