### PR TITLE
Local reducer tables

### DIFF
--- a/.github/workflows/llvm-project-tests.yml
+++ b/.github/workflows/llvm-project-tests.yml
@@ -28,7 +28,7 @@ concurrency:
 env:
   # Workaround for https://github.com/actions/virtual-environments/issues/5900.
   # This should be a no-op for non-mac OSes
-  CPLUS_INCLUDE_PATH: /usr/local/Cellar/llvm/15.0.7_1/include/c++/v1:/Library/Developer/CommandLineTools/SDKs/MacOSX12.1.sdk/usr/include
+  CPLUS_INCLUDE_PATH: /usr/local/Cellar/llvm@15/15.0.7/include/c++/v1:/usr/local/Cellar/llvm/15.0.7_1/include/c++/v1:/Library/Developer/CommandLineTools/SDKs/MacOSX12.1.sdk/usr/include
 
 jobs:
   lit-tests:

--- a/clang/include/clang/Basic/Builtins.def
+++ b/clang/include/clang/Basic/Builtins.def
@@ -1691,7 +1691,7 @@ LANGBUILTIN(__arithmetic_fence, "v.", "t", ALL_LANGUAGES)
 
 // Tapir.  Rewriting of reducer references happens during sema
 // and needs a builtin to carry the information to codegen.
-BUILTIN(__hyper_lookup, "v*vC*zvC*vC*", "nU")
+BUILTIN(__hyper_lookup, "v*vC*z.", "nU")
 
 #undef BUILTIN
 #undef LIBBUILTIN

--- a/clang/include/clang/Basic/Builtins.def
+++ b/clang/include/clang/Basic/Builtins.def
@@ -1691,7 +1691,7 @@ LANGBUILTIN(__arithmetic_fence, "v.", "t", ALL_LANGUAGES)
 
 // Tapir.  Rewriting of reducer references happens during sema
 // and needs a builtin to carry the information to codegen.
-BUILTIN(__hyper_lookup, "v*vC*", "nU")
+BUILTIN(__hyper_lookup, "v*vC*zvC*vC*", "nU")
 
 #undef BUILTIN
 #undef LIBBUILTIN

--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -5440,9 +5440,12 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
   case Builtin::BI__hyper_lookup: {
     llvm::Value *Size = EmitScalarExpr(E->getArg(1));
     Function *F = CGM.getIntrinsic(Intrinsic::hyper_lookup, Size->getType());
+    llvm::Value *Ptr = EmitScalarExpr(E->getArg(0));
+    llvm::Value *Identity = EmitScalarExpr(E->getArg(2));
+    llvm::Value *Reduce = EmitScalarExpr(E->getArg(3));
     return RValue::get(Builder.CreateCall(
-        F, {EmitScalarExpr(E->getArg(0)), Size, EmitScalarExpr(E->getArg(2)),
-            EmitScalarExpr(E->getArg(3))}));
+        F, {Ptr, Size, Builder.CreateBitCast(Identity, VoidPtrTy),
+            Builder.CreateBitCast(Reduce, VoidPtrTy)}));
   }
   }
   IsSpawnedScope SpawnedScp(this);

--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -5438,8 +5438,11 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
     return RValue::get(Ptr);
   }
   case Builtin::BI__hyper_lookup: {
-    Function *F = CGM.getIntrinsic(Intrinsic::hyper_lookup);
-    return RValue::get(Builder.CreateCall(F, {EmitScalarExpr(E->getArg(0))}));
+    llvm::Value *Size = EmitScalarExpr(E->getArg(1));
+    Function *F = CGM.getIntrinsic(Intrinsic::hyper_lookup, Size->getType());
+    return RValue::get(Builder.CreateCall(
+        F, {EmitScalarExpr(E->getArg(0)), Size, EmitScalarExpr(E->getArg(2)),
+            EmitScalarExpr(E->getArg(3))}));
   }
   }
   IsSpawnedScope SpawnedScp(this);

--- a/clang/test/Cilk/hyper-array-extern-1.cpp
+++ b/clang/test/Cilk/hyper-array-extern-1.cpp
@@ -11,7 +11,7 @@ int read_array_hyper(unsigned i)
   return x[i];
   // CHECK: %[[ARRAYIDX:.+]] = getelementptr inbounds
   // CHECK: %[[KEY:.+]] = bitcast i32* %[[ARRAYIDX]] to i8*
