### PR TITLE
Cilktool bitcode support

### DIFF
--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -420,19 +420,42 @@ static void addCilkSanitizerPass(const PassManagerBuilder &Builder,
   // of the original code, but operates on "shadow" values.  It can benefit from
   // re-running some general purpose optimization passes.
   if (Builder.OptLevel > 0) {
-    PM.add(createInstructionCombiningPass());
-    PM.add(createEarlyCSEPass());
+    PM.add(createSROAPass());
+    PM.add(createEarlyCSEPass(true));
     PM.add(createJumpThreadingPass());
     PM.add(createCorrelatedValuePropagationPass());
     PM.add(createCFGSimplificationPass());
     PM.add(createReassociatePass());
     PM.add(createLICMPass());
-    PM.add(createGVNPass());
+    PM.add(createCFGSimplificationPass());
+    PM.add(createInstructionCombiningPass());
     PM.add(createSCCPPass());
     PM.add(createBitTrackingDCEPass());
     PM.add(createInstructionCombiningPass());
     PM.add(createDeadStoreEliminationPass());
     PM.add(createCFGSimplificationPass());
+    PM.add(createInstructionCombiningPass());
+    if (Builder.OptLevel > 1) {
+      PM.add(createFunctionInliningPass(
+                 Builder.OptLevel, Builder.SizeLevel, false));
+      PM.add(createGlobalOptimizerPass());
+      PM.add(createGlobalDCEPass());
+      PM.add(createSROAPass());
+      PM.add(createEarlyCSEPass(true));
+      PM.add(createJumpThreadingPass());
+      PM.add(createCorrelatedValuePropagationPass());
+      PM.add(createCFGSimplificationPass());
+      PM.add(createReassociatePass());
+      PM.add(createLICMPass());
+      PM.add(createCFGSimplificationPass());
+      PM.add(createInstructionCombiningPass());
+      PM.add(createSCCPPass());
+      PM.add(createBitTrackingDCEPass());
+      PM.add(createInstructionCombiningPass());
+      PM.add(createDeadStoreEliminationPass());
+      PM.add(createCFGSimplificationPass());
+      PM.add(createInstructionCombiningPass());
+    }
   }
 }
 

--- a/llvm/examples/Kaleidoscope/Tapir/KaleidoscopeJIT.h
+++ b/llvm/examples/Kaleidoscope/Tapir/KaleidoscopeJIT.h
@@ -18,11 +18,11 @@
 #include "llvm/ExecutionEngine/Orc/CompileUtils.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/ExecutionEngine/Orc/ExecutionUtils.h"
+#include "llvm/ExecutionEngine/Orc/ExecutorProcessControl.h"
 #include "llvm/ExecutionEngine/Orc/IRCompileLayer.h"
 #include "llvm/ExecutionEngine/Orc/IRTransformLayer.h"
 #include "llvm/ExecutionEngine/Orc/JITTargetMachineBuilder.h"
 #include "llvm/ExecutionEngine/Orc/RTDyldObjectLinkingLayer.h"
-#include "llvm/ExecutionEngine/Orc/TargetProcessControl.h"
 #include "llvm/ExecutionEngine/SectionMemoryManager.h"
 #include "llvm/IR/DataLayout.h"
 #include "llvm/IR/IRBuilder.h"
