### PR TITLE
Updates and bugfixes

### DIFF
--- a/.github/workflows/llvm-project-tests.yml
+++ b/.github/workflows/llvm-project-tests.yml
@@ -28,7 +28,7 @@ concurrency:
 env:
   # Workaround for https://github.com/actions/virtual-environments/issues/5900.
   # This should be a no-op for non-mac OSes
-  CPLUS_INCLUDE_PATH: /usr/local/Cellar/llvm@14/14.0.6/include/c++/v1:/Library/Developer/CommandLineTools/SDKs/MacOSX12.sdk/usr/include
+  CPLUS_INCLUDE_PATH: /usr/local/Cellar/llvm/15.0.7_1/include/c++/v1:/Library/Developer/CommandLineTools/SDKs/MacOSX12.1.sdk/usr/include
 
 jobs:
   lit-tests:

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5915,11 +5915,14 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
     /* JFC: Is it possible to confuse with with -fno-opencilk? */
     bool OpenCilk = Args.hasArgNoClaim(options::OPT_fopencilk);
     bool Cheetah = false;
+    bool CustomTarget = false;
 
     if (Arg *TapirRuntime = Args.getLastArgNoClaim(options::OPT_ftapir_EQ)) {
       Cheetah = TapirRuntime->getValue() == StringRef("cheetah");
       if (TapirRuntime->getValue() == StringRef("opencilk")) {
         OpenCilk = true;
+      } else {
+        CustomTarget = true;
       }
     }
 
@@ -5958,8 +5961,9 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
       // Forward flags for enabling pedigrees.
       Args.AddLastArg(CmdArgs, options::OPT_fopencilk_enable_pedigrees);
 
-      // Add the OpenCilk ABI bitcode file.
-      getToolChain().AddOpenCilkABIBitcode(Args, CmdArgs);
+      if (!CustomTarget)
+        // Add the OpenCilk ABI bitcode file.
+        getToolChain().AddOpenCilkABIBitcode(Args, CmdArgs);
     }
   }
 

--- a/llvm/include/llvm/Transforms/Instrumentation/CSI.h
+++ b/llvm/include/llvm/Transforms/Instrumentation/CSI.h
@@ -564,6 +564,61 @@ private:
   static constexpr PropertyBits PropBits = {1, 1, (64 - 1 - 1)};
 };
 