-  // CHECK: %[[VIEWRAW:.+]] = call i8* @llvm.hyper.lookup(i8* %[[KEY]])
+  // CHECK: %[[VIEWRAW:.+]] = call i8* @llvm.hyper.lookup.i64(i8* %[[KEY]], i64 4, i8* null, i8* null)
   // CHECK-NOT: call i8* @llvm.hyper.lookup
   // CHECK: %[[VIEW:.+]] = bitcast i8* %[[VIEWRAW]] to i32*
   // CHECK: %[[VAL:.+]] = load i32, i32* %[[VIEW]]

--- a/clang/test/Cilk/hyper-assign.c
+++ b/clang/test/Cilk/hyper-assign.c
@@ -6,20 +6,20 @@ extern long _Hyperobject x, _Hyperobject y;
 
 long chain_assign()
 {
-  // CHECK: %[[Y1RAW:.+]] = call i8* @llvm.hyper.lookup(i8* bitcast (i64* @y to i8*))
+  // CHECK: %[[Y1RAW:.+]] = call i8* @llvm.hyper.lookup.i64(i8* bitcast (i64* @y to i8*), i64 8, i8* null, i8* null)
   // CHECK: %[[Y1PTR:.+]] = bitcast i8* %[[Y1RAW]] to i64*
   // CHECK: %[[Y1VAL:.+]] = load i64, i64* %[[Y1PTR]]
-  // CHECK: call i8* @llvm.hyper.lookup(i8* bitcast (i64* @x to i8*))
+  // CHECK: call i8* @llvm.hyper.lookup.i64(i8* bitcast (i64* @x to i8*), i64 8, i8* null, i8* null)
   // CHECK: store i64 %[[Y1VAL]]
-  // CHECK: call i8* @llvm.hyper.lookup(i8* bitcast (i64* @y to i8*))
-  // CHECK: call i8* @llvm.hyper.lookup(i8* bitcast (i64* @x to i8*))
+  // CHECK: call i8* @llvm.hyper.lookup.i64(i8* bitcast (i64* @y to i8*), i64 8, i8* null, i8* null)
+  // CHECK: call i8* @llvm.hyper.lookup.i64(i8* bitcast (i64* @x to i8*), i64 8, i8* null, i8* null)
   return x = y = x = y;
 }
 
 long simple_assign(long val)
 {
-  // CHECK: call i8* @llvm.hyper.lookup(i8* bitcast (i64* @x to i8*))
-  // CHECK-NOT: call i8* @llvm.hyper.lookup(i8* bitcast (i64* @x to i8*))
+  // CHECK: call i8* @llvm.hyper.lookup.i64(i8* bitcast (i64* @x to i8*), i64 8, i8* null, i8* null)
+  // CHECK-NOT: call i8* @llvm.hyper.lookup
   // CHECK: store i64
   return x = val;
 }