@@ -35,7 +35,6 @@ namespace orc {
 
 class KaleidoscopeJIT {
 private:
-  std::unique_ptr<TargetProcessControl> TPC;
   std::unique_ptr<ExecutionSession> ES;
 
   DataLayout DL;
@@ -113,10 +112,9 @@ private:
   };
 
 public:
-  KaleidoscopeJIT(std::unique_ptr<TargetProcessControl> TPC,
-                  std::unique_ptr<ExecutionSession> ES,
+  KaleidoscopeJIT(std::unique_ptr<ExecutionSession> ES,
                   JITTargetMachineBuilder JTMB, DataLayout DL)
-      : TPC(std::move(TPC)), ES(std::move(ES)), DL(std::move(DL)),
+      : ES(std::move(ES)), DL(std::move(DL)),
         Mangle(*this->ES, this->DL),
         ObjectLayer(*this->ES,
                     []() { return std::make_unique<SectionMemoryManager>(); }),
@@ -138,19 +136,20 @@ public:
 
   static Expected<std::unique_ptr<KaleidoscopeJIT>> Create() {
     auto SSP = std::make_shared<SymbolStringPool>();
-    auto TPC = SelfTargetProcessControl::Create(SSP);
-    if (!TPC)
-      return TPC.takeError();
+    auto EPC = SelfExecutorProcessControl::Create();
+    if (!EPC)
+      return EPC.takeError();
 
-    auto ES = std::make_unique<ExecutionSession>(std::move(SSP));
+    auto ES = std::make_unique<ExecutionSession>(std::move(*EPC));
 
-    JITTargetMachineBuilder JTMB((*TPC)->getTargetTriple());
+    JITTargetMachineBuilder JTMB(
+        ES->getExecutorProcessControl().getTargetTriple());
 
     auto DL = JTMB.getDefaultDataLayoutForTarget();
     if (!DL)
       return DL.takeError();
 
-    return std::make_unique<KaleidoscopeJIT>(std::move(*TPC), std::move(ES),
+    return std::make_unique<KaleidoscopeJIT>(std::move(ES),
                                              std::move(JTMB), std::move(*DL));
   }
 

--- a/llvm/include/llvm/Transforms/Instrumentation/CSI.h
+++ b/llvm/include/llvm/Transforms/Instrumentation/CSI.h
@@ -811,6 +811,7 @@ public:
                         IntegerType::get(C, PropBits.IsOnStack),
                         IntegerType::get(C, PropBits.MayBeCaptured),
                         IntegerType::get(C, PropBits.IsAtomic),
+                        IntegerType::get(C, PropBits.IsThreadLocal),
                         IntegerType::get(C, PropBits.LoadReadBeforeWriteInBB),
                         IntegerType::get(C, PropBits.Padding)));
   }
@@ -837,6 +838,8 @@ public:
   void setMayBeCaptured(bool v) { PropValue.Fields.MayBeCaptured = v; }
   /// Set the value of the IsAtomic property.
   void setIsAtomic(bool v) { PropValue.Fields.IsAtomic = v; }
+  /// Set the value of the IsThreadLocal property.
+  void setIsThreadLocal(bool v) { PropValue.Fields.IsThreadLocal = v; }
   /// Set the value of the LoadReadBeforeWriteInBB property.
   void setLoadReadBeforeWriteInBB(bool v) {
     PropValue.Fields.LoadReadBeforeWriteInBB = v;
@@ -852,8 +855,9 @@ private:
       unsigned IsOnStack : 1;
       unsigned MayBeCaptured : 1;
       unsigned IsAtomic : 1;
+      unsigned IsThreadLocal : 1;
       unsigned LoadReadBeforeWriteInBB : 1;
-      uint64_t Padding : 50;
+      uint64_t Padding : 49;
     } Fields;
     uint64_t Bits;
   } Property;
@@ -868,13 +872,14 @@ private:
     int IsOnStack;
     int MayBeCaptured;
     int IsAtomic;