+class CsiDetachProperty : public CsiProperty {
+public:
+  CsiDetachProperty() { PropValue.Bits = 0; }
+
+  /// Return the Type of a property.
+  static StructType *getStructType(LLVMContext &C) {
+    // Must match the definition of property type in csi.h
+    return StructType::get(IntegerType::get(C, PropBits.ForTapirLoopBody),
+                           IntegerType::get(C, PropBits.Padding));
+  }
+  static Type *getType(LLVMContext &C) {
+    return getCoercedType(C, getStructType(C));
+  }
+  /// Get the default value for this property.
+  static Constant *getDefaultValueImpl(LLVMContext &C) {
+    return Constant::getNullValue(getType(C));
+  }
+
+  /// Return a constant value holding this property.
+  Constant *getValueImpl(LLVMContext &C) const override {
+    // Must match the definition of property type in csi.h
+    // StructType *StructTy = getType(C);
+    // return ConstantStruct::get(StructTy,
+    //                            ConstantInt::get(IntegerType::get(C, 64), 0),
+    //                            nullptr);
+    // TODO: This solution works for x86, but should be generalized to support
+    // other architectures in the future.
+    return ConstantInt::get(getType(C), PropValue.Bits);
+  }
+
+  /// Set the value of the IsTapirLoopBody property.
+  void setForTapirLoopBody(bool v) { PropValue.Fields.ForTapirLoopBody = v; }
+
+private:
+  typedef union {
+    // Must match the definition of property type in csi.h
+    struct {
+      unsigned ForTapirLoopBody : 1;
+      uint64_t Padding : 63;
+    } Fields;
+    uint64_t Bits;
+  } Property;
+
+  /// The underlying values of the properties.
+  Property PropValue;
+
+  typedef struct {
+    int ForTapirLoopBody;
+    int Padding;
+  } PropertyBits;
+
+  /// The number of bits representing each property.
+  static constexpr PropertyBits PropBits = {1, (64 - 1)};
+};
+
 class CsiTaskProperty : public CsiProperty {
 public:
   CsiTaskProperty() { PropValue.Bits = 0; }
@@ -687,6 +742,7 @@ public:
   static StructType *getStructType(LLVMContext &C) {
     // Must match the definition of property type in csi.h
     return StructType::get(IntegerType::get(C, PropBits.IsUnwind),
+                           IntegerType::get(C, PropBits.ForTapirLoopBody),
                            IntegerType::get(C, PropBits.Padding));
   }
   static Type *getType(LLVMContext &C) {
@@ -712,12 +768,18 @@ public:
   /// Set the value of the IsUnwind property.
   void setIsUnwind(bool v = true) { PropValue.Fields.IsUnwind = v; }
 
+  /// Set the value of the ForTapirLoopBody property.
+  void setForTapirLoopBody(bool v = true) {
+    PropValue.Fields.ForTapirLoopBody = v;
+  }
+
 private:
   typedef union {
     // Must match the definition of property type in csi.h
     struct {
       unsigned IsUnwind : 1;
-      uint64_t Padding : 63;
+      unsigned ForTapirLoopBody : 1;
+      uint64_t Padding : 62;
     } Fields;
     uint64_t Bits;
   } Property;
@@ -727,11 +789,12 @@ private:
 
   typedef struct {
     int IsUnwind;
+    int ForTapirLoopBody;
     int Padding;
   } PropertyBits;
 
   /// The number of bits representing each property.
-  static constexpr PropertyBits PropBits = {1, (64 - 1)};
+  static constexpr PropertyBits PropBits = {1, 1, (64 - 1 - 1)};
 };
 
 class CsiCallProperty : public CsiProperty {

--- a/llvm/include/llvm/Transforms/Utils/TapirUtils.h
+++ b/llvm/include/llvm/Transforms/Utils/TapirUtils.h
@@ -88,6 +88,9 @@ bool removeDeadSyncUnwind(CallBase *SyncUnwind, DomTreeUpdater *DTU = nullptr);
 bool ReattachMatchesDetach(const ReattachInst *RI, const DetachInst *DI,
                            DominatorTree *DT = nullptr);
 
+/// Returns true of the given task itself contains a sync instruction.
+bool taskContainsSync(const Task *T);
+
 /// Move static allocas in Block into Entry, which is assumed to dominate Block.
 /// Leave lifetime markers behind in Block and before each instruction in
 /// ExitPoints for those static allocas.  Returns true if Block still contains
@@ -124,6 +127,7 @@ void SerializeDetach(DetachInst *DI, BasicBlock *ParentEntry,
                      SmallPtrSetImpl<BasicBlock *> *EHBlockPreds,
                      SmallPtrSetImpl<LandingPadInst *> *InlinedLPads,
                      SmallVectorImpl<Instruction *> *DetachedRethrows,
+                     bool ReplaceWithTaskFrame = false,
                      DominatorTree *DT = nullptr, LoopInfo *LI = nullptr);
 
 /// Analyze a task T for serialization.  Gets the reattaches, landing pads, and
@@ -137,12 +141,8 @@ void AnalyzeTaskForSerialization(
 
 /// Serialize the detach DI that spawns task T.  If \p DT is provided, then it
 /// will be updated to reflect the CFG changes.
-void SerializeDetach(DetachInst *DI, Task *T, DominatorTree *DT = nullptr);
-
-/// Serialize the sub-CFG detached by the specified detach
-/// instruction.  Removes the detach instruction and returns a pointer
-/// to the branch instruction that replaces it.
-BranchInst *SerializeDetachedCFG(DetachInst *DI, DominatorTree *DT = nullptr);
+void SerializeDetach(DetachInst *DI, Task *T, bool ReplaceWithTaskFrame = false,
+                     DominatorTree *DT = nullptr);
 
 /// Get the entry basic block to the detached context that contains
 /// the specified block.

--- a/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
@@ -2032,6 +2032,42 @@ Instruction *InstCombinerImpl::visitCallInst(CallInst &CI) {
     assert(isa<CallInst>(II));
     return eraseInstFromFunction(CI);
   }
+  case Intrinsic::tapir_runtime_end: {
+    Value *PrevRTStart = CI.getArgOperand(0);
+    // If there's a tapir.runtime.start in the same block after this
+    // tapir.runtime.end with no interesting instructions in between, eliminate
+    // both.
+    BasicBlock::iterator Iter(CI);
+    while (++Iter != CI.getParent()->end()) {
+      if (isTapirIntrinsic(Intrinsic::tapir_runtime_start, &*Iter)) {
+        // Replce the uses of the tapir.runtime.start with the argument to the
+        // tapir.runtime.end.
+        replaceInstUsesWith(*Iter, PrevRTStart);
+        eraseInstFromFunction(*Iter);
+        return eraseInstFromFunction(CI);
+      }
+      if (isa<CallBase>(&*Iter) && !isa<DbgInfoIntrinsic>(&*Iter))
+        // We found a nontrivial call.  Give up.
+        break;
+    }
+    break;
+  }
+  case Intrinsic::tapir_runtime_start: {
+    // If there's tapir.runtime.end in the same block after this
+    // tapir.runtime.start with no interesting instructions in between,
+    // eliminate both.
+    BasicBlock::iterator Iter(CI);
+    while (++Iter != CI.getParent()->end()) {
+      if (isTapirIntrinsic(Intrinsic::tapir_runtime_end, &*Iter, &CI)) {
+        eraseInstFromFunction(CI);
+        return eraseInstFromFunction(*Iter);
+      }
+      if (isa<CallBase>(&*Iter) && !isa<DbgInfoIntrinsic>(&*Iter))
+        // We found a nontrivial call.  Give up.
+        break;
+    }
+    break;
+  }
   case Intrinsic::assume: {
     Value *IIOperand = II->getArgOperand(0);
     SmallVector<OperandBundleDef, 4> OpBundles;

--- a/llvm/lib/Transforms/Instrumentation/CilkSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/CilkSanitizer.cpp
@@ -902,6 +902,7 @@ void CilkSanitizerImpl::initializeCsanHooks() {
   Type *LoopPropertyTy = CsiLoopProperty::getType(C);
   Type *AllocFnPropertyTy = CsiAllocFnProperty::getType(C);
   Type *FreePropertyTy = CsiFreeProperty::getType(C);
+  Type *DetachPropertyTy = CsiDetachProperty::getType(C);
   Type *DetContPropertyTy = CsiDetachContinueProperty::getType(C);
   Type *RetType = IRB.getVoidTy();
   Type *AddrType = IRB.getInt8PtrTy();
@@ -983,7 +984,8 @@ void CilkSanitizerImpl::initializeCsanHooks() {
     AttributeList FnAttrs = GeneralFnAttrs;
     CsanDetach = M.getOrInsertFunction("__csan_detach", FnAttrs, RetType,
                                        /* detach_id */ IDType,
-                                       /* sync_reg */ SyncRegType);
+                                       /* sync_reg */ SyncRegType,
+                                       DetachPropertyTy);
   }
   {
     AttributeList FnAttrs = GeneralFnAttrs;
@@ -4249,13 +4251,16 @@ bool CilkSanitizerImpl::instrumentDetach(DetachInst *DI, unsigned SyncRegNum,
   bool TapirLoopBody = spawnsTapirLoopBody(DI, LI, TI);
   ConstantInt *SyncRegVal = ConstantInt::get(Type::getInt32Ty(Ctx), SyncRegNum);
   ConstantInt *DefaultSyncRegVal = ConstantInt::get(Type::getInt32Ty(Ctx), 0);
+  CsiDetachProperty DetachProp;
+  DetachProp.setForTapirLoopBody(TapirLoopBody);
   // Instrument the detach instruction itself
   Value *DetachID;
   {
     IRBuilder<> IRB(DI);
     uint64_t LocalID = DetachFED.add(*DI);
     DetachID = DetachFED.localToGlobalId(LocalID, IDBuilder);
-    Instruction *Call = IRB.CreateCall(CsanDetach, {DetachID, SyncRegVal});
+    Instruction *Call = IRB.CreateCall(
+        CsanDetach, {DetachID, SyncRegVal, DetachProp.getValue(IRB)});
     IRB.SetInstDebugLocation(Call);
   }
   NumInstrumentedDetaches++;
@@ -4342,6 +4347,7 @@ bool CilkSanitizerImpl::instrumentDetach(DetachInst *DI, unsigned SyncRegNum,
     uint64_t LocalID = DetachContinueFED.add(*ContinueBlock);
     Value *ContinueID = DetachContinueFED.localToGlobalId(LocalID, IDBuilder);
     CsiDetachContinueProperty ContProp;
+    ContProp.setForTapirLoopBody(TapirLoopBody);
     Instruction *Call =
         IRB.CreateCall(CsanDetachContinue, {ContinueID, DetachID, SyncRegVal,
                                             ContProp.getValue(IRB)});
@@ -4366,6 +4372,7 @@ bool CilkSanitizerImpl::instrumentDetach(DetachInst *DI, unsigned SyncRegNum,
     CsiDetachContinueProperty ContProp;
     Value *DefaultPropVal = ContProp.getValueImpl(Ctx);
     ContProp.setIsUnwind();
+    ContProp.setForTapirLoopBody(TapirLoopBody);
     insertHookCallInSuccessorBB(
         UnwindBlock, PredBlock, CsanDetachContinue,
         {ContinueID, DetachID, SyncRegVal, ContProp.getValue(Ctx)},

--- a/llvm/lib/Transforms/Tapir/LoopStripMine.cpp
+++ b/llvm/lib/Transforms/Tapir/LoopStripMine.cpp
@@ -1009,6 +1009,7 @@ Loop *llvm::StripMineLoop(Loop *L, unsigned Count, bool AllowExpensiveTripCount,
   // Analyze the original task for serialization.
   AnalyzeTaskForSerialization(T, Reattaches, EHBlocksToClone, EHBlockPreds,
                               InlinedLPads, DetachedRethrows);
+  bool NeedToInsertTaskFrame = taskContainsSync(T);
 
   // If this detach can throw, get the exceptional continuation of the detach
   // and its associated landingpad value.
@@ -1103,7 +1104,8 @@ Loop *llvm::StripMineLoop(Loop *L, unsigned Count, bool AllowExpensiveTripCount,
     // Serialize the new task.
     SerializeDetach(ClonedDI, ParentEntry, EHCont, EHContLPadVal,
                     ClonedReattaches, &ClonedEHBlocks, &ClonedEHBlockPreds,
-                    &ClonedInlinedLPads, &ClonedDetachedRethrows, DT, LI);
+                    &ClonedInlinedLPads, &ClonedDetachedRethrows,
+                    NeedToInsertTaskFrame, DT, LI);
   }
 
   // Detach the stripmined loop.

--- a/llvm/lib/Transforms/Utils/TapirUtils.cpp
+++ b/llvm/lib/Transforms/Utils/TapirUtils.cpp
@@ -20,6 +20,7 @@
 #include "llvm/IR/Dominators.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/IntrinsicInst.h"
+#include "llvm/IR/Intrinsics.h"
 #include "llvm/Transforms/Utils/BasicBlockUtils.h"
 #include "llvm/Transforms/Utils/Cloning.h"
 #include "llvm/Transforms/Utils/Local.h"
@@ -171,7 +172,7 @@ bool llvm::removeDeadSyncUnwind(CallBase *SyncUnwind,
 /// does not actually match the detach instruction, but instead matches a
 /// sibling detach instruction with the same continuation.  This best-effort
 /// check is sufficient in some cases, such as during a traversal of a detached
-/// task..
+/// task.
 bool llvm::ReattachMatchesDetach(const ReattachInst *RI, const DetachInst *DI,
                                  DominatorTree *DT) {
   // Check that the reattach instruction belonds to the same sync region as the
@@ -193,6 +194,19 @@ bool llvm::ReattachMatchesDetach(const ReattachInst *RI, const DetachInst *DI,
   }
 
   return true;
+}
+
+/// Returns true of the given task itself contains a sync instruction.
+bool llvm::taskContainsSync(const Task *T) {
+  for (const Spindle *S :
+       depth_first<InTask<Spindle *>>(T->getEntrySpindle())) {
+    if (S == T->getEntrySpindle())
+      continue;
+    for (const BasicBlock *Pred : predecessors(S->getEntry()))
+      if (isa<SyncInst>(Pred->getTerminator()))
+        return true;
+  }
+  return false;
 }
 
 /// Return the result of AI->isStaticAlloca() if AI were moved to the entry
@@ -817,13 +831,15 @@ void llvm::InlineTaskFrameResumes(Value *TaskFrame, DominatorTree *DT) {
 
 static void startSerializingTaskFrame(Value *TaskFrame,
                                       SmallVectorImpl<Instruction *> &ToErase,
-                                      DominatorTree *DT) {
+                                      DominatorTree *DT,
+                                      bool PreserveTaskFrame) {
   for (User *U : TaskFrame->users())
     if (Instruction *UI = dyn_cast<Instruction>(U))
       if (isTapirIntrinsic(Intrinsic::taskframe_use, UI))
         ToErase.push_back(UI);
 
-  InlineTaskFrameResumes(TaskFrame, DT);
+  if (!PreserveTaskFrame)
+    InlineTaskFrameResumes(TaskFrame, DT);
 }
 
 void llvm::SerializeDetach(DetachInst *DI, BasicBlock *ParentEntry,
@@ -833,17 +849,20 @@ void llvm::SerializeDetach(DetachInst *DI, BasicBlock *ParentEntry,
                            SmallPtrSetImpl<BasicBlock *> *EHBlockPreds,
                            SmallPtrSetImpl<LandingPadInst *> *InlinedLPads,
                            SmallVectorImpl<Instruction *> *DetachedRethrows,
-                           DominatorTree *DT, LoopInfo *LI) {
+                           bool ReplaceWithTaskFrame, DominatorTree *DT,
+                           LoopInfo *LI) {
   BasicBlock *Spawner = DI->getParent();
   BasicBlock *TaskEntry = DI->getDetached();
   BasicBlock *Continue = DI->getContinue();
   BasicBlock *Unwind = DI->getUnwindDest();
   Value *SyncRegion = DI->getSyncRegion();
+  Module *M = Spawner->getModule();
 
   // If the spawned task has a taskframe, serialize the taskframe.
   SmallVector<Instruction *, 8> ToErase;
-  if (Value *TaskFrame = getTaskFrameUsed(TaskEntry))
-    startSerializingTaskFrame(TaskFrame, ToErase, DT);
+  Value *TaskFrame = getTaskFrameUsed(TaskEntry);
+  if (TaskFrame)
+    startSerializingTaskFrame(TaskFrame, ToErase, DT, ReplaceWithTaskFrame);
 
   // Clone any EH blocks that need cloning.
   if (EHBlocksToClone) {
@@ -868,7 +887,6 @@ void llvm::SerializeDetach(DetachInst *DI, BasicBlock *ParentEntry,
   // If the cloned loop contained dynamic alloca instructions, wrap the inlined
   // code with llvm.stacksave/llvm.stackrestore intrinsics.
   if (ContainsDynamicAllocas) {
-    Module *M = Spawner->getParent()->getParent();
     // Get the two intrinsics we care about.
     Function *StackSave = Intrinsic::getDeclaration(M, Intrinsic::stacksave);
     Function *StackRestore =
@@ -884,12 +902,39 @@ void llvm::SerializeDetach(DetachInst *DI, BasicBlock *ParentEntry,
       IRBuilder<>(Exit).CreateCall(StackRestore, SavedPtr);
   }
 
+  // If we're replacing the detach with a taskframe and we don't have a
+  // taskframe already, create one.
+  if (ReplaceWithTaskFrame) {
+    if (!TaskFrame) {
+      // Create a new task frame.
+      Function *TFCreate =
+          Intrinsic::getDeclaration(M, Intrinsic::taskframe_create);
+      TaskFrame = IRBuilder<>(TaskEntry, TaskEntry->begin())
+                      .CreateCall(TFCreate, {}, "repltf");
+    }
+  }
+
   // Handle any detached-rethrows in the task.
   if (DI->hasUnwindDest()) {
     assert(InlinedLPads && "Missing set of landing pads in task.");
     assert(DetachedRethrows && "Missing set of detached rethrows in task.");
-    handleDetachedLandingPads(DI, EHContinue, LPadValInEHContinue,
-                              *InlinedLPads, *DetachedRethrows, DT);
+    if (ReplaceWithTaskFrame) {
+      // If we're replacing the detach with a taskframe, simply replace the
+      // detached.rethrow intrinsics with taskframe.resume intrinsics.
+      for (Instruction *I : *DetachedRethrows) {
+        InvokeInst *II = cast<InvokeInst>(I);
+        Value *LPad = II->getArgOperand(1);
+        Function *TFResume = Intrinsic::getDeclaration(
+            M, Intrinsic::taskframe_resume, {LPad->getType()});
+        IRBuilder<>(II).CreateInvoke(TFResume, II->getNormalDest(),
+                                     II->getUnwindDest(), {TaskFrame, LPad});
+        II->eraseFromParent();
+      }
+    } else {
+      // Otherwise, "inline" the detached landingpads.
+      handleDetachedLandingPads(DI, EHContinue, LPadValInEHContinue,
+                                *InlinedLPads, *DetachedRethrows, DT);
+    }
   }
 
   // Replace reattaches with unconditional branches to the continuation.
@@ -904,6 +949,13 @@ void llvm::SerializeDetach(DetachInst *DI, BasicBlock *ParentEntry,
       else
         ReattachDom = DT->findNearestCommonDominator(ReattachDom,
                                                      I->getParent());
+    }
+
+    // If we're replacing the detach with a taskframe, insert a taskframe.end
+    // immediately before the reattach.
+    if (ReplaceWithTaskFrame) {
+      Function *TFEnd = Intrinsic::getDeclaration(M, Intrinsic::taskframe_end);
+      IRBuilder<>(I).CreateCall(TFEnd, {TaskFrame});
     }
     ReplaceInstWithInst(I, BranchInst::Create(Continue));
   }
@@ -987,7 +1039,8 @@ void llvm::AnalyzeTaskForSerialization(
 
 /// Serialize the detach DI that spawns task T.  If provided, the dominator tree
 /// DT will be updated to reflect the serialization.
-void llvm::SerializeDetach(DetachInst *DI, Task *T, DominatorTree *DT) {
+void llvm::SerializeDetach(DetachInst *DI, Task *T, bool ReplaceWithTaskFrame,
+                           DominatorTree *DT) {
   assert(DI && "SerializeDetach given nullptr for detach.");
   assert(DI == T->getDetach() && "Task and detach arguments do not match.");
   SmallVector<BasicBlock *, 4> EHBlocksToClone;
@@ -1006,82 +1059,7 @@ void llvm::SerializeDetach(DetachInst *DI, Task *T, DominatorTree *DT) {
   }
   SerializeDetach(DI, T->getParentTask()->getEntry(), EHContinue, LPadVal,
                   Reattaches, &EHBlocksToClone, &EHBlockPreds, &InlinedLPads,
-                  &DetachedRethrows, DT);
-}
-
-/// SerializeDetachedCFG - Serialize the sub-CFG detached by the specified
-/// detach instruction.  Removes the detach instruction and returns a pointer to
-/// the branch instruction that replaces it.
-///
-BranchInst *llvm::SerializeDetachedCFG(DetachInst *DI, DominatorTree *DT) {
-  // Get the parent of the detach instruction.
-  BasicBlock *Detacher = DI->getParent();
-  // Get the detached block and continuation of this detach.
-  BasicBlock *Detached = DI->getDetached();
-  BasicBlock *Continuation = DI->getContinue();
-  BasicBlock *Unwind = nullptr;
-  if (DI->hasUnwindDest())
-    Unwind = DI->getUnwindDest();
-
-  assert(Detached->getSinglePredecessor() &&
-         "Detached block has multiple predecessors.");
-
-  // Get the detach edge from DI.
-  BasicBlockEdge DetachEdge(Detacher, Detached);
-
-  // Collect the reattaches into the continuation.  If DT is available, verify
-  // that all reattaches are dominated by the detach edge from DI.
-  SmallVector<ReattachInst *, 8> Reattaches;
-  // If we only find a single reattach into the continuation, capture it so we
-  // can later update the dominator tree.
-  BasicBlock *SingleReattacher = nullptr;
-  int ReattachesFound = 0;
-  for (auto PI = pred_begin(Continuation), PE = pred_end(Continuation);
-       PI != PE; PI++) {
-    BasicBlock *Pred = *PI;
-    // Skip the detacher.
-    if (Detacher == Pred) continue;
-    // Record the reattaches found.
-    if (isa<ReattachInst>(Pred->getTerminator())) {
-      ReattachesFound++;
-      if (!SingleReattacher)
-        SingleReattacher = Pred;
-      if (DT) {
-        assert(DT->dominates(DetachEdge, Pred) &&
-               "Detach edge does not dominate a reattach "
-               "into its continuation.");
-      }
-      Reattaches.push_back(cast<ReattachInst>(Pred->getTerminator()));
-    }
-  }
-  // TODO: It's possible to detach a CFG that does not terminate with a
-  // reattach.  For example, optimizations can create detached CFG's that are
-  // terminated by unreachable terminators only.  Some of these special cases
-  // lead to problems with other passes, however, and this check will identify
-  // those special cases early while we sort out those issues.
-  assert(!Reattaches.empty() && "No reattach found for detach.");
-
-  // Replace each reattach with branches to the continuation.
-  for (ReattachInst *RI : Reattaches) {
-    BranchInst *ReplacementBr = BranchInst::Create(Continuation, RI);
-    ReplacementBr->setDebugLoc(RI->getDebugLoc());
-    RI->eraseFromParent();
-  }
-
-  // Replace the new detach with a branch to the detached CFG.
-  Continuation->removePredecessor(DI->getParent());
-  if (Unwind)
-    Unwind->removePredecessor(DI->getParent());
-  BranchInst *ReplacementBr = BranchInst::Create(Detached, DI);
-  ReplacementBr->setDebugLoc(DI->getDebugLoc());
-  DI->eraseFromParent();
-
-  // Update the dominator tree.
-  if (DT)
-    if (DT->dominates(Detacher, Continuation) && 1 == ReattachesFound)
-      DT->changeImmediateDominator(Continuation, SingleReattacher);
-
-  return ReplacementBr;
+                  &DetachedRethrows, ReplaceWithTaskFrame, DT);
 }
 
 static bool isCanonicalTaskFrameEnd(const Instruction *TFEnd) {

--- a/llvm/test/Transforms/Tapir/dead-tapir-intrinsics.ll
+++ b/llvm/test/Transforms/Tapir/dead-tapir-intrinsics.ll
@@ -1,10 +1,10 @@
 ; Test that basic -O1 optimizations effectively remove Tapir
 ; instructions and intrinsics.
 ;
-; RUN: opt < %s -O1 -simplify-taskframes=false -S -o - | FileCheck %s --check-prefixes=CHECK,CHECK-NOTFSIMPLIFY
-; RUN: opt < %s -passes='default<O1>' -simplify-taskframes=false -S -o - | FileCheck %s --check-prefixes=CHECK,CHECK-NOTFSIMPLIFY
-; RUN: opt < %s -O1 -S -o - | FileCheck %s --check-prefixes=CHECK,CHECK-TFSIMPLIFY
-; RUN: opt < %s -passes='default<O1>' -S -o - | FileCheck %s --check-prefixes=CHECK,CHECK-TFSIMPLIFY
+; RUN: opt < %s -O1 -simplify-taskframes=false -S | FileCheck %s --check-prefixes=CHECK,CHECK-NOTFSIMPLIFY
+; RUN: opt < %s -passes='default<O1>' -simplify-taskframes=false -S | FileCheck %s --check-prefixes=CHECK,CHECK-NOTFSIMPLIFY
+; RUN: opt < %s -O1 -S | FileCheck %s --check-prefixes=CHECK,CHECK-TFSIMPLIFY
+; RUN: opt < %s -passes='default<O1>' -S | FileCheck %s --check-prefixes=CHECK,CHECK-TFSIMPLIFY
 
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
@@ -35,12 +35,19 @@ define dso_local void @_Z6parentl(i64 %x) #1 personality i8* bitcast (i32 (...)*
 ; CHECK-LABEL: define dso_local void @_Z6parentl(i64
 ; CHECK: %[[SYNCREG:.+]] = {{.*}}call token @llvm.syncregion.start()
 ; CHECK-NOT: call token @llvm.syncregion.start()
-; CHECK: call token @llvm.taskframe.create()
-; CHECK: call token @llvm.taskframe.create()
-; CHECK detach within %[[SYNCREG]]
 ; CHECK-NOTFSIMPLIFY: call token @llvm.taskframe.create()
+; CHECK-NOTFSIMPLIFY: call token @llvm.taskframe.create()
+; CHECK-NOTFSIMPLIFY: call token @llvm.taskframe.create()
+; CHECK-TFSIMPLIFY: call i8* @llvm.stacksave()
+; CHECK-TFSIMPLIFY: call i8* @llvm.stacksave()
+; CHECK-TFSIMPLIFY: call i8* @llvm.stacksave()
 ; CHECK-TFSIMPLIFY-NOT: call token @llvm.taskframe.create()
+; CHECK: call token @llvm.taskframe.create()
 ; CHECK detach within %[[SYNCREG]]
+; CHECK: call void @llvm.taskframe.use(token
+; CHECK detach within %[[SYNCREG]]
+; CHECK-NOTFSIMPLIFY: call void @llvm.taskframe.use(token
+; CHECK-TFSIMPLIFY-NOT: call void @llvm.taskframe.use(token
 entry:
   %this.addr.i122.i133.i32 = alloca %class.object.1*, align 8
   %exn.slot12.i124.i134.i33 = alloca i8*

--- a/llvm/test/Transforms/Tapir/loop-stripmine-epilog-taskframe.ll
+++ b/llvm/test/Transforms/Tapir/loop-stripmine-epilog-taskframe.ll
@@ -1,0 +1,540 @@
+; RUN: opt < %s -passes="loop-stripmine" -S | FileCheck %s
+
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+%"class.std::vector" = type { %"struct.std::_Vector_base" }
+%"struct.std::_Vector_base" = type { %"struct.std::_Vector_base<long, std::allocator<long>>::_Vector_impl" }
+%"struct.std::_Vector_base<long, std::allocator<long>>::_Vector_impl" = type { %"struct.std::_Vector_base<long, std::allocator<long>>::_Vector_impl_data" }
+%"struct.std::_Vector_base<long, std::allocator<long>>::_Vector_impl_data" = type { i64*, i64*, i64* }
+
+$_Z3sumIlEvRSt6vectorIT_SaIS1_EE = comdat any
+
+$_ZNSt6vectorIlSaIlEE17_M_realloc_insertIJRKlEEEvN9__gnu_cxx17__normal_iteratorIPlS1_EEDpOT_ = comdat any
+
+@.str = private unnamed_addr constant [26 x i8] c"vector::_M_realloc_insert\00", align 1
+@.str.1 = private unnamed_addr constant [38 x i8] c"sum_pos %ld\0Asum_neg %ld\0Asum_racy %ld\0A\00", align 1
+@str = private unnamed_addr constant [45 x i8] c"WARNING: sum_pos is not negation of sum_neg!\00", align 1
+
+; Function Attrs: norecurse uwtable
+define dso_local noundef i32 @main(i32 noundef %argc, i8** nocapture noundef readonly %argv) local_unnamed_addr #0 personality i8* bitcast (i32 (...)* @__gxx_personality_v0 to i8*) {
+entry:
+  %vec = alloca %"class.std::vector", align 8
+  %i = alloca i64, align 8
+  %cmp = icmp sgt i32 %argc, 1
+  br i1 %cmp, label %if.then, label %if.end
+
+if.then:                                          ; preds = %entry
+  %arrayidx = getelementptr inbounds i8*, i8** %argv, i64 1
+  %0 = load i8*, i8** %arrayidx, align 8, !tbaa !3
+  %call.i = call i64 @strtol(i8* nocapture noundef nonnull %0, i8** noundef null, i32 noundef 10) #20
+  br label %if.end
+
+if.end:                                           ; preds = %if.then, %entry
+  %n.0 = phi i64 [ %call.i, %if.then ], [ 10000, %entry ]
+  %1 = bitcast %"class.std::vector"* %vec to i8*
+  call void @llvm.lifetime.start.p0i8(i64 24, i8* nonnull %1) #20
+  call void @llvm.memset.p0i8.i64(i8* noundef nonnull align 8 dereferenceable(24) %1, i8 0, i64 24, i1 false) #20
+  %2 = bitcast i64* %i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %2) #20
+  store i64 0, i64* %i, align 8, !tbaa !7
+  %cmp114 = icmp sgt i64 %n.0, 0
+  br i1 %cmp114, label %for.body.lr.ph, label %for.cond.cleanup
+
+for.body.lr.ph:                                   ; preds = %if.end
+  %_M_finish.i = getelementptr inbounds %"class.std::vector", %"class.std::vector"* %vec, i64 0, i32 0, i32 0, i32 0, i32 1
+  %_M_end_of_storage.i = getelementptr inbounds %"class.std::vector", %"class.std::vector"* %vec, i64 0, i32 0, i32 0, i32 0, i32 2
+  br label %for.body
+
+for.cond.cleanup:                                 ; preds = %for.inc, %if.end
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %2) #20
+  invoke void @_Z3sumIlEvRSt6vectorIT_SaIS1_EE(%"class.std::vector"* noundef nonnull align 8 dereferenceable(24) %vec)
+          to label %invoke.cont3 unwind label %lpad2
+
+for.body:                                         ; preds = %for.body.lr.ph, %for.inc
+  %storemerge15 = phi i64 [ 0, %for.body.lr.ph ], [ %inc, %for.inc ]
+  %3 = load i64*, i64** %_M_finish.i, align 8, !tbaa !9
+  %4 = load i64*, i64** %_M_end_of_storage.i, align 8, !tbaa !11
+  %cmp.not.i = icmp eq i64* %3, %4
+  br i1 %cmp.not.i, label %if.else.i, label %if.then.i
+
+if.then.i:                                        ; preds = %for.body
+  store i64 %storemerge15, i64* %3, align 8, !tbaa !7
+  %incdec.ptr.i = getelementptr inbounds i64, i64* %3, i64 1
+  store i64* %incdec.ptr.i, i64** %_M_finish.i, align 8, !tbaa !9
+  br label %for.inc
+
+if.else.i:                                        ; preds = %for.body
+  invoke void @_ZNSt6vectorIlSaIlEE17_M_realloc_insertIJRKlEEEvN9__gnu_cxx17__normal_iteratorIPlS1_EEDpOT_(%"class.std::vector"* noundef nonnull align 8 dereferenceable(24) %vec, i64* %3, i64* noundef nonnull align 8 dereferenceable(8) %i)
+          to label %for.inc unwind label %lpad
+
+for.inc:                                          ; preds = %if.then.i, %if.else.i
+  %5 = load i64, i64* %i, align 8, !tbaa !7
+  %inc = add nsw i64 %5, 1
+  store i64 %inc, i64* %i, align 8, !tbaa !7
+  %cmp1 = icmp slt i64 %inc, %n.0
+  br i1 %cmp1, label %for.body, label %for.cond.cleanup, !llvm.loop !12
+
+lpad:                                             ; preds = %if.else.i
+  %6 = landingpad { i8*, i32 }
+          cleanup
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %2) #20
+  br label %ehcleanup
+
+invoke.cont3:                                     ; preds = %for.cond.cleanup
+  %_M_start.i.i = getelementptr inbounds %"class.std::vector", %"class.std::vector"* %vec, i64 0, i32 0, i32 0, i32 0, i32 0
+  %7 = load i64*, i64** %_M_start.i.i, align 8, !tbaa !15
+  %tobool.not.i.i.i = icmp eq i64* %7, null
+  br i1 %tobool.not.i.i.i, label %_ZNSt6vectorIlSaIlEED2Ev.exit, label %if.then.i.i.i
+
+if.then.i.i.i:                                    ; preds = %invoke.cont3
+  %8 = bitcast i64* %7 to i8*
+  call void @_ZdlPv(i8* noundef %8) #21
+  br label %_ZNSt6vectorIlSaIlEED2Ev.exit
+
+_ZNSt6vectorIlSaIlEED2Ev.exit:                    ; preds = %invoke.cont3, %if.then.i.i.i
+  call void @llvm.lifetime.end.p0i8(i64 24, i8* nonnull %1) #20
+  ret i32 0
+
+lpad2:                                            ; preds = %for.cond.cleanup
+  %9 = landingpad { i8*, i32 }
+          cleanup
+  br label %ehcleanup
+
+ehcleanup:                                        ; preds = %lpad2, %lpad
+  %.pn = phi { i8*, i32 } [ %6, %lpad ], [ %9, %lpad2 ]
+  %_M_start.i.i10 = getelementptr inbounds %"class.std::vector", %"class.std::vector"* %vec, i64 0, i32 0, i32 0, i32 0, i32 0
+  %10 = load i64*, i64** %_M_start.i.i10, align 8, !tbaa !15
+  %tobool.not.i.i.i11 = icmp eq i64* %10, null
+  br i1 %tobool.not.i.i.i11, label %_ZNSt6vectorIlSaIlEED2Ev.exit13, label %if.then.i.i.i12
+
+if.then.i.i.i12:                                  ; preds = %ehcleanup
+  %11 = bitcast i64* %10 to i8*
+  call void @_ZdlPv(i8* noundef %11) #21
+  br label %_ZNSt6vectorIlSaIlEED2Ev.exit13
+
+_ZNSt6vectorIlSaIlEED2Ev.exit13:                  ; preds = %ehcleanup, %if.then.i.i.i12
+  call void @llvm.lifetime.end.p0i8(i64 24, i8* nonnull %1) #20
+  resume { i8*, i32 } %.pn
+}
+
+; Function Attrs: argmemonly mustprogress nofree nosync nounwind willreturn
+declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #1
+
+declare dso_local i32 @__gxx_personality_v0(...)
+
+; Function Attrs: argmemonly mustprogress nofree nosync nounwind willreturn
+declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #1
+
+; Function Attrs: mustprogress uwtable
+define linkonce_odr dso_local void @_Z3sumIlEvRSt6vectorIT_SaIS1_EE(%"class.std::vector"* noundef nonnull align 8 dereferenceable(24) %v) local_unnamed_addr #2 comdat personality i8* bitcast (i32 (...)* @__gxx_personality_v0 to i8*) {
+entry:
+  %sum_racy = alloca i64, align 8
+  %sum_pos = alloca i64, align 8
+  %sum_neg = alloca i64, align 8
+  %syncreg = call token @llvm.syncregion.start()
+  %sum_racy.0.sum_racy.0.sum_racy.0..sroa_cast = bitcast i64* %sum_racy to i8*
+  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %sum_racy.0.sum_racy.0.sum_racy.0..sroa_cast)
+  store i64 0, i64* %sum_racy, align 8, !tbaa !7
+  %0 = bitcast i64* %sum_pos to i8*
+  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %0) #20
+  store i64 0, i64* %sum_pos, align 8, !tbaa !7
+  call void @llvm.reducer.register.i64(i8* nonnull %0, i64 8, i8* bitcast (void (i8*)* @_ZN4cilkL4zeroIlEEvPv to i8*), i8* bitcast (void (i8*, i8*)* @_ZN4cilkL4plusIlEEvPvS1_ to i8*))
+  %1 = bitcast i64* %sum_neg to i8*
+  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %1) #20
+  store i64 0, i64* %sum_neg, align 8, !tbaa !7
+  call void @llvm.reducer.register.i64(i8* nonnull %1, i64 8, i8* bitcast (void (i8*)* @_ZN4cilkL4zeroIlEEvPv to i8*), i8* bitcast (void (i8*, i8*)* @_ZN4cilkL4plusIlEEvPvS1_ to i8*))
+  %_M_finish.i = getelementptr inbounds %"class.std::vector", %"class.std::vector"* %v, i64 0, i32 0, i32 0, i32 0, i32 1
+  %2 = load i64*, i64** %_M_finish.i, align 8, !tbaa !9
+  %_M_start.i = getelementptr inbounds %"class.std::vector", %"class.std::vector"* %v, i64 0, i32 0, i32 0, i32 0, i32 0
+  %3 = load i64*, i64** %_M_start.i, align 8, !tbaa !15
+  %sub.ptr.lhs.cast.i = ptrtoint i64* %2 to i64
+  %sub.ptr.rhs.cast.i = ptrtoint i64* %3 to i64
+  %sub.ptr.sub.i = sub i64 %sub.ptr.lhs.cast.i, %sub.ptr.rhs.cast.i
+  %cmp = icmp sgt i64 %sub.ptr.sub.i, 0
+  br i1 %cmp, label %pfor.cond.preheader, label %cleanup
+
+pfor.cond.preheader:                              ; preds = %entry
+  %sub.ptr.div.i = ashr i64 %sub.ptr.sub.i, 3
+  %smax = call i64 @llvm.smax.i64(i64 %sub.ptr.div.i, i64 1)
+  br label %pfor.cond
+
+; CHECK: pfor.cond.preheader:
+; CHECK: %[[ICMP:.+]] = icmp ult i64
+; CHECK-NEXT: br i1 %[[ICMP]], label %[[EPIL_CHECK:.+]], label %[[PLOOP_START:.+]]
+
+; CHECK: [[EPIL_CHECK]]:
+; CHECK: %[[ICMP_XTRA:.+]] = icmp ne i64
+; CHECK-NEXT: br i1 %[[ICMP_XTRA]], label %[[EPIL_PH:.+]], label %pfor.cond.cleanup
+
+; CHECK: [[EPIL_PH]]:
+; CHECK: br label %[[EPIL_HEAD:.+]]
+
+; CHECK: [[EPIL_HEAD]]:
+; CHECK: br label %[[EPIL_BODY_ENTRY:.+]]
+
+; CHECK: [[EPIL_BODY_ENTRY]]:
+; CHECK-NEXT: %[[REPLTF:.+]] = call token @llvm.taskframe.create()
+
+; CHECK: detach within %[[SYNCREG_EPIL:.+]], label %[[EPIL_DETACHED:.+]], label %[[EPIL_DETCONT:.+]]
+
+; CHECK: [[EPIL_DETCONT]]:
+; CHECK: sync within %[[SYNCREG_EPIL]], label %[[SYNC_CONT_EPIL:.+]]
+
+; CHECK: [[SYNC_CONT_EPIL]]:
+; CHECK-NEXT: invoke void @llvm.sync.unwind(token %[[SYNCREG_EPIL]])
+; CHECK-NEXT: to label %[[EPIL_PREATTACH:.+]] unwind label %[[EPIL_LPAD:.+]]
+
+; CHECK: [[EPIL_PREATTACH]]:
+; CHECK-NEXT: call void @llvm.taskframe.end(token %[[REPLTF]])
+; CHECK-NEXT: br label %[[EPIL_INC:.+]]
+
+; CHECK: [[EPIL_LPAD]]:
+; CHECK-NEXT: %[[LANDINGPAD:.+]] = landingpad
+; CHECK-NEXT: cleanup
+; CHECK-NEXT: invoke void @llvm.taskframe.resume.sl_p0i8i32s(token %[[REPLTF]], { i8*, i32 } %[[LANDINGPAD]])
+; CHECK-NEXT: to label %[[UNREACHABLE:.+]] unwind label %[[DETLOOP_UNWIND:.+]]
+
+pfor.cond:                                        ; preds = %pfor.cond.preheader, %pfor.inc
+  %__begin.0 = phi i64 [ %inc, %pfor.inc ], [ 0, %pfor.cond.preheader ]
+  detach within %syncreg, label %pfor.body.entry, label %pfor.inc unwind label %lpad17.loopexit
+
+pfor.body.entry:                                  ; preds = %pfor.cond
+  %syncreg3 = call token @llvm.syncregion.start()
+  br label %pfor.body
+
+pfor.body:                                        ; preds = %pfor.body.entry
+  detach within %syncreg3, label %det.achd, label %det.cont
+
+det.achd:                                         ; preds = %pfor.body
+  %add.ptr.i = getelementptr inbounds i64, i64* %3, i64 %__begin.0
+  %4 = load i64, i64* %add.ptr.i, align 8, !tbaa !7
+  %sum_racy.0.load = load i64, i64* %sum_racy, align 8
+  %add5 = add nsw i64 %sum_racy.0.load, %4
+  store i64 %add5, i64* %sum_racy, align 8, !tbaa !7
+  %5 = call i8* @llvm.hyper.lookup.i64(i8* nonnull %0, i64 8, i8* bitcast (void (i8*)* @_ZN4cilkL4zeroIlEEvPv to i8*), i8* bitcast (void (i8*, i8*)* @_ZN4cilkL4plusIlEEvPvS1_ to i8*))
+  %6 = bitcast i8* %5 to i64*
+  %7 = load i64, i64* %6, align 8, !tbaa !7
+  %add7 = add nsw i64 %7, %4
+  store i64 %add7, i64* %6, align 8, !tbaa !7
+  %8 = load i64, i64* %add.ptr.i, align 8, !tbaa !7
+  %9 = call i8* @llvm.hyper.lookup.i64(i8* nonnull %1, i64 8, i8* bitcast (void (i8*)* @_ZN4cilkL4zeroIlEEvPv to i8*), i8* bitcast (void (i8*, i8*)* @_ZN4cilkL4plusIlEEvPvS1_ to i8*))
+  %10 = bitcast i8* %9 to i64*
+  %11 = load i64, i64* %10, align 8, !tbaa !7
+  %sub9 = sub nsw i64 %11, %8
+  store i64 %sub9, i64* %10, align 8, !tbaa !7
+  reattach within %syncreg3, label %det.cont
+
+det.cont:                                         ; preds = %det.achd, %pfor.body
+  %add.ptr.i79 = getelementptr inbounds i64, i64* %3, i64 %__begin.0
+  %12 = load i64, i64* %add.ptr.i79, align 8, !tbaa !7
+  %sum_racy.0.load91 = load i64, i64* %sum_racy, align 8
+  %add11 = add nsw i64 %sum_racy.0.load91, %12
+  store i64 %add11, i64* %sum_racy, align 8, !tbaa !7
+  %13 = call i8* @llvm.hyper.lookup.i64(i8* nonnull %0, i64 8, i8* bitcast (void (i8*)* @_ZN4cilkL4zeroIlEEvPv to i8*), i8* bitcast (void (i8*, i8*)* @_ZN4cilkL4plusIlEEvPvS1_ to i8*))
+  %14 = bitcast i8* %13 to i64*
+  %15 = load i64, i64* %14, align 8, !tbaa !7
+  %add13 = add nsw i64 %15, %12
+  store i64 %add13, i64* %14, align 8, !tbaa !7
+  %16 = load i64, i64* %add.ptr.i79, align 8, !tbaa !7
+  %17 = call i8* @llvm.hyper.lookup.i64(i8* nonnull %1, i64 8, i8* bitcast (void (i8*)* @_ZN4cilkL4zeroIlEEvPv to i8*), i8* bitcast (void (i8*, i8*)* @_ZN4cilkL4plusIlEEvPvS1_ to i8*))
+  %18 = bitcast i8* %17 to i64*
+  %19 = load i64, i64* %18, align 8, !tbaa !7
+  %sub15 = sub nsw i64 %19, %16
+  store i64 %sub15, i64* %18, align 8, !tbaa !7
+  sync within %syncreg3, label %sync.continue
+
+sync.continue:                                    ; preds = %det.cont
+  invoke void @llvm.sync.unwind(token %syncreg3)
+          to label %pfor.preattach unwind label %lpad
+
+pfor.preattach:                                   ; preds = %sync.continue
+  reattach within %syncreg, label %pfor.inc
+
+pfor.inc:                                         ; preds = %pfor.cond, %pfor.preattach
+  %inc = add nuw nsw i64 %__begin.0, 1
+  %exitcond.not = icmp eq i64 %inc, %smax
+  br i1 %exitcond.not, label %pfor.cond.cleanup, label %pfor.cond, !llvm.loop !16
+
+pfor.cond.cleanup:                                ; preds = %pfor.inc
+  sync within %syncreg, label %sync.continue21
+
+lpad:                                             ; preds = %sync.continue
+  %20 = landingpad { i8*, i32 }
+          cleanup
+  invoke void @llvm.detached.rethrow.sl_p0i8i32s(token %syncreg, { i8*, i32 } %20)
+          to label %unreachable unwind label %lpad17.loopexit
+
+lpad17.loopexit:                                  ; preds = %lpad, %pfor.cond
+  %lpad.loopexit = landingpad { i8*, i32 }
+          cleanup
+  br label %lpad17
+
+lpad17.loopexit.split-lp:                         ; preds = %sync.continue21
+  %lpad.loopexit.split-lp = landingpad { i8*, i32 }
+          cleanup
+  br label %lpad17
+
+lpad17:                                           ; preds = %lpad17.loopexit.split-lp, %lpad17.loopexit
+  %lpad.phi = phi { i8*, i32 } [ %lpad.loopexit, %lpad17.loopexit ], [ %lpad.loopexit.split-lp, %lpad17.loopexit.split-lp ]
+  call void @llvm.reducer.unregister(i8* nonnull %1)
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %1) #20
+  call void @llvm.reducer.unregister(i8* nonnull %0)
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %0) #20
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %sum_racy.0.sum_racy.0.sum_racy.0..sroa_cast)
+  resume { i8*, i32 } %lpad.phi
+
+sync.continue21:                                  ; preds = %pfor.cond.cleanup
+  invoke void @llvm.sync.unwind(token %syncreg)
+          to label %cleanup unwind label %lpad17.loopexit.split-lp
+
+cleanup:                                          ; preds = %sync.continue21, %entry
+  %21 = call i8* @llvm.hyper.lookup.i64(i8* nonnull %0, i64 8, i8* bitcast (void (i8*)* @_ZN4cilkL4zeroIlEEvPv to i8*), i8* bitcast (void (i8*, i8*)* @_ZN4cilkL4plusIlEEvPvS1_ to i8*))
+  %22 = bitcast i8* %21 to i64*
+  %23 = load i64, i64* %22, align 8, !tbaa !7
+  %24 = call i8* @llvm.hyper.lookup.i64(i8* nonnull %1, i64 8, i8* bitcast (void (i8*)* @_ZN4cilkL4zeroIlEEvPv to i8*), i8* bitcast (void (i8*, i8*)* @_ZN4cilkL4plusIlEEvPvS1_ to i8*))
+  %25 = bitcast i8* %24 to i64*
+  %26 = load i64, i64* %25, align 8, !tbaa !7
+  %sum_racy.0.load92 = load i64, i64* %sum_racy, align 8
+  %call29 = call i32 (i8*, ...) @printf(i8* noundef nonnull dereferenceable(1) getelementptr inbounds ([38 x i8], [38 x i8]* @.str.1, i64 0, i64 0), i64 noundef %23, i64 noundef %26, i64 noundef %sum_racy.0.load92)
+  %27 = load i64, i64* %22, align 8, !tbaa !7
+  %28 = load i64, i64* %25, align 8, !tbaa !7
+  %sub30 = sub nsw i64 0, %28
+  %cmp31.not = icmp eq i64 %27, %sub30
+  br i1 %cmp31.not, label %if.end, label %if.then
+
+if.then:                                          ; preds = %cleanup
+  %puts = call i32 @puts(i8* nonnull dereferenceable(1) getelementptr inbounds ([45 x i8], [45 x i8]* @str, i64 0, i64 0))
+  br label %if.end
+
+if.end:                                           ; preds = %if.then, %cleanup
+  call void @llvm.reducer.unregister(i8* nonnull %1)
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %1) #20
+  call void @llvm.reducer.unregister(i8* nonnull %0)
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %0) #20
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %sum_racy.0.sum_racy.0.sum_racy.0..sroa_cast)
+  ret void
+
+unreachable:                                      ; preds = %lpad
+  unreachable
+}
+
+; Function Attrs: mustprogress nofree nounwind willreturn
+declare dso_local i64 @strtol(i8* noundef readonly, i8** nocapture noundef, i32 noundef) local_unnamed_addr #3
+
+; Function Attrs: nobuiltin nounwind
+declare dso_local void @_ZdlPv(i8* noundef) local_unnamed_addr #4
+
+; Function Attrs: uwtable
+define linkonce_odr dso_local void @_ZNSt6vectorIlSaIlEE17_M_realloc_insertIJRKlEEEvN9__gnu_cxx17__normal_iteratorIPlS1_EEDpOT_(%"class.std::vector"* noundef nonnull align 8 dereferenceable(24) %this, i64* %__position.coerce, i64* noundef nonnull align 8 dereferenceable(8) %__args) local_unnamed_addr #5 comdat align 2 personality i32 (...)* @__gxx_personality_v0 {
+entry:
+  %_M_finish.i.i = getelementptr inbounds %"class.std::vector", %"class.std::vector"* %this, i64 0, i32 0, i32 0, i32 0, i32 1
+  %0 = load i64*, i64** %_M_finish.i.i, align 8, !tbaa !9
+  %_M_start.i.i = getelementptr inbounds %"class.std::vector", %"class.std::vector"* %this, i64 0, i32 0, i32 0, i32 0, i32 0
+  %1 = load i64*, i64** %_M_start.i.i, align 8, !tbaa !15
+  %sub.ptr.lhs.cast.i.i = ptrtoint i64* %0 to i64
+  %sub.ptr.rhs.cast.i.i = ptrtoint i64* %1 to i64
+  %sub.ptr.sub.i.i = sub i64 %sub.ptr.lhs.cast.i.i, %sub.ptr.rhs.cast.i.i
+  %sub.ptr.div.i.i = ashr exact i64 %sub.ptr.sub.i.i, 3
+  %cmp.i = icmp eq i64 %sub.ptr.sub.i.i, 9223372036854775800
+  br i1 %cmp.i, label %if.then.i, label %_ZNKSt6vectorIlSaIlEE12_M_check_lenEmPKc.exit
+
+if.then.i:                                        ; preds = %entry
+  call void @_ZSt20__throw_length_errorPKc(i8* noundef getelementptr inbounds ([26 x i8], [26 x i8]* @.str, i64 0, i64 0)) #22
+  unreachable
+
+_ZNKSt6vectorIlSaIlEE12_M_check_lenEmPKc.exit:    ; preds = %entry
+  %cmp.i.i = icmp eq i64 %sub.ptr.sub.i.i, 0
+  %.sroa.speculated.i = select i1 %cmp.i.i, i64 1, i64 %sub.ptr.div.i.i
+  %add.i = add nsw i64 %.sroa.speculated.i, %sub.ptr.div.i.i
+  %cmp7.i = icmp ult i64 %add.i, %sub.ptr.div.i.i
+  %cmp9.i = icmp ugt i64 %add.i, 1152921504606846975
+  %or.cond.i = or i1 %cmp7.i, %cmp9.i
+  %cond.i = select i1 %or.cond.i, i64 1152921504606846975, i64 %add.i
+  %sub.ptr.lhs.cast.i = ptrtoint i64* %__position.coerce to i64
+  %sub.ptr.sub.i = sub i64 %sub.ptr.lhs.cast.i, %sub.ptr.rhs.cast.i.i
+  %sub.ptr.div.i = ashr exact i64 %sub.ptr.sub.i, 3
+  %cmp.not.i = icmp eq i64 %cond.i, 0
+  br i1 %cmp.not.i, label %_ZNSt12_Vector_baseIlSaIlEE11_M_allocateEm.exit, label %cond.true.i
+
+cond.true.i:                                      ; preds = %_ZNKSt6vectorIlSaIlEE12_M_check_lenEmPKc.exit
+  %cmp.i.i.i = icmp ugt i64 %cond.i, 1152921504606846975
+  br i1 %cmp.i.i.i, label %if.then.i.i.i, label %_ZNSt16allocator_traitsISaIlEE8allocateERS0_m.exit.i, !prof !19
+
+if.then.i.i.i:                                    ; preds = %cond.true.i
+  %cmp2.i.i.i = icmp ugt i64 %cond.i, 2305843009213693951
+  br i1 %cmp2.i.i.i, label %if.then3.i.i.i, label %if.end.i.i.i
+
+if.then3.i.i.i:                                   ; preds = %if.then.i.i.i
+  call void @_ZSt28__throw_bad_array_new_lengthv() #22
+  unreachable
+
+if.end.i.i.i:                                     ; preds = %if.then.i.i.i
+  call void @_ZSt17__throw_bad_allocv() #22
+  unreachable
+
+_ZNSt16allocator_traitsISaIlEE8allocateERS0_m.exit.i: ; preds = %cond.true.i
+  %mul.i.i.i = shl i64 %cond.i, 3
+  %call5.i.i.i = call noalias noundef nonnull i8* @_Znwm(i64 noundef %mul.i.i.i) #23
+  %2 = bitcast i8* %call5.i.i.i to i64*
+  br label %_ZNSt12_Vector_baseIlSaIlEE11_M_allocateEm.exit
+
+_ZNSt12_Vector_baseIlSaIlEE11_M_allocateEm.exit:  ; preds = %_ZNKSt6vectorIlSaIlEE12_M_check_lenEmPKc.exit, %_ZNSt16allocator_traitsISaIlEE8allocateERS0_m.exit.i
+  %cond.i38 = phi i64* [ %2, %_ZNSt16allocator_traitsISaIlEE8allocateERS0_m.exit.i ], [ null, %_ZNKSt6vectorIlSaIlEE12_M_check_lenEmPKc.exit ]
+  %add.ptr = getelementptr inbounds i64, i64* %cond.i38, i64 %sub.ptr.div.i
+  %3 = load i64, i64* %__args, align 8, !tbaa !7
+  store i64 %3, i64* %add.ptr, align 8, !tbaa !7
+  %cmp.i.i.i.i = icmp sgt i64 %sub.ptr.sub.i, 0
+  br i1 %cmp.i.i.i.i, label %if.then.i.i.i.i, label %_ZNSt6vectorIlSaIlEE11_S_relocateEPlS2_S2_RS0_.exit
+
+if.then.i.i.i.i:                                  ; preds = %_ZNSt12_Vector_baseIlSaIlEE11_M_allocateEm.exit
+  %4 = bitcast i64* %cond.i38 to i8*
+  %5 = bitcast i64* %1 to i8*
+  call void @llvm.memmove.p0i8.p0i8.i64(i8* align 8 %4, i8* align 8 %5, i64 %sub.ptr.sub.i, i1 false) #20
+  br label %_ZNSt6vectorIlSaIlEE11_S_relocateEPlS2_S2_RS0_.exit
+
+_ZNSt6vectorIlSaIlEE11_S_relocateEPlS2_S2_RS0_.exit: ; preds = %_ZNSt12_Vector_baseIlSaIlEE11_M_allocateEm.exit, %if.then.i.i.i.i
+  %incdec.ptr = getelementptr inbounds i64, i64* %add.ptr, i64 1
+  %sub.ptr.sub.i.i.i.i42 = sub i64 %sub.ptr.lhs.cast.i.i, %sub.ptr.lhs.cast.i
+  %cmp.i.i.i.i43 = icmp sgt i64 %sub.ptr.sub.i.i.i.i42, 0
+  br i1 %cmp.i.i.i.i43, label %if.then.i.i.i.i44, label %_ZNSt6vectorIlSaIlEE11_S_relocateEPlS2_S2_RS0_.exit47
+
+if.then.i.i.i.i44:                                ; preds = %_ZNSt6vectorIlSaIlEE11_S_relocateEPlS2_S2_RS0_.exit
+  %6 = bitcast i64* %incdec.ptr to i8*
+  %7 = bitcast i64* %__position.coerce to i8*
+  call void @llvm.memmove.p0i8.p0i8.i64(i8* nonnull align 8 %6, i8* align 8 %7, i64 %sub.ptr.sub.i.i.i.i42, i1 false) #20
+  br label %_ZNSt6vectorIlSaIlEE11_S_relocateEPlS2_S2_RS0_.exit47
+
+_ZNSt6vectorIlSaIlEE11_S_relocateEPlS2_S2_RS0_.exit47: ; preds = %_ZNSt6vectorIlSaIlEE11_S_relocateEPlS2_S2_RS0_.exit, %if.then.i.i.i.i44
+  %tobool.not.i = icmp eq i64* %1, null
+  br i1 %tobool.not.i, label %_ZNSt12_Vector_baseIlSaIlEE13_M_deallocateEPlm.exit, label %if.then.i48
+
+if.then.i48:                                      ; preds = %_ZNSt6vectorIlSaIlEE11_S_relocateEPlS2_S2_RS0_.exit47
+  %8 = bitcast i64* %1 to i8*
+  call void @_ZdlPv(i8* noundef %8) #21
+  br label %_ZNSt12_Vector_baseIlSaIlEE13_M_deallocateEPlm.exit
+
+_ZNSt12_Vector_baseIlSaIlEE13_M_deallocateEPlm.exit: ; preds = %_ZNSt6vectorIlSaIlEE11_S_relocateEPlS2_S2_RS0_.exit47, %if.then.i48
+  %_M_end_of_storage = getelementptr inbounds %"class.std::vector", %"class.std::vector"* %this, i64 0, i32 0, i32 0, i32 0, i32 2
+  %sub.ptr.div.i.i.i.i45 = ashr exact i64 %sub.ptr.sub.i.i.i.i42, 3
+  %add.ptr.i.i.i.i46 = getelementptr inbounds i64, i64* %incdec.ptr, i64 %sub.ptr.div.i.i.i.i45
+  store i64* %cond.i38, i64** %_M_start.i.i, align 8, !tbaa !15
+  store i64* %add.ptr.i.i.i.i46, i64** %_M_finish.i.i, align 8, !tbaa !9
+  %add.ptr20 = getelementptr inbounds i64, i64* %cond.i38, i64 %cond.i
+  store i64* %add.ptr20, i64** %_M_end_of_storage, align 8, !tbaa !11
+  ret void
+}
+
+; Function Attrs: noreturn
+declare dso_local void @_ZSt20__throw_length_errorPKc(i8* noundef) local_unnamed_addr #6
+
+; Function Attrs: noreturn
+declare dso_local void @_ZSt28__throw_bad_array_new_lengthv() local_unnamed_addr #6
+
+; Function Attrs: noreturn
+declare dso_local void @_ZSt17__throw_bad_allocv() local_unnamed_addr #6
+
+; Function Attrs: nobuiltin allocsize(0)
+declare dso_local noundef nonnull i8* @_Znwm(i64 noundef) local_unnamed_addr #7
+
+; Function Attrs: argmemonly mustprogress nofree nounwind willreturn
+declare void @llvm.memmove.p0i8.p0i8.i64(i8* nocapture writeonly, i8* nocapture readonly, i64, i1 immarg) #8
+
+; Function Attrs: argmemonly mustprogress nofree norecurse nosync nounwind uwtable willreturn writeonly
+define internal void @_ZN4cilkL4zeroIlEEvPv(i8* nocapture noundef writeonly %v) #9 {
+entry:
+  %0 = bitcast i8* %v to i64*
+  store i64 0, i64* %0, align 8, !tbaa !7
+  ret void
+}
+
+; Function Attrs: argmemonly mustprogress nofree norecurse nosync nounwind uwtable willreturn
+define internal void @_ZN4cilkL4plusIlEEvPvS1_(i8* nocapture noundef %l, i8* nocapture noundef readonly %r) #10 {
+entry:
+  %0 = bitcast i8* %r to i64*
+  %1 = load i64, i64* %0, align 8, !tbaa !7
+  %2 = bitcast i8* %l to i64*
+  %3 = load i64, i64* %2, align 8, !tbaa !7
+  %add = add nsw i64 %3, %1
+  store i64 %add, i64* %2, align 8, !tbaa !7
+  ret void
+}
+
+; Function Attrs: inaccessiblememonly mustprogress nounwind reducer_register willreturn
+declare void @llvm.reducer.register.i64(i8*, i64, i8*, i8*) #11
+
+; Function Attrs: argmemonly mustprogress nounwind willreturn
+declare token @llvm.syncregion.start() #12
+
+; Function Attrs: hyper_view inaccessiblememonly injective mustprogress nofree nounwind readonly strand_pure willreturn
+declare i8* @llvm.hyper.lookup.i64(i8*, i64, i8*, i8*) #13
+
+; Function Attrs: argmemonly mustprogress willreturn
+declare void @llvm.sync.unwind(token) #14
+
+; Function Attrs: argmemonly mustprogress willreturn
+declare void @llvm.detached.rethrow.sl_p0i8i32s(token, { i8*, i32 }) #14
+
+; Function Attrs: nofree nounwind
+declare dso_local noundef i32 @printf(i8* nocapture noundef readonly, ...) local_unnamed_addr #15
+
+; Function Attrs: inaccessiblememonly mustprogress nounwind reducer_unregister willreturn
+declare void @llvm.reducer.unregister(i8*) #16
+
+; Function Attrs: nofree nounwind
+declare noundef i32 @puts(i8* nocapture noundef readonly) local_unnamed_addr #17
+
+; Function Attrs: argmemonly nofree nounwind willreturn writeonly
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #18
+
+; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
+declare i64 @llvm.smax.i64(i64, i64) #19
+
+attributes #0 = { norecurse uwtable "frame-pointer"="none" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #1 = { argmemonly mustprogress nofree nosync nounwind willreturn }
+attributes #2 = { mustprogress uwtable "frame-pointer"="none" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #3 = { mustprogress nofree nounwind willreturn "frame-pointer"="none" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #4 = { nobuiltin nounwind "frame-pointer"="none" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #5 = { uwtable "frame-pointer"="none" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #6 = { noreturn "frame-pointer"="none" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #7 = { nobuiltin allocsize(0) "frame-pointer"="none" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #8 = { argmemonly mustprogress nofree nounwind willreturn }
+attributes #9 = { argmemonly mustprogress nofree norecurse nosync nounwind uwtable willreturn writeonly "frame-pointer"="none" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #10 = { argmemonly mustprogress nofree norecurse nosync nounwind uwtable willreturn "frame-pointer"="none" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #11 = { inaccessiblememonly mustprogress nounwind reducer_register willreturn }
+attributes #12 = { argmemonly mustprogress nounwind willreturn }
+attributes #13 = { hyper_view inaccessiblememonly injective mustprogress nofree nounwind readonly strand_pure willreturn }
+attributes #14 = { argmemonly mustprogress willreturn }
+attributes #15 = { nofree nounwind "frame-pointer"="none" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #16 = { inaccessiblememonly mustprogress nounwind reducer_unregister willreturn }
+attributes #17 = { nofree nounwind }
+attributes #18 = { argmemonly nofree nounwind willreturn writeonly }
+attributes #19 = { nofree nosync nounwind readnone speculatable willreturn }
+attributes #20 = { nounwind }
+attributes #21 = { builtin nounwind }
+attributes #22 = { noreturn }
+attributes #23 = { builtin allocsize(0) }
+
+!llvm.module.flags = !{!0, !1}
+!llvm.ident = !{!2}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 7, !"uwtable", i32 1}
+!2 = !{!"clang version 14.0.6 (git@github.com:OpenCilk/opencilk-project.git 5f6bec7c28155ec1f1ae0efebdb5cec40d39fda1)"}
+!3 = !{!4, !4, i64 0}
+!4 = !{!"any pointer", !5, i64 0}
+!5 = !{!"omnipotent char", !6, i64 0}
+!6 = !{!"Simple C++ TBAA"}
+!7 = !{!8, !8, i64 0}
+!8 = !{!"long", !5, i64 0}
+!9 = !{!10, !4, i64 8}
+!10 = !{!"_ZTSNSt12_Vector_baseIlSaIlEE17_Vector_impl_dataE", !4, i64 0, !4, i64 8, !4, i64 16}
+!11 = !{!10, !4, i64 16}
+!12 = distinct !{!12, !13, !14}
+!13 = !{!"llvm.loop.mustprogress"}
+!14 = !{!"llvm.loop.unroll.disable"}
+!15 = !{!10, !4, i64 0}
+!16 = distinct !{!16, !17, !18, !14}
+!17 = !{!"tapir.loop.spawn.strategy", i32 1}
+!18 = !{!"tapir.loop.grainsize", i32 64}
+!19 = !{!"branch_weights", i32 1, i32 2000}

--- a/llvm/test/Transforms/Tapir/tapir-runtime-merge.ll
+++ b/llvm/test/Transforms/Tapir/tapir-runtime-merge.ll
@@ -1,0 +1,178 @@
+; RUN: opt < %s -passes="instcombine" -S | FileCheck %s
+
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+%struct.timeval = type { i64, i64 }
+
+@A = dso_local global [1024 x [1024 x double]] zeroinitializer, align 16
+@B = dso_local global [1024 x [1024 x double]] zeroinitializer, align 16
+@C = dso_local global [1024 x [1024 x double]] zeroinitializer, align 16
+@.str = private unnamed_addr constant [7 x i8] c"%0.6f\0A\00", align 1
+
+; Function Attrs: mustprogress nofree nosync nounwind readnone speculatable willreturn
+declare double @llvm.fmuladd.f64(double, double, double) #1
+
+; Function Attrs: nounwind uwtable
+declare dso_local void @mmbase(double* noalias noundef %C, double* noundef %A, double* noundef %B, i32 noundef %size) local_unnamed_addr #0
+
+; Function Attrs: argmemonly mustprogress nofree nosync nounwind willreturn
+declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #2
+
+; Function Attrs: argmemonly mustprogress nofree nosync nounwind willreturn
+declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #2
+
+; Function Attrs: nounwind uwtable
+define dso_local void @mmdac(double* noalias noundef %C, double* noundef %A, double* noundef %B, i32 noundef %size) local_unnamed_addr #0 {
+entry:
+  %syncreg = call token @llvm.syncregion.start()
+  %syncreg36 = call token @llvm.syncregion.start()
+  %cmp = icmp sle i32 %size, 32
+  br i1 %cmp, label %if.then, label %if.else
+
+if.then:                                          ; preds = %entry
+  call void @mmbase(double* noundef %C, double* noundef %A, double* noundef %B, i32 noundef %size)
+  br label %if.end
+
+if.else:                                          ; preds = %entry
+  %div = sdiv i32 %size, 2
+  %mul = mul nsw i32 %div, 1024
+  %mul3 = mul nsw i32 %div, 1025
+  %0 = call token @llvm.tapir.runtime.start()
+  %1 = call token @llvm.taskframe.create()
+  detach within %syncreg, label %det.achd, label %det.cont
+
+det.achd:                                         ; preds = %if.else
+  call void @llvm.taskframe.use(token %1)
+  call void @mmdac(double* noundef %C, double* noundef %A, double* noundef %B, i32 noundef %div)
+  reattach within %syncreg, label %det.cont
+
+det.cont:                                         ; preds = %det.achd, %if.else
+  %2 = call token @llvm.taskframe.create()
+  %3 = zext i32 %div to i64
+  %add.ptr10 = getelementptr inbounds double, double* %C, i64 %3
+  %add.ptr14 = getelementptr inbounds double, double* %B, i64 %3
+  detach within %syncreg, label %det.achd16, label %det.cont17
+
+det.achd16:                                       ; preds = %det.cont
+  call void @llvm.taskframe.use(token %2)
+  call void @mmdac(double* noundef %add.ptr10, double* noundef %A, double* noundef %add.ptr14, i32 noundef %div)
+  reattach within %syncreg, label %det.cont17
+
+det.cont17:                                       ; preds = %det.achd16, %det.cont
+  %4 = call token @llvm.taskframe.create()
+  %idx.ext18 = sext i32 %mul to i64
+  %add.ptr19 = getelementptr inbounds double, double* %C, i64 %idx.ext18
+  %add.ptr21 = getelementptr inbounds double, double* %A, i64 %idx.ext18
+  detach within %syncreg, label %det.achd25, label %det.cont26
+
+det.achd25:                                       ; preds = %det.cont17
+  call void @llvm.taskframe.use(token %4)
+  call void @mmdac(double* noundef %add.ptr19, double* noundef %add.ptr21, double* noundef %B, i32 noundef %div)
+  reattach within %syncreg, label %det.cont26
+
+det.cont26:                                       ; preds = %det.achd25, %det.cont17
+  %idx.ext27 = sext i32 %mul3 to i64
+  %add.ptr28 = getelementptr inbounds double, double* %C, i64 %idx.ext27
+  call void @mmdac(double* noundef %add.ptr28, double* noundef %add.ptr21, double* noundef %add.ptr14, i32 noundef %div)
+  sync within %syncreg, label %sync.continue
+
+sync.continue:                                    ; preds = %det.cont26
+  call void @llvm.tapir.runtime.end(token %0)
+  %5 = call token @llvm.tapir.runtime.start()
+  %6 = call token @llvm.taskframe.create()
+  %add.ptr40 = getelementptr inbounds double, double* %A, i64 %3
+  %add.ptr42 = getelementptr inbounds double, double* %B, i64 %idx.ext18
+  detach within %syncreg36, label %det.achd44, label %det.cont45
+
+; CHECK: %[[TRS1:.+]] = call token @llvm.tapir.runtime.start()
+
+; CHECK: sync.continue:
+; CHECK-NOT: call void @llvm.tapir.runtime.end($[[TRS1]])
+; CHECK-NOT: call token @llvm.tapir.runtime.start()
+; CHECK: detach within
+
+det.achd44:                                       ; preds = %sync.continue
+  call void @llvm.taskframe.use(token %6)
+  call void @mmdac(double* noundef %C, double* noundef %add.ptr40, double* noundef %add.ptr42, i32 noundef %div)
+  reattach within %syncreg36, label %det.cont45
+
+det.cont45:                                       ; preds = %det.achd44, %sync.continue
+  %7 = call token @llvm.taskframe.create()
+  %add.ptr51 = getelementptr inbounds double, double* %B, i64 %idx.ext27
+  detach within %syncreg36, label %det.achd53, label %det.cont54
+
+det.achd53:                                       ; preds = %det.cont45
+  call void @llvm.taskframe.use(token %7)
+  call void @mmdac(double* noundef %add.ptr10, double* noundef %add.ptr40, double* noundef %add.ptr51, i32 noundef %div)
+  reattach within %syncreg36, label %det.cont54
+
+det.cont54:                                       ; preds = %det.achd53, %det.cont45
+  %8 = call token @llvm.taskframe.create()
+  %add.ptr58 = getelementptr inbounds double, double* %A, i64 %idx.ext27
+  detach within %syncreg36, label %det.achd62, label %det.cont63
+
+det.achd62:                                       ; preds = %det.cont54
+  call void @llvm.taskframe.use(token %8)
+  call void @mmdac(double* noundef %add.ptr19, double* noundef %add.ptr58, double* noundef %add.ptr42, i32 noundef %div)
+  reattach within %syncreg36, label %det.cont63
+
+det.cont63:                                       ; preds = %det.achd62, %det.cont54
+  call void @mmdac(double* noundef %add.ptr28, double* noundef %add.ptr58, double* noundef %add.ptr51, i32 noundef %div)
+  sync within %syncreg36, label %sync.continue73
+
+sync.continue73:                                  ; preds = %det.cont63
+  call void @llvm.tapir.runtime.end(token %5)
+  br label %if.end
+
+; CHECK: sync.continue73:
+; CHECK: call void @llvm.tapir.runtime.end(token %[[TRS1]])
+
+if.end:                                           ; preds = %sync.continue73, %if.then
+  ret void
+}
+
+; Function Attrs: argmemonly mustprogress nounwind willreturn
+declare token @llvm.tapir.runtime.start() #3
+
+; Function Attrs: argmemonly mustprogress nounwind willreturn
+declare token @llvm.syncregion.start() #3
+
+; Function Attrs: argmemonly mustprogress nounwind willreturn
+declare token @llvm.taskframe.create() #3
+
+; Function Attrs: argmemonly mustprogress nounwind willreturn
+declare void @llvm.taskframe.use(token) #3
+
+; Function Attrs: argmemonly mustprogress nounwind willreturn
+declare void @llvm.tapir.runtime.end(token) #3
+
+attributes #0 = { nounwind uwtable "frame-pointer"="none" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #1 = { mustprogress nofree nosync nounwind readnone speculatable willreturn }
+attributes #2 = { argmemonly mustprogress nofree nosync nounwind willreturn }
+attributes #3 = { argmemonly mustprogress nounwind willreturn }
+attributes #4 = { nounwind "frame-pointer"="none" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #5 = { nofree nounwind "frame-pointer"="none" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #6 = { nounwind }
+
+!llvm.module.flags = !{!0, !1}
+!llvm.ident = !{!2}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 7, !"uwtable", i32 1}
+!2 = !{!"clang version 14.0.6 (git@github.com:OpenCilk/opencilk-project.git 5f6bec7c28155ec1f1ae0efebdb5cec40d39fda1)"}
+!3 = !{!4, !5, i64 0}
+!4 = !{!"timeval", !5, i64 0, !5, i64 8}
+!5 = !{!"long", !6, i64 0}
+!6 = !{!"omnipotent char", !7, i64 0}
+!7 = !{!"Simple C/C++ TBAA"}
+!8 = !{!4, !5, i64 8}
+!9 = distinct !{!9, !10, !11}
+!10 = !{!"llvm.loop.mustprogress"}
+!11 = !{!"llvm.loop.unroll.disable"}
+!12 = distinct !{!12, !10, !11}
+!13 = !{!14, !14, i64 0}
+!14 = !{!"double", !6, i64 0}
+!15 = distinct !{!15, !10, !11}
+!16 = distinct !{!16, !10, !11}
+!17 = distinct !{!17, !10, !11}

--- a/llvm/test/Transforms/Tapir/taskframe-shared-exit.ll
+++ b/llvm/test/Transforms/Tapir/taskframe-shared-exit.ll
@@ -1,0 +1,190 @@
+; Check how Tapir-lowering handles a taskframe with an unusual
+; shared-exiting spindle.
+;
+; RUN: opt < %s -passes="loop-spawning,tapir2target" -tapir-target=opencilk -use-opencilk-runtime-bc=false -debug-abi-calls -S | FileCheck %s
+
+%"struct.miniFE::CSRMatrix" = type { i8, %"class.std::vector.21", %"class.std::vector.21", %"class.std::vector.21", %"class.std::vector.21", %"class.std::vector.26", i32, %"class.std::vector.21", %"class.std::vector.21", %"class.std::vector.21", %"class.std::vector.21", %"class.std::vector.21", %"class.std::vector.21", %"class.std::vector.26", %"class.std::vector" }
+%"class.std::vector.21" = type { %"struct.std::_Vector_base.22" }
+%"struct.std::_Vector_base.22" = type { %"struct.std::_Vector_base<int, std::allocator<int>>::_Vector_impl" }
+%"struct.std::_Vector_base<int, std::allocator<int>>::_Vector_impl" = type { %"struct.std::_Vector_base<int, std::allocator<int>>::_Vector_impl_data" }
+%"struct.std::_Vector_base<int, std::allocator<int>>::_Vector_impl_data" = type { i32*, i32*, i32* }
+%"class.std::vector.26" = type { %"struct.std::_Vector_base.27" }
+%"struct.std::_Vector_base.27" = type { %"struct.std::_Vector_base<double, std::allocator<double>>::_Vector_impl" }
+%"struct.std::_Vector_base<double, std::allocator<double>>::_Vector_impl" = type { %"struct.std::_Vector_base<double, std::allocator<double>>::_Vector_impl_data" }
+%"struct.std::_Vector_base<double, std::allocator<double>>::_Vector_impl_data" = type { double*, double*, double* }
+%"class.std::vector" = type { %"struct.std::_Vector_base" }
+%"struct.std::_Vector_base" = type { %"struct.std::_Vector_base<ompi_request_t *, std::allocator<ompi_request_t *>>::_Vector_impl" }
+%"struct.std::_Vector_base<ompi_request_t *, std::allocator<ompi_request_t *>>::_Vector_impl" = type { %"struct.std::_Vector_base<ompi_request_t *, std::allocator<ompi_request_t *>>::_Vector_impl_data" }
+%"struct.std::_Vector_base<ompi_request_t *, std::allocator<ompi_request_t *>>::_Vector_impl_data" = type { %struct.ompi_request_t**, %struct.ompi_request_t**, %struct.ompi_request_t** }
+%struct.ompi_request_t = type opaque
+%"class.std::__cxx11::basic_ostringstream" = type { %"class.std::basic_ostream.base", %"class.std::__cxx11::basic_stringbuf", %"class.std::basic_ios" }
+%"class.std::basic_ostream.base" = type { i32 (...)** }
+%"class.std::__cxx11::basic_stringbuf" = type { %"class.std::basic_streambuf", i32, %"class.std::__cxx11::basic_string" }
+%"class.std::basic_streambuf" = type { i32 (...)**, i8*, i8*, i8*, i8*, i8*, i8*, %"class.std::locale" }
+%"class.std::locale" = type { %"class.std::locale::_Impl"* }
+%"class.std::locale::_Impl" = type { i32, %"class.std::locale::facet"**, i64, %"class.std::locale::facet"**, i8** }
+%"class.std::locale::facet" = type <{ i32 (...)**, i32, [4 x i8] }>
+%"class.std::__cxx11::basic_string" = type { %"struct.std::__cxx11::basic_string<char>::_Alloc_hider", i64, %union.anon }
+%"struct.std::__cxx11::basic_string<char>::_Alloc_hider" = type { i8* }
+%union.anon = type { i64, [8 x i8] }
+%"class.std::basic_ios" = type { %"class.std::ios_base", %"class.std::basic_ostream"*, i8, i8, %"class.std::basic_streambuf"*, %"class.std::ctype"*, %"class.std::num_put"*, %"class.std::num_get"* }
+%"class.std::ios_base" = type { i32 (...)**, i64, i64, i32, i32, i32, %"struct.std::ios_base::_Callback_list"*, %"struct.std::ios_base::_Words", [8 x %"struct.std::ios_base::_Words"], i32, %"struct.std::ios_base::_Words"*, %"class.std::locale" }
+%"struct.std::ios_base::_Callback_list" = type { %"struct.std::ios_base::_Callback_list"*, void (i32, %"class.std::ios_base"*, i32)*, i32, i32 }
+%"struct.std::ios_base::_Words" = type { i8*, i64 }
+%"class.std::basic_ostream" = type { i32 (...)**, %"class.std::basic_ios" }
+%"class.std::ctype" = type <{ %"class.std::locale::facet.base", [4 x i8], %struct.__locale_struct*, i8, [7 x i8], i32*, i32*, i16*, i8, [256 x i8], [256 x i8], i8, [6 x i8] }>
+%"class.std::locale::facet.base" = type <{ i32 (...)**, i32 }>
+%struct.__locale_struct = type { [13 x %struct.__locale_data*], i16*, i32*, i32*, [13 x i8*] }
+%struct.__locale_data = type opaque
+%"class.std::num_put" = type { %"class.std::locale::facet.base", [4 x i8] }
+%"class.std::num_get" = type { %"class.std::locale::facet.base", [4 x i8] }
+
+; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
+declare void @llvm.dbg.declare(metadata, metadata, metadata) #0
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #1
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #1
+
+; Function Attrs: argmemonly nofree nounwind willreturn writeonly
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #2
+
+define linkonce_odr i32 @_ZN6miniFE25generate_matrix_structureINS_9CSRMatrixIdiiEEEEiRKNS_23simple_mesh_descriptionINT_17GlobalOrdinalTypeEEERS4_() personality i8* undef {
+  br label %for.body.i
+
+for.body.i:                                       ; preds = %2, %0
+  br label %1
+
+1:                                                ; preds = %for.body.i
+  br label %2
+
+2:                                                ; preds = %1
+  br i1 false, label %_ZN6miniFE8copy_boxERK3BoxRS0_.exit, label %for.body.i
+
+_ZN6miniFE8copy_boxERK3BoxRS0_.exit:              ; preds = %2
+  br label %if.end
+
+if.end:                                           ; preds = %_ZN6miniFE8copy_boxERK3BoxRS0_.exit
+  ; br label %if.end38
+  invoke void undef(%"struct.miniFE::CSRMatrix"* null, i32 0, i32 0)
+          to label %if.end38 unwind label %lpad218  
+
+if.end38:                                         ; preds = %if.end
+  br label %if.end55.split
+
+if.end55.split:                                   ; preds = %if.end38
+  %3 = call token @llvm.taskframe.create()
+  invoke void undef(%"struct.miniFE::CSRMatrix"* null, i32 0, i32 0)
+          to label %try.cont.split unwind label %lpad58.split
+
+lpad58.split:                                     ; preds = %if.end55.split
+  %4 = landingpad { i8*, i32 }
+          cleanup
+          catch i8* null
+  br label %catch.split
+
+catch.split:                                      ; preds = %lpad58.split
+  invoke void undef(%"class.std::__cxx11::basic_ostringstream"* null)
+          to label %invoke.cont63 unwind label %lpad62
+
+invoke.cont63:                                    ; preds = %catch.split
+  br label %try.cont.split
+
+lpad62:                                           ; preds = %catch.split
+  %5 = landingpad { i8*, i32 }
+          cleanup
+  br label %ehcleanup81
+
+ehcleanup81:                                      ; preds = %lpad62
+  invoke void undef()
+          to label %invoke.cont83 unwind label %terminate.lpad
+
+invoke.cont83:                                    ; preds = %ehcleanup81
+  br label %try.cont.split
+
+try.cont.split:                                   ; preds = %if.end55.split
+  call void @llvm.taskframe.end(token %3)
+  ret i32 0
+
+pfor.body.entry.i:                                ; No predecessors!
+  %6 = call i8* @llvm.task.frameaddress(i32 0)
+  ret i32 0
+
+lpad218:                                          ; No predecessors!
+  %test = landingpad { i8*, i32 }
+          cleanup
+  invoke void undef()
+          to label %invoke.cont228 unwind label %terminate.lpad
+
+invoke.cont228:                                   ; preds = %lpad218
+  ret i32 0
+
+terminate.lpad:                                   ; preds = %lpad218, %ehcleanup81
+  %7 = phi i64 [ 0, %lpad218 ], [ 0, %ehcleanup81 ]
+  %8 = landingpad { i8*, i32 }
+          catch i8* null
+  unreachable
+}
+
+; CHECK-LABEL: define {{.*}}i32 @_ZN6miniFE25generate_matrix_structureINS_9CSRMatrixIdiiEEEEiRKNS_23simple_mesh_descriptionINT_17GlobalOrdinalTypeEEERS4_(
+; CHECK: if.end38:
+; CHECK-NEXT: call {{.*}}void @_ZN6miniFE25generate_matrix_structureINS_9CSRMatrixIdiiEEEEiRKNS_23simple_mesh_descriptionINT_17GlobalOrdinalTypeEEERS4_.outline_if.end55.split.otf0
+; CHECK-NEXT: br label %try.cont.split.tfend
+
+; CHECK-LABEL: define {{.*}}void @_ZN6miniFE25generate_matrix_structureINS_9CSRMatrixIdiiEEEEiRKNS_23simple_mesh_descriptionINT_17GlobalOrdinalTypeEEERS4_.outline_if.end55.split.otf0(
+
+; CHECK: ehcleanup81.otf0:
+; CHECK-NEXT: invoke void undef()
+; CHECK-NEXT: to label %invoke.cont83.otf0 unwind label %terminate.lpad.otf0
+
+; CHECK: terminate.lpad.otf0:
+; CHECK-NEXT: phi i64 [ 0, %ehcleanup81.otf0 ]
+; CHECK-NOT: [
+; CHECK-NEXT: landingpad
+; CHECK-NEXT: catch
+; CHECK-NEXT: unreachable
+
+; Function Attrs: argmemonly nounwind willreturn
+declare token @llvm.taskframe.create() #3
+
+; Function Attrs: nounwind readnone
+declare i32 @llvm.eh.typeid.for(i8*) #4
+
+; Function Attrs: argmemonly nounwind willreturn
+declare void @llvm.taskframe.end(token) #3
+
+; Function Attrs: argmemonly willreturn
+declare void @llvm.taskframe.resume.sl_p0i8i32s(token, { i8*, i32 }) #5
+
+; Function Attrs: argmemonly nounwind willreturn
+declare token @llvm.syncregion.start() #3
+
+; Function Attrs: argmemonly willreturn
+declare void @llvm.sync.unwind(token) #5
+
+; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
+declare void @llvm.dbg.value(metadata, metadata, metadata) #0
+
+; Function Attrs: argmemonly willreturn
+declare void @llvm.detached.rethrow.sl_p0i8i32s(token, { i8*, i32 }) #5
+
+; Function Attrs: nofree nosync nounwind readnone willreturn
+declare i8* @llvm.frameaddress.p0i8(i32 immarg) #6
+
+; Function Attrs: nofree nosync nounwind willreturn
+declare i8* @llvm.stacksave() #7
+
+; Function Attrs: nounwind willreturn
+declare i8* @llvm.task.frameaddress(i32) #8
+
+attributes #0 = { nofree nosync nounwind readnone speculatable willreturn }
+attributes #1 = { argmemonly nofree nosync nounwind willreturn }
+attributes #2 = { argmemonly nofree nounwind willreturn writeonly }
+attributes #3 = { argmemonly nounwind willreturn }
+attributes #4 = { nounwind readnone }
+attributes #5 = { argmemonly willreturn }
+attributes #6 = { nofree nosync nounwind readnone willreturn }
+attributes #7 = { nofree nosync nounwind willreturn }
+attributes #8 = { nounwind willreturn }

--- a/llvm/test/Transforms/Tapir/tre-middle-sync.ll
+++ b/llvm/test/Transforms/Tapir/tre-middle-sync.ll
@@ -1,0 +1,203 @@
+; RUN: opt < %s -passes="tailcallelim" -S | FileCheck %s
+
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+%struct.timeval = type { i64, i64 }
+
+@A = dso_local global [1024 x [1024 x double]] zeroinitializer, align 16
+@B = dso_local global [1024 x [1024 x double]] zeroinitializer, align 16
+@C = dso_local global [1024 x [1024 x double]] zeroinitializer, align 16
+@.str = private unnamed_addr constant [7 x i8] c"%0.6f\0A\00", align 1
+
+; Function Attrs: mustprogress nofree nosync nounwind readnone speculatable willreturn
+declare double @llvm.fmuladd.f64(double, double, double) #1
+
+; Function Attrs: argmemonly nofree nosync nounwind uwtable
+declare dso_local void @mmbase(double* noalias nocapture noundef %C, double* nocapture noundef readonly %A, double* nocapture noundef readonly %B, i32 noundef %size) local_unnamed_addr #2
+
+; Function Attrs: argmemonly mustprogress nofree nosync nounwind willreturn
+declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #3
+
+; Function Attrs: argmemonly mustprogress nofree nosync nounwind willreturn
+declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #3
+
+; Function Attrs: inaccessiblemem_or_argmemonly nounwind uwtable
+define dso_local void @mmdac(double* noalias noundef %C, double* noundef %A, double* noundef %B, i32 noundef %size) local_unnamed_addr #4 {
+entry:
+  %syncreg = call token @llvm.syncregion.start()
+  %cmp = icmp slt i32 %size, 33
+  br i1 %cmp, label %if.then, label %if.else
+
+if.then:                                          ; preds = %entry
+  call void @llvm.experimental.noalias.scope.decl(metadata !15)
+  %cmp43.i = icmp sgt i32 %size, 0
+  br i1 %cmp43.i, label %for.cond1.preheader.lr.ph.i, label %if.end
+
+for.cond1.preheader.lr.ph.i:                      ; preds = %if.then
+  %wide.trip.count59.i = zext i32 %size to i64
+  br label %for.cond5.preheader.lr.ph.i
+
+for.cond5.preheader.lr.ph.i:                      ; preds = %for.cond.cleanup3.i, %for.cond1.preheader.lr.ph.i
+  %indvars.iv56.i = phi i64 [ 0, %for.cond1.preheader.lr.ph.i ], [ %indvars.iv.next57.i, %for.cond.cleanup3.i ]
+  %0 = trunc i64 %indvars.iv56.i to i32
+  %mul.i = shl nsw i32 %0, 10
+  %1 = zext i32 %mul.i to i64
+  br label %for.body8.lr.ph.i
+
+for.body8.lr.ph.i:                                ; preds = %for.cond.cleanup7.i, %for.cond5.preheader.lr.ph.i
+  %indvars.iv50.i = phi i64 [ 0, %for.cond5.preheader.lr.ph.i ], [ %indvars.iv.next51.i, %for.cond.cleanup7.i ]
+  %2 = trunc i64 %indvars.iv50.i to i32
+  %3 = add i32 %mul.i, %2
+  %idxprom16.i = zext i32 %3 to i64
+  %arrayidx17.i = getelementptr inbounds double, double* %C, i64 %idxprom16.i
+  %arrayidx17.promoted.i = load double, double* %arrayidx17.i, align 8, !tbaa !9, !alias.scope !15
+  br label %for.body8.i
+
+for.cond.cleanup3.i:                              ; preds = %for.cond.cleanup7.i
+  %indvars.iv.next57.i = add nuw nsw i64 %indvars.iv56.i, 1
+  %exitcond60.not.i = icmp eq i64 %indvars.iv.next57.i, %wide.trip.count59.i
+  br i1 %exitcond60.not.i, label %if.end, label %for.cond5.preheader.lr.ph.i, !llvm.loop !11
+
+for.cond.cleanup7.i:                              ; preds = %for.body8.i
+  store double %10, double* %arrayidx17.i, align 8, !tbaa !9, !alias.scope !15
+  %indvars.iv.next51.i = add nuw nsw i64 %indvars.iv50.i, 1
+  %exitcond55.not.i = icmp eq i64 %indvars.iv.next51.i, %wide.trip.count59.i
+  br i1 %exitcond55.not.i, label %for.cond.cleanup3.i, label %for.body8.lr.ph.i, !llvm.loop !13
+
+for.body8.i:                                      ; preds = %for.body8.i, %for.body8.lr.ph.i
+  %indvars.iv.i = phi i64 [ 0, %for.body8.lr.ph.i ], [ %indvars.iv.next.i, %for.body8.i ]
+  %4 = phi double [ %arrayidx17.promoted.i, %for.body8.lr.ph.i ], [ %10, %for.body8.i ]
+  %5 = add nuw nsw i64 %indvars.iv.i, %1
+  %arrayidx.i = getelementptr inbounds double, double* %A, i64 %5
+  %6 = load double, double* %arrayidx.i, align 8, !tbaa !9, !noalias !15
+  %7 = shl nsw i64 %indvars.iv.i, 10
+  %8 = add nuw nsw i64 %7, %indvars.iv50.i
+  %arrayidx12.i = getelementptr inbounds double, double* %B, i64 %8
+  %9 = load double, double* %arrayidx12.i, align 8, !tbaa !9, !noalias !15
+  %10 = call double @llvm.fmuladd.f64(double %6, double %9, double %4) #10
+  %indvars.iv.next.i = add nuw nsw i64 %indvars.iv.i, 1
+  %exitcond.not.i = icmp eq i64 %indvars.iv.next.i, %wide.trip.count59.i
+  br i1 %exitcond.not.i, label %for.cond.cleanup7.i, label %for.body8.i, !llvm.loop !14
+
+if.else:                                          ; preds = %entry
+  %div130 = lshr i32 %size, 1
+  %mul = shl nsw i32 %div130, 10
+  %mul3 = mul nsw i32 %div130, 1025
+  detach within %syncreg, label %det.achd, label %det.cont.tf
+
+det.achd:                                         ; preds = %if.else
+  call void @mmdac(double* noundef %C, double* noundef %A, double* noundef %B, i32 noundef %div130)
+  reattach within %syncreg, label %det.cont.tf
+
+det.cont.tf:                                      ; preds = %if.else, %det.achd
+  %11 = zext i32 %div130 to i64
+  %add.ptr10 = getelementptr inbounds double, double* %C, i64 %11
+  %add.ptr14 = getelementptr inbounds double, double* %B, i64 %11
+  detach within %syncreg, label %det.achd16, label %det.cont17.tf
+
+det.achd16:                                       ; preds = %det.cont.tf
+  call void @mmdac(double* noundef %add.ptr10, double* noundef %A, double* noundef %add.ptr14, i32 noundef %div130)
+  reattach within %syncreg, label %det.cont17.tf
+
+det.cont17.tf:                                    ; preds = %det.cont.tf, %det.achd16
+  %idx.ext18 = zext i32 %mul to i64
+  %add.ptr19 = getelementptr inbounds double, double* %C, i64 %idx.ext18
+  %add.ptr21 = getelementptr inbounds double, double* %A, i64 %idx.ext18
+  detach within %syncreg, label %det.achd25, label %det.cont26
+
+det.achd25:                                       ; preds = %det.cont17.tf
+  call void @mmdac(double* noundef %add.ptr19, double* noundef %add.ptr21, double* noundef %B, i32 noundef %div130)
+  reattach within %syncreg, label %det.cont26
+
+det.cont26:                                       ; preds = %det.achd25, %det.cont17.tf
+  %idx.ext27 = zext i32 %mul3 to i64
+  %add.ptr28 = getelementptr inbounds double, double* %C, i64 %idx.ext27
+  call void @mmdac(double* noundef %add.ptr28, double* noundef %add.ptr21, double* noundef %add.ptr14, i32 noundef %div130)
+  sync within %syncreg, label %sync.continue.tf
+
+sync.continue.tf:                                 ; preds = %det.cont26
+  %add.ptr37 = getelementptr inbounds double, double* %A, i64 %11
+  %add.ptr39 = getelementptr inbounds double, double* %B, i64 %idx.ext18
+  detach within %syncreg, label %det.achd41, label %det.cont42.tf
+
+det.achd41:                                       ; preds = %sync.continue.tf
+  call void @mmdac(double* noundef %C, double* noundef %add.ptr37, double* noundef %add.ptr39, i32 noundef %div130)
+  reattach within %syncreg, label %det.cont42.tf
+
+det.cont42.tf:                                    ; preds = %sync.continue.tf, %det.achd41
+  %add.ptr48 = getelementptr inbounds double, double* %B, i64 %idx.ext27
+  detach within %syncreg, label %det.achd50, label %det.cont51.tf
+
+det.achd50:                                       ; preds = %det.cont42.tf
+  call void @mmdac(double* noundef %add.ptr10, double* noundef %add.ptr37, double* noundef %add.ptr48, i32 noundef %div130)
+  reattach within %syncreg, label %det.cont51.tf
+
+det.cont51.tf:                                    ; preds = %det.cont42.tf, %det.achd50
+  %add.ptr55 = getelementptr inbounds double, double* %A, i64 %idx.ext27
+  detach within %syncreg, label %det.achd59, label %det.cont60
+
+det.achd59:                                       ; preds = %det.cont51.tf
+  call void @mmdac(double* noundef %add.ptr19, double* noundef %add.ptr55, double* noundef %add.ptr39, i32 noundef %div130)
+  reattach within %syncreg, label %det.cont60
+
+det.cont60:                                       ; preds = %det.achd59, %det.cont51.tf
+  call void @mmdac(double* noundef %add.ptr28, double* noundef %add.ptr55, double* noundef %add.ptr48, i32 noundef %div130)
+  sync within %syncreg, label %if.end
+
+; CHECK: det.cont60:
+; CHECK: call void @mmdac
+; CHECK-NOT: br label
+; CHECK: sync within %syncreg
+
+if.end:                                           ; preds = %for.cond.cleanup3.i, %if.then, %det.cont60
+  ret void
+}
+
+; Function Attrs: argmemonly mustprogress nounwind willreturn
+declare token @llvm.syncregion.start() #5
+
+; Function Attrs: argmemonly mustprogress nounwind willreturn
+declare token @llvm.taskframe.create() #5
+
+; Function Attrs: argmemonly mustprogress nounwind willreturn
+declare void @llvm.taskframe.use(token) #5
+
+; Function Attrs: inaccessiblememonly nofree nosync nounwind willreturn
+declare void @llvm.experimental.noalias.scope.decl(metadata) #9
+
+attributes #0 = { argmemonly mustprogress nofree nosync nounwind readonly uwtable willreturn "frame-pointer"="none" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #1 = { mustprogress nofree nosync nounwind readnone speculatable willreturn }
+attributes #2 = { argmemonly nofree nosync nounwind uwtable "frame-pointer"="none" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #3 = { argmemonly mustprogress nofree nosync nounwind willreturn }
+attributes #4 = { inaccessiblemem_or_argmemonly nounwind uwtable "frame-pointer"="none" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #5 = { argmemonly mustprogress nounwind willreturn }
+attributes #6 = { nounwind uwtable "frame-pointer"="none" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #7 = { nounwind "frame-pointer"="none" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #8 = { nofree nounwind "frame-pointer"="none" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #9 = { inaccessiblememonly nofree nosync nounwind willreturn }
+attributes #10 = { nounwind }
+
+!llvm.module.flags = !{!0, !1}
+!llvm.ident = !{!2}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 7, !"uwtable", i32 1}
+!2 = !{!"clang version 14.0.6 (git@github.com:OpenCilk/opencilk-project.git 5f6bec7c28155ec1f1ae0efebdb5cec40d39fda1)"}
+!3 = !{!4, !5, i64 0}
+!4 = !{!"timeval", !5, i64 0, !5, i64 8}
+!5 = !{!"long", !6, i64 0}
+!6 = !{!"omnipotent char", !7, i64 0}
+!7 = !{!"Simple C/C++ TBAA"}
+!8 = !{!4, !5, i64 8}
+!9 = !{!10, !10, i64 0}
+!10 = !{!"double", !6, i64 0}
+!11 = distinct !{!11, !12}
+!12 = !{!"llvm.loop.mustprogress"}
+!13 = distinct !{!13, !12}
+!14 = distinct !{!14, !12}
+!15 = !{!16}
+!16 = distinct !{!16, !17, !"mmbase: %C"}
+!17 = distinct !{!17, !"mmbase"}
+!18 = distinct !{!18, !12}
+!19 = distinct !{!19, !12}

--- a/llvm/test/Transforms/Tapir/tre-tapir-runtime.ll
+++ b/llvm/test/Transforms/Tapir/tre-tapir-runtime.ll
@@ -1,0 +1,76 @@
+; RUN: opt < %s -passes="tailcallelim" -S | FileCheck %s
+
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+; Function Attrs: mustprogress nounwind uwtable
+define dso_local void @_Z12sample_qsortPiS_(i32* noundef %begin, i32* noundef %end) local_unnamed_addr #0 {
+entry:
+  %syncreg = call token @llvm.syncregion.start()
+  %cmp.not = icmp eq i32* %begin, %end
+  br i1 %cmp.not, label %if.end, label %if.then
+
+if.then:                                          ; preds = %entry
+  %incdec.ptr = getelementptr inbounds i32, i32* %end, i64 -1
+  %call = call noundef i32* @_Z9partitionPiS_(i32* noundef %begin, i32* noundef nonnull %incdec.ptr) #3
+  call void @_Z4swapRiS_(i32* noundef nonnull align 4 dereferenceable(4) %incdec.ptr, i32* noundef nonnull align 4 dereferenceable(4) %call) #3
+  %0 = call token @llvm.tapir.runtime.start()
+  detach within %syncreg, label %det.achd, label %det.cont
+
+det.achd:                                         ; preds = %if.then
+  call void @_Z12sample_qsortPiS_(i32* noundef %begin, i32* noundef nonnull %call)
+  reattach within %syncreg, label %det.cont
+
+det.cont:                                         ; preds = %det.achd, %if.then
+  %incdec.ptr1 = getelementptr inbounds i32, i32* %call, i64 1
+  call void @_Z12sample_qsortPiS_(i32* noundef nonnull %incdec.ptr1, i32* noundef %end)
+  sync within %syncreg, label %sync.continue
+
+sync.continue:                                    ; preds = %det.cont
+  call void @llvm.tapir.runtime.end(token %0)
+  br label %if.end
+
+if.end:                                           ; preds = %sync.continue, %entry
+  ret void
+}
+
+; CHECK: define {{.*}}void @_Z12sample_qsortPiS_(
+; CHECK: tail call token @llvm.syncregion.start()
+; CHECK-NEXT: br label %[[TAILRECURSE:.+]]
+; CHECK: [[TAILRECURSE]]:
+; CHECK-NOT: call token @llvm.tapir.runtime.start()
+; CHECK: det.cont:
+; CHECK: br label %[[TAILRECURSE]]
+; CHECK-NOT: call void @llvm.tapir.runtime.end(token
+; CHECK: sync within
+
+declare dso_local noundef i32* @_Z9partitionPiS_(i32* noundef, i32* noundef) local_unnamed_addr #1
+
+declare dso_local void @_Z4swapRiS_(i32* noundef nonnull align 4 dereferenceable(4), i32* noundef nonnull align 4 dereferenceable(4)) local_unnamed_addr #1
+
+; Function Attrs: argmemonly mustprogress nounwind willreturn
+declare token @llvm.tapir.runtime.start() #2
+
+; Function Attrs: argmemonly mustprogress nounwind willreturn
+declare token @llvm.syncregion.start() #2
+
+; Function Attrs: argmemonly mustprogress nounwind willreturn
+declare token @llvm.taskframe.create() #2
+
+; Function Attrs: argmemonly mustprogress nounwind willreturn
+declare void @llvm.taskframe.use(token) #2
+
+; Function Attrs: argmemonly mustprogress nounwind willreturn
+declare void @llvm.tapir.runtime.end(token) #2
+
+attributes #0 = { mustprogress nounwind uwtable "frame-pointer"="none" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #1 = { "frame-pointer"="none" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #2 = { argmemonly mustprogress nounwind willreturn }
+attributes #3 = { nounwind }
+
+!llvm.module.flags = !{!0, !1}
+!llvm.ident = !{!2}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 7, !"uwtable", i32 1}
+!2 = !{!"clang version 14.0.6 (git@github.com:OpenCilk/opencilk-project.git f125821debd115939f9177c347e3780f27f4be03)"}


### PR DESCRIPTION
This PR contains a few assorted updates and bugfixes:
- Enable some optimizations of and around `tapir.runtime` intrinsics, which suggest locations for starting up or shutting down a parallel runtime.
- Prevent tail-recursion elimination from eliminating recursive tail calls that are followed by a sync if there is a sync preceding them in the function.  Tail-recursion elimination on such functions is legal, but it can be a pessimization by causing tasks to synchronize earlier than in the original code.
- Add property information to CSI hooks for Tapir detach and detach-continuation points to identify detaches that are part of a parallel loop.  This change makes it easier for tools, such as Cilksan, to distinguish detach operations associated with loops from ordinary detaches that happen to be inside a loop body.
- Minor bug fixes.