### PR TITLE
Fix crash on type error in Cilk for statement

### DIFF
--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -3753,7 +3753,8 @@ StmtResult Sema::HandleSimpleCilkForStmt(SourceLocation CilkForLoc,
     BuildBinOp(S, LoopVarLoc, StrideIsNegative ? BO_Sub : BO_Add, InitRef.get(),
                BuildBinOp(S, LoopVarLoc, BO_Mul,
                           BeginRef.get(), Stride).get());
-  AddInitializerToDecl(LoopVar, NewLoopVarInit.get(), /*DirectInit=*/false);
+  if (!NewLoopVarInit.isInvalid())
+    AddInitializerToDecl(LoopVar, NewLoopVarInit.get(), /*DirectInit=*/false);
 
   return new (Context) CilkForStmt(
       NewInit.get(), cast<DeclStmt>(LimitDecl.get()), InitCond.get(),

--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -3646,9 +3646,10 @@ StmtResult Sema::HandleSimpleCilkForStmt(SourceLocation CilkForLoc,
   else // DeclUseInRHS
     InitCond = BuildBinOp(S, CondLoc, Cond->getOpcode(), LimitRef.get(),
                           CastInit.get());
-  assert(!InitCond.isInvalid());
-  if (InitCond.isInvalid())
+  if (InitCond.isInvalid()) {
+    llvm_unreachable("Invalid InitCond");
     return StmtError();
+  }
 
   // Compute the range of this _Cilk_for loop.
   ExprResult Range;
@@ -3677,16 +3678,20 @@ StmtResult Sema::HandleSimpleCilkForStmt(SourceLocation CilkForLoc,
     NewLimit = BuildBinOp(S, CondLoc, BO_Add, NewLimit.get(),
                           ActOnIntegerConstant(CilkForLoc, 1).get());
 
+  // The range is the result of subtracting the loop bounds
+  // and should be an integer.
+  QualType CountTy = NewLimit.get()->getType();
+
   // Create new declarations for replacement loop control variables.
   // Declaration for new beginning loop control variable.
-  VarDecl *BeginVar = BuildForRangeVarDecl(*this, CondLoc, LoopVarTy,
+  VarDecl *BeginVar = BuildForRangeVarDecl(*this, CondLoc, CountTy,
                                            "__begin");
   AddInitializerToDecl(BeginVar, ActOnIntegerConstant(CondLoc, 0).get(),
                        /*DirectInit=*/false);
   FinalizeDeclaration(BeginVar);
   CurContext->addHiddenDecl(BeginVar);
   // Declaration for new end loop control variable.
-  VarDecl *EndVar = BuildForRangeVarDecl(*this, CondLoc, LoopVarTy, "__end");
+  VarDecl *EndVar = BuildForRangeVarDecl(*this, CondLoc, CountTy, "__end");
   AddInitializerToDecl(EndVar, NewLimit.get(), /*DirectInit=*/false);
   FinalizeDeclaration(EndVar);
   CurContext->addHiddenDecl(EndVar);
@@ -3708,10 +3713,8 @@ StmtResult Sema::HandleSimpleCilkForStmt(SourceLocation CilkForLoc,
 
   // Create a new condition expression that uses the new VarDecl
   // in place of the lifted expression.
-  ExprResult BeginRef = BuildDeclRefExpr(BeginVar, LoopVarTy, VK_LValue,
-                                         CondLoc);
-  ExprResult EndRef = BuildDeclRefExpr(EndVar, LoopVarTy, VK_LValue,
-                                       CondLoc);
+  ExprResult BeginRef = BuildDeclRefExpr(BeginVar, CountTy, VK_LValue, CondLoc);
+  ExprResult EndRef = BuildDeclRefExpr(EndVar, CountTy, VK_LValue, CondLoc);
   ExprResult NewCond;
   if (CompareUpperLimit == DeclUseInLHS)
     NewCond = BuildBinOp(S, CondLoc, Cond->getOpcode(), BeginRef.get(),

--- a/clang/test/Cilk/cilkfor-bad-input.c
+++ b/clang/test/Cilk/cilkfor-bad-input.c
@@ -16,3 +16,12 @@ void f4() {
   int i;
   _Cilk_for(; i < 42; ++i); // expected-error{{missing control variable declaration and initialization in '_Cilk_for'}} expected-error{{expected control variable declaration in initializer in '_Cilk_for'}}
 }
+
+void f5(const long *begin, const long *end) { // expected-note{{previous}}
+  long end = 666; // expected-error{{redefinition of 'end' with a different type}}
+  _Cilk_for (const long *p = begin; p != end; ++p)
+    ;
+  // expected-error@-2{{invalid operands}}
+  // expected-warning@-3{{incompatible integer to pointer conversion}}
+  // expected-warning@-4{{Cilk for loop has empty body}}
+}

--- a/clang/test/Cilk/cilkfor-bad-input.c
+++ b/clang/test/Cilk/cilkfor-bad-input.c
@@ -17,11 +17,9 @@ void f4() {
   _Cilk_for(; i < 42; ++i); // expected-error{{missing control variable declaration and initialization in '_Cilk_for'}} expected-error{{expected control variable declaration in initializer in '_Cilk_for'}}
 }
 
-void f5(const long *begin, const long *end) { // expected-note{{previous}}
-  long end = 666; // expected-error{{redefinition of 'end' with a different type}}
-  _Cilk_for (const long *p = begin; p != end; ++p)
+void f5(const long *begin) {
+  _Cilk_for (const long *p = begin; p != 666; ++p)
     ;
-  // expected-error@-2{{invalid operands}}
-  // expected-warning@-3{{incompatible integer to pointer conversion}}
-  // expected-warning@-4{{Cilk for loop has empty body}}
+  // expected-warning@-2{{comparison between pointer and integer}}
+  // expected-warning@-3{{Cilk for loop has empty body}}
 }

--- a/clang/test/Cilk/cilkfor-pointer.c
+++ b/clang/test/Cilk/cilkfor-pointer.c
@@ -1,0 +1,9 @@
+// RUN: %clang_cc1 %s -fopencilk -verify -fsyntax-only
+
+// Make sure the front end accepts pointer loop variables.
+long cilk_for_pointer_type(const long *begin, const long *end)
+{
+  _Cilk_for (const long *p = begin; p != end; ++p)
+    ; // expected-warning@-1{{Cilk for loop has empty body}}
+  return 0;
+}


### PR DESCRIPTION
The added test case caused a compiler crash due to a null pointer dereference.