@@ -27,11 +27,11 @@ long simple_assign(long val)
 long subtract()
 {
   // The order is not fixed here.
-  // CHECK: call i8* @llvm.hyper.lookup(i8* bitcast (i64* @y to i8*))
+  // CHECK: call i8* @llvm.hyper.lookup.i64(i8* bitcast (i64* @y to i8*), i64 8, i8* null, i8* null)
   // CHECK: load i64
   // CHECK: add nsw i64 %[[Y:.+]], 1
   // CHECK: store i64
-  // CHECK: call i8* @llvm.hyper.lookup(i8* bitcast (i64* @x to i8*))
+  // CHECK: call i8* @llvm.hyper.lookup.i64(i8* bitcast (i64* @x to i8*), i64 8, i8* null, i8* null)
   // CHECK: load i64
   // CHECK: sub nsw
   // CHECK: store i64

--- a/clang/test/Cilk/hyper-complex.c
+++ b/clang/test/Cilk/hyper-complex.c
@@ -7,7 +7,7 @@ extern __complex__ float _Hyperobject c;
 // CHECK-LABEL: get_real 
 float get_real()
 {
-  // CHECK: %[[RAW1:.+]] = call i8* @llvm.hyper.lookup(i8* bitcast ({ float, float }* @c to i8*))
+  // CHECK: %[[RAW1:.+]] = call i8* @llvm.hyper.lookup.i64(i8* bitcast ({ float, float }* @c to i8*), i64 8, i8* null, i8* null)
   // CHECK: %[[VIEW1:.+]] = bitcast i8* %[[RAW1]] to { float, float }*
   // CHECK: %[[FIELD1:.+]] = getelementptr inbounds { float, float }, { float, float }* %[[VIEW1]], i32 0, i32 0
   // CHECK: %[[RET1:.+]] = load float, float* %[[FIELD1]]
@@ -17,7 +17,7 @@ float get_real()
 // CHECK-LABEL: get_imag
 float get_imag()
 {
-  // CHECK: %[[RAW2:.+]] = call i8* @llvm.hyper.lookup(i8* bitcast ({ float, float }* @c to i8*))
+  // CHECK: %[[RAW2:.+]] = call i8* @llvm.hyper.lookup.i64(i8* bitcast ({ float, float }* @c to i8*), i64 8, i8* null, i8* null)
   // CHECK: %[[VIEW2:.+]] = bitcast i8* %[[RAW2]] to { float, float }*
   // CHECK: %[[FIELD2:.+]] = getelementptr inbounds { float, float }, { float, float }* %[[VIEW2]], i32 0, i32 1
   // CHECK: load float, float* %[[FIELD2]]
@@ -29,7 +29,7 @@ float get_imag()
 float get_abs()
 {
   // Only one call to llvm.hyper.lookup.
-  // CHECK: @llvm.hyper.lookup(i8* bitcast ({ float, float }* @c to i8*))
+  // CHECK: @llvm.hyper.lookup.i64(i8* bitcast ({ float, float }* @c to i8*), i64 8, i8* null, i8* null)
   // CHECK-NOT: @llvm.hyper.lookup
   // CHECK: call float @cabsf
   // CHECK: ret float

--- a/clang/test/Cilk/hyper-copy.c
+++ b/clang/test/Cilk/hyper-copy.c
@@ -9,9 +9,9 @@ extern struct S b __attribute__((aligned(8)));
 // CHECK-LABEL: scopy
 void scopy()
 {
-  // CHECK: call i8* @llvm.hyper.lookup(i8* bitcast (%struct.S* @a to i8*))
+  // CHECK: call i8* @llvm.hyper.lookup.i64(i8* bitcast (%struct.S* @a to i8*), i64 8, i8* null, i8* null)
   // CHECK: call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 8 bitcast (%struct.S* @b to i8*)
-  // CHECK: call i8* @llvm.hyper.lookup(i8* bitcast (%struct.S* @a to i8*))
+  // CHECK: call i8* @llvm.hyper.lookup.i64(i8* bitcast (%struct.S* @a to i8*), i64 8, i8* null, i8* null)
   // CHECK: call void @llvm.memcpy.p0i8.p0i8.i64
   // CHECK: ret void
   b = a;

--- a/clang/test/Cilk/hyper-template.cpp
+++ b/clang/test/Cilk/hyper-template.cpp
@@ -5,7 +5,7 @@ template<typename T> struct S { T member; };
 S<long> _Hyperobject S_long;
 
 // CHECK-LABEL: @_Z1fv
-// CHECK: %0 = call i8* @llvm.hyper.lookup(i8* bitcast (%struct.S* @S_long to i8*))
+// CHECK: %0 = call i8* @llvm.hyper.lookup.i64(i8* bitcast (%struct.S* @S_long to i8*), i64 8, i8* null, i8* null)
 // CHECK-NOT: call i8* @llvm.hyper.lookup
 // CHECK: getelementptr
 // CHECK: %[[RET:.+]] = load i64

--- a/clang/test/Cilk/hyper-unary.c
+++ b/clang/test/Cilk/hyper-unary.c
@@ -11,10 +11,10 @@ void function1()
 {
   // CHECK: store i32 1, i32* %[[Y:.+]],
   int _Hyperobject y = 1;
-  // CHECK: call i8* @llvm.hyper.lookup(i8* bitcast (i32* @x to i8*))
+  // CHECK: call i8* @llvm.hyper.lookup.i64(i8* bitcast (i32* @x to i8*), i64 4, i8* null, i8* null)
   // CHECK: load i32
   // CHECK: %[[Y1:.+]] = bitcast i32* %[[Y]] to i8*
-  // CHECK: call i8* @llvm.hyper.lookup(i8* %[[Y1]])
+  // CHECK: call i8* @llvm.hyper.lookup.i64(i8* %[[Y1]], i64 4, i8* null, i8* null)
   // CHECK: load i32
   (void)x; (void)y;
 }
@@ -24,10 +24,10 @@ void function2()
 {
   // CHECK: store i32 1, i32* %[[Y:.+]],
   int _Hyperobject y = 1;
-  // CHECK: call i8* @llvm.hyper.lookup(i8* bitcast (i32* @x to i8*))
+  // CHECK: call i8* @llvm.hyper.lookup.i64(i8* bitcast (i32* @x to i8*), i64 4, i8* null, i8* null)
   // CHECK: load i32
   // CHECK: %[[Y2:.+]] = bitcast i32* %[[Y]] to i8*
-  // CHECK: call i8* @llvm.hyper.lookup(i8* %[[Y2]])
+  // CHECK: call i8* @llvm.hyper.lookup.i64(i8* %[[Y2]], i64 4, i8* null, i8* null)
   // CHECK: load i32
   (void)!x; (void)!y;
 }
@@ -37,21 +37,21 @@ void function3()
 {
   // CHECK: store i32 1, i32* %[[Y:.+]],
   int _Hyperobject y = 1;
-  // CHECK: call i8* @llvm.hyper.lookup(i8* bitcast (i32* @x to i8*))
+  // CHECK: call i8* @llvm.hyper.lookup.i64(i8* bitcast (i32* @x to i8*), i64 4, i8* null, i8* null)
   // CHECK: load i32
   // CHECK: %[[Y3:.+]] = bitcast i32* %[[Y]] to i8*
-  // CHECK: call i8* @llvm.hyper.lookup(i8* %[[Y3]])
+  // CHECK: call i8* @llvm.hyper.lookup.i64(i8* %[[Y3]], i64 4, i8* null, i8* null)
   // CHECK: load i32
   (void)-x; (void)-y;
-  // CHECK: call i8* @llvm.hyper.lookup(i8* bitcast (i32* @x to i8*))
+  // CHECK: call i8* @llvm.hyper.lookup.i64(i8* bitcast (i32* @x to i8*), i64 4, i8* null, i8* null)
   // CHECK: load i32
   // CHECK: %[[Y4:.+]] = bitcast i32* %[[Y]] to i8*
-  // CHECK: call i8* @llvm.hyper.lookup(i8* %[[Y4]])
+  // CHECK: call i8* @llvm.hyper.lookup.i64(i8* %[[Y4]], i64 4, i8* null, i8* null)
   // CHECK: load i32
   (void)~x; (void)~y;
   // CHECK: %[[XP:.+]] = load i32*, i32** @xp
   // CHECK: %[[XP1:.+]] = bitcast i32* %[[XP]] to i8*
-  // CHECK: call i8* @llvm.hyper.lookup(i8* %[[XP1]])
+  // CHECK: call i8* @llvm.hyper.lookup.i64(i8* %[[XP1]], i64 4, i8* null, i8* null)
   // CHECK: load i32
   (void)*xp;
 }

--- a/llvm/include/llvm/IR/Intrinsics.td
+++ b/llvm/include/llvm/IR/Intrinsics.td
@@ -1386,9 +1386,11 @@ def int_task_frameaddress
 // Ideally the types would be [llvm_anyptr_ty], [LLVMMatchType<0>]
 // but that does not work, so rely on the front end to insert bitcasts.
 def int_hyper_lookup
-    : Intrinsic<[llvm_ptr_ty], [llvm_ptr_ty],
-    [IntrWillReturn, IntrReadMem, IntrInaccessibleMemOnly,
-     IntrStrandPure, IntrHyperView, IntrInjective]>;
+    : Intrinsic<[llvm_ptr_ty],
+                [llvm_ptr_ty, llvm_anyint_ty, llvm_ptr_ty, llvm_ptr_ty], [
+                  IntrWillReturn, IntrReadMem, IntrInaccessibleMemOnly,
+                  IntrStrandPure, IntrHyperView, IntrInjective
+                ]>;
 
 // TODO: Change tablegen to allow function pointer types in intrinsics.
 def int_reducer_register

--- a/llvm/lib/Analysis/BasicAliasAnalysis.cpp
+++ b/llvm/lib/Analysis/BasicAliasAnalysis.cpp
@@ -1662,7 +1662,7 @@ static const Value *getRecognizedArgument(const Value *V, bool InSameSpindle,
   if (!C)
     return nullptr;
   unsigned NumOperands = C->getNumOperands();
-  if (NumOperands != 2)
+  if (NumOperands != 2 && NumOperands != 5)
     return nullptr;
   for (auto E : TapirFnAttrTable) {
     if (C->hasFnAttr(E.first))

--- a/llvm/lib/Transforms/Tapir/OpenCilkABI.cpp
+++ b/llvm/lib/Transforms/Tapir/OpenCilkABI.cpp
@@ -223,7 +223,8 @@ void OpenCilkABI::prepareModule() {
   FunctionType *Grainsize16FnTy = FunctionType::get(Int16Ty, {Int16Ty}, false);
   FunctionType *Grainsize32FnTy = FunctionType::get(Int32Ty, {Int32Ty}, false);
   FunctionType *Grainsize64FnTy = FunctionType::get(Int64Ty, {Int64Ty}, false);
-  FunctionType *PtrPtrTy = FunctionType::get(VoidPtrTy, {VoidPtrTy}, false);
+  FunctionType *LookupTy = FunctionType::get(
+      VoidPtrTy, {VoidPtrTy, Int64Ty, VoidPtrTy, VoidPtrTy}, false);
   FunctionType *UnregTy = FunctionType::get(VoidTy, {VoidPtrTy}, false);
   FunctionType *Reg32Ty =
       FunctionType::get(VoidTy, {VoidPtrTy, Int32Ty, VoidPtrTy,
@@ -258,7 +259,7 @@ void OpenCilkABI::prepareModule() {
        CilkRTSCilkForGrainsize32},
       {"__cilkrts_cilk_for_grainsize_64", Grainsize64FnTy,
        CilkRTSCilkForGrainsize64},
-      {"__cilkrts_reducer_lookup", PtrPtrTy, CilkRTSReducerLookup},
+      {"__cilkrts_reducer_lookup", LookupTy, CilkRTSReducerLookup},
       {"__cilkrts_reducer_register_32", Reg32Ty, CilkRTSReducerRegister32},
       {"__cilkrts_reducer_register_64", Reg64Ty, CilkRTSReducerRegister64},
       {"__cilkrts_reducer_unregister", UnregTy, CilkRTSReducerUnregister},

--- a/llvm/test/Transforms/Tapir/157.ll
+++ b/llvm/test/Transforms/Tapir/157.ll
@@ -34,7 +34,7 @@ pfor.cond:                                        ; preds = %pfor.inc, %pfor.ph
 pfor.body:                                        ; preds = %pfor.cond
   %2 = load i64, i64* %add.ptr, align 8, !tbaa !4
   %3 = bitcast i64* %sum to i8*
-  %4 = call i8* @llvm.hyper.lookup(i8* nonnull %3)
+  %4 = call i8* @llvm.hyper.lookup(i8* nonnull %3, i64 8, i8* bitcast (void (i8*)* @zero to i8*), i8* bitcast (void (i8*, i8*)* @plus to i8*))
   %5 = bitcast i8* %4 to i64*
   %6 = load i64, i64* %5, align 8, !tbaa !4
   %add = add nsw i64 %6, %2
@@ -51,7 +51,7 @@ pfor.cond.cleanup:                                ; preds = %pfor.inc
 
 pfor.end:                                         ; preds = %entry, %pfor.cond.cleanup
   %7 = bitcast i64* %sum to i8*
-  %8 = call i8* @llvm.hyper.lookup(i8* nonnull %7)
+  %8 = call i8* @llvm.hyper.lookup(i8* nonnull %7, i64 8, i8* bitcast (void (i8*)* @zero to i8*), i8* bitcast (void (i8*, i8*)* @plus to i8*))
   %9 = bitcast i8* %8 to i64*
   %10 = load i64, i64* %9, align 8, !tbaa !4
   %11 = bitcast i64* %sum to i8*
@@ -91,7 +91,7 @@ declare void @llvm.reducer.register.i64(i8*, i64, i8*, i8*) #2
 declare token @llvm.syncregion.start() #3
 
 ; Function Attrs: hyper_view inaccessiblememonly injective mustprogress nofree nounwind readonly strand_pure willreturn
-declare i8* @llvm.hyper.lookup(i8*) #4
+declare i8* @llvm.hyper.lookup(i8*, i64, i8*, i8*) #4
 
 ; Function Attrs: argmemonly mustprogress nofree nosync nounwind willreturn
 declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #1

--- a/llvm/test/Transforms/Tapir/157.ll
+++ b/llvm/test/Transforms/Tapir/157.ll
@@ -1,5 +1,6 @@
 ; Check that loops with reducers can be vectorized (OpenCilk issue 157).
-; RUN: opt -S < %s -passes='loop-mssa(tapir-indvars),loop-stripmine,loop-mssa(loop-simplifycfg,licm),loop-vectorize' -o - | FileCheck %s
+; RUN: opt -S < %s -passes='loop-mssa(tapir-indvars),loop-stripmine,loop-mssa(loop-simplifycfg,licm),loop-vectorize' | FileCheck %s
+; REQUIRES: x86-registered-target
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-freebsd13.1"
 


### PR DESCRIPTION
This PR contains changes to the OpenCilk compiler to support a new implementation of reducers in the runtime system using only local reducer tables.