### PR TITLE
Fix crashes on weird reducer declarations

### DIFF
--- a/clang/lib/CodeGen/CGDecl.cpp
+++ b/clang/lib/CodeGen/CGDecl.cpp
@@ -1837,17 +1837,15 @@ void CodeGenFunction::EmitReducerInit(const VarDecl *D,
   RValue Reduce = EmitAnyExpr(C.Reduce);
 
   llvm::Type *SizeType = ConvertType(getContext().getSizeType());
-  unsigned SizeBits = SizeType->getIntegerBitWidth();
   llvm::Value *Size = nullptr;
   QualType Type = D->getType();
-  if (uint64_t Bits = getContext().getTypeSize(Type)) {
-    Size = llvm::Constant::getIntegerValue(SizeType,
-                                           llvm::APInt(SizeBits, Bits / 8));
-  } else {
-    auto V = getVLASize(Type);
-    llvm::Value *Size1 = llvm::Constant::getIntegerValue(
-        SizeType, llvm::APInt(64, getContext().getTypeSize(V.Type) / 8));
+  if (const VariableArrayType *VLA =
+      getContext().getAsVariableArrayType(Type)) {
+    auto V = getVLASize(VLA);
+    llvm::Value *Size1 = CGM.getSize(getContext().getTypeSizeInChars(V.Type));
     Size = Builder.CreateNUWMul(V.NumElts, Size1);
+  } else {
+    Size = CGM.getSize(getContext().getTypeSizeInChars(Type));
   }
   // TODO: mark this call as registering a local
   // TODO: add better handling of attribute arguments that evaluate to null

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -2394,6 +2394,8 @@ Expr *Sema::ValidateReducerCallback(Expr *E, unsigned NumArgs,
     E = new (Context) CXXNullPtrLiteralExpr(Context.NullPtrTy,
                                             E->getExprLoc());
     Cast = CK_NullToPointer;
+  } else if (Mismatch == IntToPointer) {
+    Cast = CK_IntegralToPointer;
   }
 
   return ImplicitCastExpr::Create(Context, Context.VoidPtrTy, Cast, E,

--- a/clang/test/Cilk/hyper-zero.c
+++ b/clang/test/Cilk/hyper-zero.c
@@ -1,0 +1,16 @@
+// RUN: %clang_cc1 %s -x c -fopencilk -verify -S -emit-llvm -disable-llvm-passes -o - | FileCheck %s
+extern int c;
+extern void *d;
+
+// Test for crash on definition of empty hyperobject
+// CHECK-LABEL: __cxx_global_var_init
+// CHECK: call void @llvm.reducer.register.i64(i8* getelementptr inbounds ([0 x i8], [0 x i8]* @x, i32 0, i32 0), i64 0
+typedef char Empty[0];
+Empty _Hyperobject(d, d) x;
+
+void declares_hyperobject()
+{
+  // Test for crash on int to pointer conversion in hyperobject definition
+  int _Hyperobject(c, d) y;
+  //expected-warning@-1{{incompatible integer to pointer conversion}}
+}


### PR DESCRIPTION
Fixes crashes if
* A reducer callback is an integer instead of a pointer
* A reducer has zero size