+    int IsThreadLocal;
     int LoadReadBeforeWriteInBB;
     int Padding;
   } PropertyBits;
 
   /// The number of bits representing each property.
   static constexpr PropertyBits PropBits = {
-      8, 1, 1, 1, 1, 1, 1, (64 - 8 - 1 - 1 - 1 - 1 - 1 - 1)};
+      8, 1, 1, 1, 1, 1, 1, 1, (64 - 8 - 1 - 1 - 1 - 1 - 1 - 1 - 1)};
 };
 
 class CsiAllocaProperty : public CsiProperty {
@@ -1071,6 +1076,7 @@ public:
   static bool isVtableAccess(Instruction *I);
   static bool addrPointsToConstantData(Value *Addr);
   static bool isAtomic(Instruction *I);
+  static bool isThreadLocalObject(Value *Obj);
   static bool getAllocFnArgs(const Instruction *I,
                              SmallVectorImpl<Value *> &AllocFnArgs,
                              Type *SizeTy, Type *AddrTy,

--- a/llvm/lib/Transforms/Instrumentation/ComprehensiveStaticInstrumentation.cpp
+++ b/llvm/lib/Transforms/Instrumentation/ComprehensiveStaticInstrumentation.cpp
@@ -2266,6 +2266,12 @@ bool CSIImpl::isAtomic(Instruction *I) {
   return false;
 }
 
+bool CSIImpl::isThreadLocalObject(Value *Obj) {
+  if (GlobalValue *GV = dyn_cast<GlobalValue>(Obj))
+    return GV->isThreadLocal();
+  return false;
+}
+
 void CSIImpl::computeLoadAndStoreProperties(
     SmallVectorImpl<std::pair<Instruction *, CsiLoadStoreProperty>>
         &LoadAndStoreProperties,
@@ -2295,6 +2301,8 @@ void CSIImpl::computeLoadAndStoreProperties(
       // Set may-be-captured property
       Prop.setMayBeCaptured(isa<GlobalValue>(Obj) ||
                             PointerMayBeCaptured(Addr, true, true));
+      // Set is-thread-local property
+      Prop.setIsThreadLocal(isThreadLocalObject(Obj));
       LoadAndStoreProperties.push_back(std::make_pair(I, Prop));
     } else {
       LoadInst *Load = cast<LoadInst>(I);
@@ -2313,6 +2321,8 @@ void CSIImpl::computeLoadAndStoreProperties(
       // Set may-be-captured property
       Prop.setMayBeCaptured(isa<GlobalValue>(Obj) ||
                             PointerMayBeCaptured(Addr, true, true));
+      // Set is-thread-local property
+      Prop.setIsThreadLocal(isThreadLocalObject(Obj));
       // Set load-read-before-write-in-bb property
       bool HasBeenSeen = WriteTargets.count(Addr) > 0;
       Prop.setLoadReadBeforeWriteInBB(HasBeenSeen);

--- a/llvm/test/Examples/Kaleidoscope/Tapir.test
+++ b/llvm/test/Examples/Kaleidoscope/Tapir.test
@@ -1,0 +1,17 @@
+# RUN: Kaleidoscope-Tapir < %s 2>&1 | FileCheck %s
+# NOREQUIRES: default_triple
+
+# Sequence operator and iterative fibonacci function to test user defined vars.
+def binary : 1 (x y) y;
+
+def fib(n)
+  if (n < 2) then
+    n
+  else
+    var x, y in (spawn x = fib(n-1)) : y = fib(n-2) : sync : (x+y);
+
+def fibloop(n)
+  parfor i = 1, i < n in
+
+fib(10);
+# CHECK: Evaluated to 55.000000

--- a/llvm/test/Transforms/Tapir/inline-taskframe-split.ll
+++ b/llvm/test/Transforms/Tapir/inline-taskframe-split.ll
@@ -1,0 +1,166 @@
+; Check that function inlining properly splits taskframe intrinsics in the callee.
+;
+; RUN: opt < %s -inline -S | FileCheck %s
+
+%struct.edgeArray = type <{ %struct.timezone*, i32, i32, i32, [4 x i8] }>
+%struct.timezone = type { i32, i32 }
+
+declare i32 @__gxx_personality_v0(...)
+
+; Function Attrs: argmemonly nounwind willreturn
+declare token @llvm.syncregion.start() #3
+
+; Function Attrs: inaccessiblememonly mustprogress nofree nounwind willreturn
+declare dso_local noalias noundef i8* @malloc(i64 noundef) local_unnamed_addr #7
+
+; Function Attrs: inaccessiblemem_or_argmemonly mustprogress nounwind willreturn
+declare dso_local void @free(i8* nocapture noundef) local_unnamed_addr #8
+
+define internal fastcc void @_Z12timeMatching9edgeArrayIiEiPc(%struct.edgeArray* %0, i32 %1, i8* %2) personality i32 (...)* @__gxx_personality_v0 {
+  br label %4
+
+4:                                                ; preds = %34, %3
+  br label %5
+
+5:                                                ; preds = %4
+  br label %6
+
+6:                                                ; preds = %5
+  br label %7
+
+7:                                                ; preds = %6
+  %8 = call token @llvm.taskframe.create()
+  %9 = tail call token @llvm.syncregion.start()
+  br label %10
+
+10:                                               ; preds = %7
+  br label %11
+
+11:                                               ; preds = %10
+  br label %12
+
+12:                                               ; preds = %11
+  %x = call noalias i8* @malloc(i64 100)
+  br label %13
+
+13:                                               ; preds = %16, %12
+  detach within none, label %14, label %16
+
+14:                                               ; preds = %13
+  br label %15
+
+15:                                               ; preds = %15, %14
+  br label %15
+
+16:                                               ; preds = %13
+  br i1 true, label %17, label %13
+
+17:                                               ; preds = %16
+  br label %18
+
+18:                                               ; preds = %17
+  sync within none, label %19
+
+19:                                               ; preds = %18
+  br label %20
+
+20:                                               ; preds = %19
+  %21 = call token @llvm.taskframe.create()
+  br label %22
+
+22:                                               ; preds = %20
+  %y = call noalias i8* @malloc(i64 100)
+  br label %23
+
+23:                                               ; preds = %22, %26
+  detach within none, label %24, label %26
+
+24:                                               ; preds = %23
+  br label %25
+
+25:                                               ; preds = %24, %25
+  br label %25
+
+26:                                               ; preds = %25
+  br i1 true, label %27, label %23
+
+27:                                               ; preds = %26
+  br label %28
+
+28:                                               ; preds = %27
+  sync within none, label %29
+
+29:                                               ; preds = %28
+  br label %30
+
+30:                                               ; preds = %29
+  br label %31
+
+31:                                               ; preds = %30
+  call void @free(i8* noundef %y)
+  call void @llvm.taskframe.end(token %21)
+  call void @free(i8* noundef %x)
+  br label %32
+
+32:                                               ; preds = %31
+  br label %33
+
+33:                                               ; preds = %32
+  br label %34
+
+34:                                               ; preds = %33
+  br label %4
+}
+
+define i32 @main() personality i8* bitcast (i32 (...)* @__gxx_personality_v0 to i8*) {
+  invoke fastcc void @_Z12timeMatching9edgeArrayIiEiPc(%struct.edgeArray* null, i32 0, i8* null)
+          to label %1 unwind label %2
+
+1:                                                ; preds = %0
+  ret i32 0
+
+2:                                                ; preds = %0
+  %3 = landingpad { i8*, i32 }
+          cleanup
+  ret i32 0
+}
+
+; CHECK: define i32 @main()
+; CHECK: br label %[[START:.+]]
+
+; CHECK: [[START]]:
+; CHECK: %[[TF1:.+]] = call token @llvm.taskframe.create()
+; CHECK: %[[X:.+]] = call noalias i8* @malloc(
+
+; CHECK: %[[TF2:.+]] = call token @llvm.taskframe.create()
+; CHECK: %[[Y:.+]] = call noalias i8* @malloc(
+
+; CHECK: call void @free(i8* noundef %[[Y]])
+; CHECK: call void @llvm.taskframe.end(token %[[TF2]])
+; CHECK-NEXT: br label %[[TFEND:.+]]
+
+; CHECK: [[TFEND]]:
+; CHECK: call void @free(i8* noundef %[[X]])
+; CHECK: br label %[[START]]
+
+; Function Attrs: argmemonly nounwind willreturn
+declare token @llvm.taskframe.create() #3
+
+; Function Attrs: argmemonly nounwind willreturn
+declare void @llvm.taskframe.end(token) #3
+
+; Function Attrs: argmemonly willreturn
+declare void @llvm.taskframe.resume.sl_p0i8i32s(token, { i8*, i32 }) #4
+
+; uselistorder directives
+uselistorder token ()* @llvm.taskframe.create, { 1, 0 }
+
+attributes #0 = { argmemonly nofree nounwind willreturn writeonly }
+attributes #1 = { argmemonly nofree nounwind willreturn }
+attributes #2 = { argmemonly nofree nosync nounwind willreturn }
+attributes #3 = { argmemonly nounwind willreturn }
+attributes #4 = { argmemonly willreturn }
+attributes #5 = { nofree nosync nounwind readnone willreturn }
+attributes #6 = { nofree nosync nounwind readnone speculatable willreturn }
+attributes #7 = { inaccessiblememonly mustprogress nofree nounwind willreturn }
+attributes #8 = { inaccessiblemem_or_argmemonly mustprogress nounwind willreturn }

--- a/llvm/test/lit.cfg.py
+++ b/llvm/test/lit.cfg.py
@@ -181,6 +181,7 @@ tools.extend([
     ToolSubst('Kaleidoscope-Ch6', unresolved='ignore'),
     ToolSubst('Kaleidoscope-Ch7', unresolved='ignore'),
     ToolSubst('Kaleidoscope-Ch8', unresolved='ignore'),
+    ToolSubst('Kaleidoscope-Tapir', unresolved='ignore'),
     ToolSubst('LLJITWithThinLTOSummaries', unresolved='ignore'),
     ToolSubst('LLJITWithRemoteDebugging', unresolved='ignore'),
     ToolSubst('OrcV2CBindingsBasicUsage', unresolved='ignore'),

--- a/llvm/tools/gold/gold-plugin.cpp
+++ b/llvm/tools/gold/gold-plugin.cpp
@@ -33,6 +33,7 @@
 #include "llvm/Support/TargetSelect.h"
 #include "llvm/Support/Threading.h"
 #include "llvm/Support/raw_ostream.h"
+#include "llvm/Transforms/Tapir/TapirTargetIDs.h"
 #include <list>
 #include <map>
 #include <plugin-api.h>
@@ -222,6 +223,23 @@ namespace options {
   static std::string cs_profile_path;
   static bool cs_pgo_gen = false;
 
+  // Tapir lowering options.
+  static TapirTargetID tapir_target = TapirTargetID::Last_TapirTargetID;
+  static std::string opencilk_abi_bitcode_file;
+
+  static TapirTargetID parseTapirTarget(StringRef tapirTarget) {
+    return StringSwitch<TapirTargetID>(tapirTarget)
+        .Case("none", TapirTargetID::None)
+        .Case("serial", TapirTargetID::Serial)
+        .Case("cheetah", TapirTargetID::Cheetah)
+        .Case("cilkplus", TapirTargetID::Cilk)
+        .Case("cuda", TapirTargetID::Cuda)
+        .Case("opencilk", TapirTargetID::OpenCilk)
+        .Case("openmp", TapirTargetID::OpenMP)
+        .Case("qthreads", TapirTargetID::Qthreads)
+        .Default(TapirTargetID::Last_TapirTargetID);
+  }
+
   static void process_plugin_option(const char *opt_)
   {
     if (opt_ == nullptr)
@@ -312,6 +330,10 @@ namespace options {
       RemarksFormat = std::string(opt);
     } else if (opt.consume_front("stats-file=")) {
       stats_file = std::string(opt);
+    } else if (opt.consume_front("tapir-target=")) {
+      tapir_target = parseTapirTarget(std::string(opt));
+    } else if (opt.consume_front("opencilk-abi-bitcode=")) {
+      opencilk_abi_bitcode_file = std::string(opt);
     } else {
       // Save this option to pass to the code generator.
       // ParseCommandLineOptions() expects argv[0] to be program name. Lazily
@@ -964,6 +986,12 @@ static std::unique_ptr<LTO> createLTO(IndexWriteCallback OnIndexWrite,
   Conf.HasWholeProgramVisibility = options::whole_program_visibility;
 
   Conf.StatsFile = options::stats_file;
+
+  if (options::tapir_target != TapirTargetID::Last_TapirTargetID) {
+    Conf.TapirTarget = options::tapir_target;
+    Conf.OpenCilkABIBitcodeFile = options::opencilk_abi_bitcode_file;
+  }
+
   return std::make_unique<LTO>(std::move(Conf), Backend,
                                 options::ParallelCodeGenParallelismLevel);
 }


### PR DESCRIPTION
This PR contains changes to support linking bitcode files for Cilksan and Cilkscale.

In addition, this PR makes the following minor changes:
- Cleanup static race detection.
- Cleanup logic for inserting MAAP checks for Cilksan instrumentation.
- Improve instrumentation for accesses to thread-local storage, to ensure that races involving such accesses can be checked.
- Add support for late Tapir lowering to the LLVM gold plugin.
- Update the Kaleidoscope Tapir tutorial for LLVM 14.
- Various bug fixes.