### PR TITLE
CMake fixes and updates

### DIFF
--- a/clang/tools/driver/CMakeLists.txt
+++ b/clang/tools/driver/CMakeLists.txt
@@ -13,6 +13,7 @@ set( LLVM_LINK_COMPONENTS
   Option
   ScalarOpts
   Support
+  TapirOpts
   TransformUtils
   Vectorize
   )

--- a/llvm/cmake/modules/LLVMExternalProjectUtils.cmake
+++ b/llvm/cmake/modules/LLVMExternalProjectUtils.cmake
@@ -221,6 +221,7 @@ function(llvm_ExternalProject_Add name source_dir)
                       -DCMAKE_OBJDUMP=${CMAKE_OBJDUMP}
                       -DCMAKE_STRIP=${CMAKE_STRIP})
     set(llvm_config_path ${LLVM_CONFIG_PATH})
+    set(llvm_link_path ${LLVM_LINK_PATH})
 
     if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
       string(REGEX MATCH "[0-9]+\\.[0-9]+(\\.[0-9]+)?" CLANG_VERSION
@@ -249,6 +250,7 @@ function(llvm_ExternalProject_Add name source_dir)
     endif()
   else()
     set(llvm_config_path "$<TARGET_FILE:llvm-config>")
+    set(llvm_link_path "$<TARGET_FILE:llvm-link>")
     set(cmake_args ${ARG_CMAKE_ARGS})
   endif()
 
@@ -266,6 +268,7 @@ function(llvm_ExternalProject_Add name source_dir)
                ${sysroot_arg}
                -DLLVM_BINARY_DIR=${PROJECT_BINARY_DIR}
                -DLLVM_CONFIG_PATH=${llvm_config_path}
+               -DLLVM_LINK_PATH=${llvm_link_path}
                -DLLVM_ENABLE_WERROR=${LLVM_ENABLE_WERROR}
                -DLLVM_HOST_TRIPLE=${LLVM_HOST_TRIPLE}
                -DLLVM_HAVE_LINK_VERSION_SCRIPT=${LLVM_HAVE_LINK_VERSION_SCRIPT}

--- a/llvm/lib/Passes/CMakeLists.txt
+++ b/llvm/lib/Passes/CMakeLists.txt
@@ -21,6 +21,7 @@ add_llvm_component_library(LLVMPasses
   ObjCARC
   Scalar
   Support
+  TapirOpts
   Target
   TransformUtils
   Vectorize

--- a/llvm/lib/Transforms/Instrumentation/CMakeLists.txt
+++ b/llvm/lib/Transforms/Instrumentation/CMakeLists.txt
@@ -31,9 +31,10 @@ add_llvm_component_library(LLVMInstrumentation
   LINK_COMPONENTS
   Analysis
   Core
+  IRReader
+  Linker
   MC
   Support
   TransformUtils
   ProfileData
-  IRReader
   )

--- a/llvm/lib/Transforms/Tapir/CMakeLists.txt
+++ b/llvm/lib/Transforms/Tapir/CMakeLists.txt
@@ -33,6 +33,7 @@ add_llvm_component_library(LLVMTapirOpts
   Core
   IRReader
   Linker
+  MC
   Scalar
   Support
   TransformUtils


### PR DESCRIPTION
- Fix some additional missing CMake dependencies.
- Propagate the path to the `llvm-link` tool when building external projects, to help those projects generate bitcode file outputs from multiple sources.