### PR TITLE
Bugfixes 20220625

### DIFF
--- a/clang/include/clang/Driver/ToolChain.h
+++ b/clang/include/clang/Driver/ToolChain.h
@@ -755,7 +755,8 @@ public:
   /// AddOpenCilkBitcodeABI - Add compiler arguments for linking against the
   /// OpenCilk runtime ABI bitcode file.
   virtual void AddOpenCilkABIBitcode(const llvm::opt::ArgList &Args,
-                                     llvm::opt::ArgStringList &CmdArgs) const;
+                                     llvm::opt::ArgStringList &CmdArgs,
+                                     bool IsLTO = false) const;
 
   /// AddTapirRuntimeLibArgs - Add the specific linker arguments to use for the
   /// given Tapir runtime library type.

--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -1958,6 +1958,7 @@ static void runThinLTOBackend(
   Conf.SplitDwarfFile = CGOpts.SplitDwarfFile;
   Conf.SplitDwarfOutput = CGOpts.SplitDwarfOutput;
   Conf.TapirTarget = CGOpts.getTapirTarget();
+  Conf.OpenCilkABIBitcodeFile = CGOpts.OpenCilkABIBitcodeFile;
   switch (Action) {
   case Backend_EmitNothing:
     Conf.PreCodeGenModuleHook = [](size_t Task, const Module &Mod) {

--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -1386,7 +1386,8 @@ Optional<std::string> ToolChain::getOpenCilkBC(const ArgList &Args,
 }
 
 void ToolChain::AddOpenCilkABIBitcode(const ArgList &Args,
-                                      ArgStringList &CmdArgs) const {
+                                      ArgStringList &CmdArgs,
+                                      bool IsLTO) const {
   // If --opencilk-abi-bitcode= is specified, use that specified path.
   if (Args.hasArg(options::OPT_opencilk_abi_bitcode_EQ)) {
     const Arg *A = Args.getLastArg(options::OPT_opencilk_abi_bitcode_EQ);
@@ -1395,6 +1396,9 @@ void ToolChain::AddOpenCilkABIBitcode(const ArgList &Args,
       getDriver().Diag(diag::err_drv_opencilk_missing_abi_bitcode)
           << A->getAsString(Args);
     }
+    if (IsLTO)
+      CmdArgs.push_back(
+          Args.MakeArgString("--plugin-opt=opencilk-abi-bitcode=" + P));
   }
 
   bool UseAsan = getSanitizerArgs(Args).needsAsanRt();
@@ -1403,8 +1407,12 @@ void ToolChain::AddOpenCilkABIBitcode(const ArgList &Args,
           ? (UseAsan ? "opencilk-pedigrees-asan-abi" : "opencilk-pedigrees-abi")
           : (UseAsan ? "opencilk-asan-abi" : "opencilk-abi");
   if (auto OpenCilkABIBCFilename = getOpenCilkBC(Args, OpenCilkBCName)) {
-    CmdArgs.push_back(
-        Args.MakeArgString("--opencilk-abi-bitcode=" + *OpenCilkABIBCFilename));
+    if (IsLTO)
+      CmdArgs.push_back(Args.MakeArgString("--plugin-opt=opencilk-abi-bitcode=" +
+                                           *OpenCilkABIBCFilename));
+    else
+      CmdArgs.push_back(Args.MakeArgString("--opencilk-abi-bitcode=" +
+                                           *OpenCilkABIBCFilename));
     return;
   }
 

--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
@@ -119,6 +119,23 @@ static void renderRemarksHotnessOptions(const ArgList &Args,
         Twine("--plugin-opt=opt-remarks-hotness-threshold=") + A->getValue()));
 }
 
+static void renderTapirLoweringOptions(const ArgList &Args,
+                                       ArgStringList &CmdArgs,
+                                       const ToolChain &TC) {
+  if (Args.hasArg(options::OPT_fcilkplus) ||
+      Args.hasArg(options::OPT_fopencilk) ||
+      Args.hasArg(options::OPT_ftapir_EQ)) {
+    if (const Arg *A = Args.getLastArg(options::OPT_ftapir_EQ))
+      CmdArgs.push_back(Args.MakeArgString(
+          Twine("--plugin-opt=tapir-target=") + A->getValue()));
+    else if (Args.hasArg(options::OPT_fopencilk)) {
+      CmdArgs.push_back("--plugin-opt=tapir-target=opencilk");
+      TC.AddOpenCilkABIBitcode(Args, CmdArgs, /*IsLTO=*/true);
+    } else if (Args.hasArg(options::OPT_fcilkplus))
+      CmdArgs.push_back("--plugin-opt=tapir-target=cilkplus");
+  }
+}
+
 void tools::addPathIfExists(const Driver &D, const Twine &Path,
                             ToolChain::path_list &Paths) {
   if (D.getVFS().exists(Path))
@@ -640,6 +657,8 @@ void tools::addLTOOptions(const ToolChain &ToolChain, const ArgList &Args,
 
   // Handle remarks hotness/threshold related options.
   renderRemarksHotnessOptions(Args, CmdArgs);
+
+  renderTapirLoweringOptions(Args, CmdArgs, ToolChain);
 
   addMachineOutlinerArgs(D, Args, CmdArgs, ToolChain.getEffectiveTriple(),
                          /*IsLTO=*/true);

--- a/clang/lib/Driver/ToolChains/Darwin.cpp
+++ b/clang/lib/Driver/ToolChains/Darwin.cpp
@@ -3088,7 +3088,8 @@ DarwinClang::getOpenCilkRuntimePaths(const ArgList &Args) const {
 }
 
 void DarwinClang::AddOpenCilkABIBitcode(const ArgList &Args,
-                                        ArgStringList &CmdArgs) const {
+                                        ArgStringList &CmdArgs,
+                                        bool IsLTO) const {
   // If --opencilk-abi-bitcode= is specified, use that specified path.
   if (Args.hasArg(options::OPT_opencilk_abi_bitcode_EQ)) {
     const Arg *A = Args.getLastArg(options::OPT_opencilk_abi_bitcode_EQ);
@@ -3096,6 +3097,9 @@ void DarwinClang::AddOpenCilkABIBitcode(const ArgList &Args,
     if (!getVFS().exists(P))
       getDriver().Diag(diag::err_drv_opencilk_missing_abi_bitcode)
           << A->getAsString(Args);
+    if (IsLTO)
+      CmdArgs.push_back(
+          Args.MakeArgString("--plugin-opt=opencilk-abi-bitcode=" + P));
   }
 
   bool UseAsan = getSanitizerArgs(Args).needsAsanRt();
@@ -3113,7 +3117,11 @@ void DarwinClang::AddOpenCilkABIBitcode(const ArgList &Args,
     SmallString<128> P(RuntimePath);
     llvm::sys::path::append(P, BitcodeFilename);
     if (getVFS().exists(P)) {
-      CmdArgs.push_back(Args.MakeArgString("--opencilk-abi-bitcode=" + P));
+      if (IsLTO)
+        CmdArgs.push_back(
+            Args.MakeArgString("--plugin-opt=opencilk-abi-bitcode=" + P));
+      else
+        CmdArgs.push_back(Args.MakeArgString("--opencilk-abi-bitcode=" + P));
       return;
     }
   }

--- a/clang/lib/Driver/ToolChains/Darwin.cpp
+++ b/clang/lib/Driver/ToolChains/Darwin.cpp
@@ -518,6 +518,27 @@ static void renderRemarksOptions(const ArgList &Args, ArgStringList &CmdArgs,
   }
 }
 
+static void renderTapirLoweringOptions(const ArgList &Args,
+                                       ArgStringList &CmdArgs,
+                                       const ToolChain &TC,
+				       bool LinkerIsLLD) {
+  if (!(TC.getDriver().isUsingLTO() && LinkerIsLLD))
+    return;
+
+  if (Args.hasArg(options::OPT_fcilkplus) ||
+      Args.hasArg(options::OPT_fopencilk) ||
+      Args.hasArg(options::OPT_ftapir_EQ)) {
+    if (const Arg *A = Args.getLastArg(options::OPT_ftapir_EQ))
+      CmdArgs.push_back(Args.MakeArgString(
+          Twine("--tapir-target=") + A->getValue()));
+    else if (Args.hasArg(options::OPT_fopencilk)) {
+      CmdArgs.push_back("--tapir-target=opencilk");
+      TC.AddOpenCilkABIBitcode(Args, CmdArgs, /*IsLTO=*/true);
+    } else if (Args.hasArg(options::OPT_fcilkplus))
+      CmdArgs.push_back("--tapir-target=cilkplus");
+  }
+}
+
 void darwin::Linker::ConstructJob(Compilation &C, const JobAction &JA,
                                   const InputInfo &Output,
                                   const InputInfoList &Inputs,
@@ -568,6 +589,8 @@ void darwin::Linker::ConstructJob(Compilation &C, const JobAction &JA,
       checkRemarksOptions(getToolChain().getDriver(), Args,
                           getToolChain().getTriple()))
     renderRemarksOptions(Args, CmdArgs, getToolChain().getTriple(), Output, JA);
+
+  renderTapirLoweringOptions(Args, CmdArgs, getToolChain(), LinkerIsLLD);
 
   // Propagate the -moutline flag to the linker in LTO.
   if (Arg *A =
@@ -3099,7 +3122,7 @@ void DarwinClang::AddOpenCilkABIBitcode(const ArgList &Args,
           << A->getAsString(Args);
     if (IsLTO)
       CmdArgs.push_back(
-          Args.MakeArgString("--plugin-opt=opencilk-abi-bitcode=" + P));
+          Args.MakeArgString("--opencilk-abi-bitcode=" + P));
   }
 
   bool UseAsan = getSanitizerArgs(Args).needsAsanRt();
@@ -3117,11 +3140,8 @@ void DarwinClang::AddOpenCilkABIBitcode(const ArgList &Args,
     SmallString<128> P(RuntimePath);
     llvm::sys::path::append(P, BitcodeFilename);
     if (getVFS().exists(P)) {
-      if (IsLTO)
-        CmdArgs.push_back(
-            Args.MakeArgString("--plugin-opt=opencilk-abi-bitcode=" + P));
-      else
-        CmdArgs.push_back(Args.MakeArgString("--opencilk-abi-bitcode=" + P));
+      // The same argument works regardless of IsLTO.
+      CmdArgs.push_back(Args.MakeArgString("--opencilk-abi-bitcode=" + P));
       return;
     }
   }

--- a/clang/lib/Driver/ToolChains/Darwin.h
+++ b/clang/lib/Driver/ToolChains/Darwin.h
@@ -590,7 +590,8 @@ public:
   getOpenCilkRuntimePaths(const llvm::opt::ArgList &Args) const override;
 
   void AddOpenCilkABIBitcode(const llvm::opt::ArgList &Args,
-                             llvm::opt::ArgStringList &CmdArgs) const override;
+                             llvm::opt::ArgStringList &CmdArgs,
+                             bool IsLTO = false) const override;
 
   void AddLinkTapirRuntime(const llvm::opt::ArgList &Args,
                            llvm::opt::ArgStringList &CmdArgs) const override;

--- a/lld/COFF/Config.h
+++ b/lld/COFF/Config.h
@@ -212,7 +212,7 @@ struct Configuration {
 
   // Used for Tapir target.
   llvm::StringRef opencilkABIBitcodeFile;
-  llvm::TapirTargetID tapirTarget;
+  llvm::TapirTargetID tapirTarget = llvm::TapirTargetID::None;
 
   // Used for /thinlto-index-only:
   llvm::StringRef thinLTOIndexOnlyArg;

--- a/lld/COFF/Config.h
+++ b/lld/COFF/Config.h
@@ -15,6 +15,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Object/COFF.h"
 #include "llvm/Support/CachePruning.h"
+#include "llvm/Transforms/Tapir/TapirTargetIDs.h"
 #include <cstdint>
 #include <map>
 #include <set>
@@ -208,6 +209,10 @@ struct Configuration {
 
   // Used for /map.
   std::string mapFile;
+
+  // Used for Tapir target.
+  llvm::StringRef opencilkABIBitcodeFile;
+  llvm::TapirTargetID tapirTarget;
 
   // Used for /thinlto-index-only:
   llvm::StringRef thinLTOIndexOnlyArg;

--- a/lld/COFF/Driver.cpp
+++ b/lld/COFF/Driver.cpp
@@ -1758,7 +1758,8 @@ void LinkerDriver::linkerMain(ArrayRef<const char *> argsArr) {
   config->lldmapFile = getMapFile(args, OPT_lldmap, OPT_lldmap_file);
   config->mapFile = getMapFile(args, OPT_map, OPT_map_file);
 
-  config->opencilkABIBitcodeFile = args.getLastArgValue(OPT_opencilk_abi_bitcode);
+  config->opencilkABIBitcodeFile =
+      args.getLastArgValue(OPT_opencilk_abi_bitcode);
   config->tapirTarget =
       args::parseTapirTarget(args.getLastArgValue(OPT_tapir_target));
 

--- a/lld/COFF/Driver.cpp
+++ b/lld/COFF/Driver.cpp
@@ -631,6 +631,7 @@ static std::string createResponseFile(const opt::InputArgList &args,
     case OPT_deffile:
     case OPT_manifestinput:
     case OPT_natvis:
+    case OPT_opencilk_abi_bitcode:
       os << arg->getSpelling() << quote(rewritePath(arg->getValue())) << '\n';
       break;
     case OPT_order: {
@@ -1756,6 +1757,10 @@ void LinkerDriver::linkerMain(ArrayRef<const char *> argsArr) {
 
   config->lldmapFile = getMapFile(args, OPT_lldmap, OPT_lldmap_file);
   config->mapFile = getMapFile(args, OPT_map, OPT_map_file);
+
+  config->opencilkABIBitcodeFile = args.getLastArgValue(OPT_opencilk_abi_bitcode);
+  config->tapirTarget =
+      args::parseTapirTarget(args.getLastArgValue(OPT_tapir_target));
 
   if (config->lldmapFile != "" && config->lldmapFile == config->mapFile) {
     warn("/lldmap and /map have the same output file '" + config->mapFile +

--- a/lld/COFF/LTO.cpp
+++ b/lld/COFF/LTO.cpp
@@ -85,6 +85,8 @@ static lto::Config createConfig() {
   c.AlwaysEmitRegularLTOObj = !config->ltoObjPath.empty();
   c.UseNewPM = config->ltoNewPassManager;
   c.DebugPassManager = config->ltoDebugPassManager;
+  c.TapirTarget = config->tapirTarget;
+  c.OpenCilkABIBitcodeFile = std::string(config->opencilkABIBitcodeFile);
   c.CSIRProfile = std::string(config->ltoCSProfileFile);
   c.RunCSIRInstr = config->ltoCSProfileGenerate;
   c.PGOWarnMismatch = config->ltoPGOWarnMismatch;

--- a/lld/COFF/LTO.cpp
+++ b/lld/COFF/LTO.cpp
@@ -85,7 +85,8 @@ static lto::Config createConfig() {
   c.AlwaysEmitRegularLTOObj = !config->ltoObjPath.empty();
   c.UseNewPM = config->ltoNewPassManager;
   c.DebugPassManager = config->ltoDebugPassManager;
-  c.TapirTarget = config->tapirTarget;
+  if (args::validTapirTarget(config->tapirTarget))
+    c.TapirTarget = config->tapirTarget;
   c.OpenCilkABIBitcodeFile = std::string(config->opencilkABIBitcodeFile);
   c.CSIRProfile = std::string(config->ltoCSProfileFile);
   c.RunCSIRInstr = config->ltoCSProfileGenerate;

--- a/lld/COFF/Options.td
+++ b/lld/COFF/Options.td
@@ -214,6 +214,9 @@ def include_optional : Joined<["/", "-", "/?", "-?"], "includeoptional:">,
 def kill_at : F<"kill-at">;
 def lldmingw : F<"lldmingw">;
 def noseh : F<"noseh">;
+def opencilk_abi_bitcode : P<
+    "opencilk-abi-bitcode",
+    "Path to OpenCilk ABI bitcode file">;
 def osversion : P_priv<"osversion">;
 def output_def : Joined<["/", "-", "/?", "-?"], "output-def:">;
 def pdb_source_path : P<"pdbsourcepath",
@@ -223,6 +226,7 @@ def rsp_quoting : Joined<["--"], "rsp-quoting=">,
 def start_lib : F<"start-lib">,
   HelpText<"Start group of objects treated as if they were in a library">;
 defm stdcall_fixup : B_priv<"stdcall-fixup">;
+def tapir_target : P<"tapir-target", "Specify the target for Tapir lowering">;
 def thinlto_emit_imports_files :
     F<"thinlto-emit-imports-files">,
     HelpText<"Emit .imports files with -thinlto-index-only">;

--- a/lld/Common/Args.cpp
+++ b/lld/Common/Args.cpp
@@ -107,3 +107,7 @@ TapirTargetID lld::args::parseTapirTarget(StringRef tapirTarget) {
       .Case("qthreads", TapirTargetID::Qthreads)
       .Default(TapirTargetID::Last_TapirTargetID);
 }
+
+bool lld::args::validTapirTarget(TapirTargetID TargetID) {
+  return TargetID < TapirTargetID::Last_TapirTargetID;
+}

--- a/lld/Common/Args.cpp
+++ b/lld/Common/Args.cpp
@@ -11,6 +11,7 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/StringSwitch.h"
 #include "llvm/Option/ArgList.h"
 #include "llvm/Support/Path.h"
 
@@ -92,4 +93,17 @@ StringRef lld::args::getFilenameWithoutExe(StringRef path) {
   if (path.endswith_insensitive(".exe"))
     return sys::path::stem(path);
   return sys::path::filename(path);
+}
+
+TapirTargetID lld::args::parseTapirTarget(StringRef tapirTarget) {
+  return llvm::StringSwitch<TapirTargetID>(tapirTarget)
+      .Case("none", TapirTargetID::None)
+      .Case("serial", TapirTargetID::Serial)
+      .Case("cheetah", TapirTargetID::Cheetah)
+      .Case("cilkplus", TapirTargetID::Cilk)
+      .Case("cuda", TapirTargetID::Cuda)
+      .Case("opencilk", TapirTargetID::OpenCilk)
+      .Case("openmp", TapirTargetID::OpenMP)
+      .Case("qthreads", TapirTargetID::Qthreads)
+      .Default(TapirTargetID::Last_TapirTargetID);
 }

--- a/lld/ELF/Config.h
+++ b/lld/ELF/Config.h
@@ -21,6 +21,7 @@
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/GlobPattern.h"
 #include "llvm/Support/PrettyStackTrace.h"
+#include "llvm/Transforms/Tapir/TapirTargetIDs.h"
 #include <atomic>
 #include <memory>
 #include <vector>
@@ -117,6 +118,7 @@ struct Configuration {
   llvm::StringRef ltoSampleProfile;
   llvm::StringRef mapFile;
   llvm::StringRef outputFile;
+  llvm::StringRef opencilkABIBitcodeFile;
   llvm::StringRef optRemarksFilename;
   llvm::Optional<uint64_t> optRemarksHotnessThreshold = 0;
   llvm::StringRef optRemarksPasses;
@@ -126,6 +128,7 @@ struct Configuration {
   llvm::StringRef printSymbolOrder;
   llvm::StringRef soName;
   llvm::StringRef sysroot;
+  llvm::TapirTargetID tapirTarget;
   llvm::StringRef thinLTOCacheDir;
   llvm::StringRef thinLTOIndexOnlyArg;
   llvm::StringRef whyExtract;

--- a/lld/ELF/Config.h
+++ b/lld/ELF/Config.h
@@ -128,7 +128,7 @@ struct Configuration {
   llvm::StringRef printSymbolOrder;
   llvm::StringRef soName;
   llvm::StringRef sysroot;
-  llvm::TapirTargetID tapirTarget;
+  llvm::TapirTargetID tapirTarget = llvm::TapirTargetID::None;
   llvm::StringRef thinLTOCacheDir;
   llvm::StringRef thinLTOIndexOnlyArg;
   llvm::StringRef whyExtract;

--- a/lld/ELF/Driver.cpp
+++ b/lld/ELF/Driver.cpp
@@ -1074,6 +1074,7 @@ static void readConfigs(opt::InputArgList &args) {
   config->nostdlib = args.hasArg(OPT_nostdlib);
   config->oFormatBinary = isOutputFormatBinary(args);
   config->omagic = args.hasFlag(OPT_omagic, OPT_no_omagic, false);
+  config->opencilkABIBitcodeFile = args.getLastArgValue(OPT_opencilk_abi_bitcode);
   config->optRemarksFilename = args.getLastArgValue(OPT_opt_remarks_filename);
 
   // Parse remarks hotness threshold. Valid value is either integer or 'auto'.
@@ -1113,6 +1114,7 @@ static void readConfigs(opt::InputArgList &args) {
   config->splitStackAdjustSize = args::getInteger(args, OPT_split_stack_adjust_size, 16384);
   config->strip = getStrip(args);
   config->sysroot = args.getLastArgValue(OPT_sysroot);
+  config->tapirTarget = args::parseTapirTarget(args.getLastArgValue(OPT_tapir_target));
   config->target1Rel = args.hasFlag(OPT_target1_rel, OPT_target1_abs, false);
   config->target2 = getTarget2(args);
   config->thinLTOCacheDir = args.getLastArgValue(OPT_thinlto_cache_dir);

--- a/lld/ELF/Driver.cpp
+++ b/lld/ELF/Driver.cpp
@@ -1074,7 +1074,8 @@ static void readConfigs(opt::InputArgList &args) {
   config->nostdlib = args.hasArg(OPT_nostdlib);
   config->oFormatBinary = isOutputFormatBinary(args);
   config->omagic = args.hasFlag(OPT_omagic, OPT_no_omagic, false);
-  config->opencilkABIBitcodeFile = args.getLastArgValue(OPT_opencilk_abi_bitcode);
+  config->opencilkABIBitcodeFile =
+      args.getLastArgValue(OPT_opencilk_abi_bitcode);
   config->optRemarksFilename = args.getLastArgValue(OPT_opt_remarks_filename);
 
   // Parse remarks hotness threshold. Valid value is either integer or 'auto'.
@@ -1114,7 +1115,8 @@ static void readConfigs(opt::InputArgList &args) {
   config->splitStackAdjustSize = args::getInteger(args, OPT_split_stack_adjust_size, 16384);
   config->strip = getStrip(args);
   config->sysroot = args.getLastArgValue(OPT_sysroot);
-  config->tapirTarget = args::parseTapirTarget(args.getLastArgValue(OPT_tapir_target));
+  config->tapirTarget =
+      args::parseTapirTarget(args.getLastArgValue(OPT_tapir_target));
   config->target1Rel = args.hasFlag(OPT_target1_rel, OPT_target1_abs, false);
   config->target2 = getTarget2(args);
   config->thinLTOCacheDir = args.getLastArgValue(OPT_thinlto_cache_dir);

--- a/lld/ELF/DriverUtils.cpp
+++ b/lld/ELF/DriverUtils.cpp
@@ -191,6 +191,7 @@ std::string elf::createResponseFile(const opt::InputArgList &args) {
     case OPT_dynamic_list:
     case OPT_just_symbols:
     case OPT_library_path:
+    case OPT_opencilk_abi_bitcode:
     case OPT_retain_symbols_file:
     case OPT_rpath:
     case OPT_script:

--- a/lld/ELF/LTO.cpp
+++ b/lld/ELF/LTO.cpp
@@ -151,7 +151,8 @@ static lto::Config createConfig() {
   c.DebugPassManager = config->ltoDebugPassManager;
   c.DwoDir = std::string(config->dwoDir);
 
-  c.TapirTarget = config->tapirTarget;
+  if (args::validTapirTarget(config->tapirTarget))
+    c.TapirTarget = config->tapirTarget;
   c.OpenCilkABIBitcodeFile = std::string(config->opencilkABIBitcodeFile);
 
   c.HasWholeProgramVisibility = config->ltoWholeProgramVisibility;

--- a/lld/ELF/LTO.cpp
+++ b/lld/ELF/LTO.cpp
@@ -151,6 +151,9 @@ static lto::Config createConfig() {
   c.DebugPassManager = config->ltoDebugPassManager;
   c.DwoDir = std::string(config->dwoDir);
 
+  c.TapirTarget = config->tapirTarget;
+  c.OpenCilkABIBitcodeFile = std::string(config->opencilkABIBitcodeFile);
+
   c.HasWholeProgramVisibility = config->ltoWholeProgramVisibility;
   c.AlwaysEmitRegularLTOObj = !config->ltoObjPath.empty();
 

--- a/lld/ELF/Options.td
+++ b/lld/ELF/Options.td
@@ -578,6 +578,7 @@ defm lto_whole_program_visibility: BB<"lto-whole-program-visibility",
   "Asserts that the LTO link does not have whole program visibility">;
 def disable_verify: F<"disable-verify">;
 defm mllvm: Eq<"mllvm", "Additional arguments to forward to LLVM's option processing">;
+defm opencilk_abi_bitcode: EEq<"opencilk-abi-bitcode", "Path to OpenCilk ABI bitcode file">;
 def opt_remarks_filename: Separate<["--"], "opt-remarks-filename">,
   HelpText<"YAML output file for optimization remarks">;
 defm opt_remarks_hotness_threshold: EEq<"opt-remarks-hotness-threshold",
@@ -600,6 +601,7 @@ defm shuffle_sections: EEq<"shuffle-sections",
   "Shuffle matched sections using the given seed before mapping them to the output sections. "
   "If -1, reverse the section order. If 0, use a random seed">,
   MetaVarName<"<section-glob>=<seed>">;
+defm tapir_target: Eq<"tapir-target", "Specify the target for Tapir lowering">;
 def thinlto_cache_dir: JJ<"thinlto-cache-dir=">,
   HelpText<"Path to ThinLTO cached object file directory">;
 defm thinlto_cache_policy: EEq<"thinlto-cache-policy", "Pruning policy for the ThinLTO cache">;
@@ -636,6 +638,9 @@ def: J<"plugin-opt=cs-profile-path=">,
 def: J<"plugin-opt=obj-path=">,
   Alias<lto_obj_path_eq>,
   HelpText<"Alias for --lto-obj-path=">;
+def: J<"plugin-opt=opencilk-abi-bitcode=">,
+  Alias<opencilk_abi_bitcode>,
+  HelpText<"Alias for --opencilk-abi-bitcode">;
 def: J<"plugin-opt=opt-remarks-filename=">,
   Alias<opt_remarks_filename>,
   HelpText<"Alias for --opt-remarks-filename">;
@@ -654,6 +659,9 @@ def: J<"plugin-opt=opt-remarks-hotness-threshold=">,
 def: J<"plugin-opt=sample-profile=">,
   Alias<lto_sample_profile>, HelpText<"Alias for --lto-sample-profile">;
 def: F<"plugin-opt=save-temps">, Alias<save_temps>, HelpText<"Alias for --save-temps">;
+def: J<"plugin-opt=tapir-target=">,
+  Alias<tapir_target>,
+  HelpText<"Alias for --tapir-target=">;
 def: F<"plugin-opt=thinlto-emit-imports-files">,
   Alias<thinlto_emit_imports_files>,
   HelpText<"Alias for --thinlto-emit-imports-files">;

--- a/lld/MachO/Config.h
+++ b/lld/MachO/Config.h
@@ -22,6 +22,7 @@
 #include "llvm/TextAPI/Architecture.h"
 #include "llvm/TextAPI/Platform.h"
 #include "llvm/TextAPI/Target.h"
+#include "llvm/Transforms/Tapir/TapirTargetIDs.h"
 
 #include <vector>
 
@@ -186,6 +187,9 @@ struct Configuration {
   bool zeroModTime = false;
 
   llvm::StringRef osoPrefix;
+
+  llvm::TapirTargetID tapirTarget = llvm::TapirTargetID::None;
+  llvm::StringRef opencilkABIBitcodeFile;
 
   llvm::MachO::Architecture arch() const { return platformInfo.target.Arch; }
 

--- a/lld/MachO/Driver.cpp
+++ b/lld/MachO/Driver.cpp
@@ -1240,6 +1240,10 @@ bool macho::link(ArrayRef<const char *> argsArr, llvm::raw_ostream &stdoutOS,
   config->callGraphProfileSort = args.hasFlag(
       OPT_call_graph_profile_sort, OPT_no_call_graph_profile_sort, true);
   config->printSymbolOrder = args.getLastArgValue(OPT_print_symbol_order);
+  config->tapirTarget =
+      args::parseTapirTarget(args.getLastArgValue(OPT_tapir_target));
+  config->opencilkABIBitcodeFile =
+      args.getLastArgValue(OPT_opencilk_abi_bitcode);
 
   // FIXME: Add a commandline flag for this too.
   config->zeroModTime = getenv("ZERO_AR_DATE");

--- a/lld/MachO/LTO.cpp
+++ b/lld/MachO/LTO.cpp
@@ -46,6 +46,9 @@ static lto::Config createConfig() {
   c.TimeTraceGranularity = config->timeTraceGranularity;
   c.OptLevel = config->ltoo;
   c.CGOptLevel = args::getCGOptLevel(config->ltoo);
+  if (args::validTapirTarget(config->tapirTarget))
+    c.TapirTarget = config->tapirTarget;
+  c.OpenCilkABIBitcodeFile = std::string(config->opencilkABIBitcodeFile);
   if (config->saveTemps)
     checkError(c.addSaveTemps(config->outputFile.str() + ".",
                               /*UseInputModulePath=*/true));

--- a/lld/MachO/Options.td
+++ b/lld/MachO/Options.td
@@ -92,6 +92,12 @@ def no_call_graph_profile_sort : Flag<["--"], "no-call-graph-profile-sort">,
 def print_symbol_order: Joined<["--"], "print-symbol-order=">,
     HelpText<"Print a symbol order specified by --call-graph-profile-sort into the specified file">,
     Group<grp_lld>;
+def tapir_target: Joined<["--"], "tapir-target=">,
+    HelpText<"Specify the target for Tapir lowering">,
+    Group<grp_lld>;
+def opencilk_abi_bitcode: Joined<["--"], "opencilk-abi-bitcode=">,
+    HelpText<"Path to the OpenCilk ABI bitcode file">,
+    Group<grp_lld>;
 
 // This is a complete Options.td compiled from Apple's ld(1) manpage
 // dated 2018-03-07 and cross checked with ld64 source code in repo

--- a/lld/include/lld/Common/Args.h
+++ b/lld/include/lld/Common/Args.h
@@ -12,6 +12,7 @@
 #include "lld/Common/LLVM.h"
 #include "llvm/Support/CodeGen.h"
 #include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Transforms/Tapir/TapirTargetIDs.h"
 #include <vector>
 
 namespace llvm {
@@ -38,6 +39,8 @@ uint64_t getZOptionValue(llvm::opt::InputArgList &args, int id, StringRef key,
 std::vector<StringRef> getLines(MemoryBufferRef mb);
 
 StringRef getFilenameWithoutExe(StringRef path);
+
+llvm::TapirTargetID parseTapirTarget(StringRef tapirTarget);
 
 } // namespace args
 } // namespace lld

--- a/lld/include/lld/Common/Args.h
+++ b/lld/include/lld/Common/Args.h
@@ -42,6 +42,8 @@ StringRef getFilenameWithoutExe(StringRef path);
 
 llvm::TapirTargetID parseTapirTarget(StringRef tapirTarget);
 
+bool validTapirTarget(llvm::TapirTargetID TargetID);
+
 } // namespace args
 } // namespace lld
 

--- a/llvm/include/llvm/LTO/Config.h
+++ b/llvm/include/llvm/LTO/Config.h
@@ -92,6 +92,9 @@ struct Config {
   /// Target for lowering Tapir constructs
   TapirTargetID TapirTarget = TapirTargetID::None;
 
+  // Path to OpenCilk runtime bitcode file.
+  std::string OpenCilkABIBitcodeFile;
+
   /// If this field is set, the set of passes run in the middle-end optimizer
   /// will be the one specified by the string. Only works with the new pass
   /// manager as the old one doesn't have this ability.

--- a/llvm/lib/LTO/LTOBackend.cpp
+++ b/llvm/lib/LTO/LTOBackend.cpp
@@ -251,6 +251,10 @@ static void runNewPMPasses(const Config &Conf, Module &Mod, TargetMachine *TM,
 
   std::unique_ptr<TargetLibraryInfoImpl> TLII(
       new TargetLibraryInfoImpl(Triple(TM->getTargetTriple())));
+  TLII->setTapirTarget(Conf.TapirTarget);
+  TLII->setTapirTargetOptions(
+      std::make_unique<OpenCilkABIOptions>(Conf.OpenCilkABIBitcodeFile));
+  TLII->addTapirTargetLibraryFunctions();
   if (Conf.Freestanding)
     TLII->disableAllFunctions();
   FAM.registerPass([&] { return TargetLibraryAnalysis(*TLII); });
@@ -425,6 +429,10 @@ static void codegen(const Config &Conf, TargetMachine *TM,
 
   legacy::PassManager CodeGenPasses;
   TargetLibraryInfoImpl TLII(Triple(Mod.getTargetTriple()));
+  TLII.setTapirTarget(Conf.TapirTarget);
+  TLII.setTapirTargetOptions(
+      std::make_unique<OpenCilkABIOptions>(Conf.OpenCilkABIBitcodeFile));
+  TLII.addTapirTargetLibraryFunctions();
   CodeGenPasses.add(new TargetLibraryInfoWrapperPass(TLII));
   CodeGenPasses.add(
       createImmutableModuleSummaryIndexWrapperPass(&CombinedIndex));


### PR DESCRIPTION
This PR addresses the following bugs:
- When using lld with LTO (thin or regular), Tapir constructs were not getting lowered to the Tapir target specified at compile time.  With these changes, Tapir lowering to the specified target occurs as intended at link time when using lld with LTO.  (Thanks to @stelleg for pointing out this issue.)
- Compilation would crash if linking a bitcode ABI file with the OpenCilk target triggered any diagnostic messages.  This change ensures that diagnostic messages from this linking step are properly emitted without crashing the compiler.