### PR TITLE
Add view lookup before overload resolution

### DIFF
--- a/clang/include/clang/Sema/Initialization.h
+++ b/clang/include/clang/Sema/Initialization.h
@@ -923,7 +923,10 @@ public:
     SK_OCLSamplerInit,
 
     /// Initialize an opaque OpenCL type (event_t, queue_t, etc.) with zero
-    SK_OCLZeroOpaqueType
+    SK_OCLZeroOpaqueType,
+
+    /// OpenCilk
+    SK_ViewLookup
   };
 
   /// A single step in the initialization sequence.
@@ -1318,6 +1321,8 @@ public:
 
   /// Add a zero-initialization step.
   void AddZeroInitializationStep(QualType T);
+
+  void AddViewLookup(QualType T);
 
   /// Add a C assignment step.
   //

--- a/clang/include/clang/Sema/Overload.h
+++ b/clang/include/clang/Sema/Overload.h
@@ -102,6 +102,8 @@ class Sema;
   /// convert an argument to a parameter's type. The enumerator values
   /// match with the table titled 'Conversions' in [over.ics.scs] and are listed
   /// such that better conversion kinds have smaller values.
+  /// Changes to the next two enumerations require corresponding changes
+  /// to clang::GetConversionRank.
   enum ImplicitConversionKind {
     /// Identity conversion (no conversion)
     ICK_Identity = 0,
@@ -114,6 +116,9 @@ class Sema;
 
     /// Function-to-pointer (C++ [conv.array])
     ICK_Function_To_Pointer,
+
+    /// OpenCilk extension
+    ICK_Hyperobject_To_View,
 
     /// Function pointer conversion (C++17 [conv.fctptr])
     ICK_Function_Conversion,

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -15293,16 +15293,20 @@ ExprResult Sema::BuildUnaryOp(Scope *S, SourceLocation OpLoc,
     Input = Result.get();
   }
 
-  if (getLangOpts().CPlusPlus && Input->getType()->isOverloadableType() &&
-      UnaryOperator::getOverloadedOperator(Opc) != OO_None &&
-      !(Opc == UO_AddrOf && isQualifiedMemberAccess(Input))) {
-    // Find all of the overloaded operators visible from this point.
-    UnresolvedSet<16> Functions;
-    OverloadedOperatorKind OverOp = UnaryOperator::getOverloadedOperator(Opc);
-    if (S && OverOp != OO_None)
-      LookupOverloadedOperatorName(OverOp, S, Functions);
+  if (getLangOpts().CPlusPlus) {
+    // A hyperobject may need to be converted to a view.
+    QualType Real = Input->getType().stripHyperobject();
+    if (Real->isOverloadableType() &&
+        UnaryOperator::getOverloadedOperator(Opc) != OO_None &&
+        !(Opc == UO_AddrOf && isQualifiedMemberAccess(Input))) {
+      // Find all of the overloaded operators visible from this point.
+      UnresolvedSet<16> Functions;
+      OverloadedOperatorKind OverOp = UnaryOperator::getOverloadedOperator(Opc);
+      if (S && OverOp != OO_None)
+        LookupOverloadedOperatorName(OverOp, S, Functions);
 
-    return CreateOverloadedUnaryOp(OpLoc, Opc, Functions, Input);
+      return CreateOverloadedUnaryOp(OpLoc, Opc, Functions, Input);
+    }
   }
 
   return CreateBuiltinUnaryOp(OpLoc, Opc, Input);

--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -4249,6 +4249,11 @@ Sema::PerformImplicitConversion(Expr *From, QualType ToType,
                .get();
     break;
 
+  case ICK_Hyperobject_To_View:
+    FromType = FromType.stripHyperobject();
+    From = BuildHyperobjectLookup(From, false);
+    break;
+
   default:
     llvm_unreachable("Improper first standard conversion");
   }
@@ -4568,6 +4573,7 @@ Sema::PerformImplicitConversion(Expr *From, QualType ToType,
   case ICK_Array_To_Pointer:
   case ICK_Function_To_Pointer:
   case ICK_Function_Conversion:
+  case ICK_Hyperobject_To_View:
   case ICK_Qualification:
   case ICK_Num_Conversion_Kinds:
   case ICK_C_Only_Conversion:

--- a/clang/lib/Sema/SemaInit.cpp
+++ b/clang/lib/Sema/SemaInit.cpp
@@ -3494,6 +3494,7 @@ void InitializationSequence::Step::Destroy() {
   case SK_StdInitializerListConstructorCall:
   case SK_OCLSamplerInit:
   case SK_OCLZeroOpaqueType:
+  case SK_ViewLookup:
     break;
 
   case SK_ConversionSequence:
@@ -3608,6 +3609,13 @@ void InitializationSequence::AddReferenceBindingStep(QualType T,
 void InitializationSequence::AddFinalCopy(QualType T) {
   Step S;
   S.Kind = SK_FinalCopy;
+  S.Type = T;
+  Steps.push_back(S);
+}
+
+void InitializationSequence::AddViewLookup(QualType T) {
+  Step S;
+  S.Kind = SK_ViewLookup;
   S.Type = T;
   Steps.push_back(S);
 }
@@ -4789,6 +4797,14 @@ static void TryReferenceInitializationCore(Sema &S,
                                            InitializationSequence &Sequence) {
   QualType DestType = Entity.getType();
   SourceLocation DeclLoc = Initializer->getBeginLoc();
+
+  // OpenCilk: If the right hand side is a hyperobject, see if the
+  // left hand side wants the hyperobject or a view.
+  if (T2->isHyperobjectType() && !T1->isHyperobjectType()) {
+    Sequence.AddViewLookup(T1);
+    T2 = T2.stripHyperobject();
+    cv2T2 = cv2T2.stripHyperobject();
+  }
 
   // Compute some basic properties of the types and the initializer.
   bool isLValueRef = DestType->isLValueReferenceType();
@@ -8136,6 +8152,7 @@ ExprResult InitializationSequence::Perform(Sema &S,
   case SK_QualificationConversionPRValue:
   case SK_FunctionReferenceConversion:
   case SK_AtomicConversion:
+  case SK_ViewLookup:
   case SK_ConversionSequence:
   case SK_ConversionSequenceNoNarrowing:
   case SK_ListInitialization:
@@ -8308,6 +8325,10 @@ ExprResult InitializationSequence::Perform(Sema &S,
     case SK_ExtraneousCopyToTemporary:
       CurInit = CopyObject(S, Step->Type, Entity, CurInit,
                            /*IsExtraneousCopy=*/true);
+      break;
+
+    case SK_ViewLookup:
+      CurInit = S.BuildHyperobjectLookup(CurInit.get());
       break;
 
     case SK_UserConversion: {
@@ -9639,6 +9660,10 @@ void InitializationSequence::dump(raw_ostream &OS) const {
     switch (S->Kind) {
     case SK_ResolveAddressOfOverloadedFunction:
       OS << "resolve address of overloaded function";
+      break;
+
+    case SK_ViewLookup:
+      OS << "lookup hyperobject view";
       break;
 
     case SK_CastDerivedToBasePRValue:

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -13320,6 +13320,9 @@ Sema::CreateOverloadedUnaryOp(SourceLocation OpLoc, UnaryOperatorKind Opc,
   if (checkPlaceholderForOverload(*this, Input))
     return ExprError();
 
+  if (Input->getType()->isHyperobjectType())
+    Input = BuildHyperobjectLookup(Input, false);
+
   Expr *Args[2] = { Input, nullptr };
   unsigned NumArgs = 1;
 

--- a/clang/test/Cilk/hyper-overload.cpp
+++ b/clang/test/Cilk/hyper-overload.cpp
@@ -1,0 +1,20 @@
+// RUN: %clang_cc1 %s -fopencilk -verify -S -emit-llvm -disable-llvm-passes -o - | FileCheck %s
+// expected-no-diagnostics
+struct S { int operator&(); };
+extern int operator+(S &, int);
+
+// Behavior without hyperobjects
+// CHECK-LABEL: f1
+// CHECK-NOT: @llvm.hyper.lookup
+// CHECK: @_ZN1SadEv
+int f1(struct S*sp) { return &*sp; }
+// Lookup view then call S::operator &().
+// CHECK-LABEL: f2
+// CHECK: @llvm.hyper.lookup
+// CHECK: @_ZN1SadEv
+int f2(struct S _Hyperobject*sp) { return &*sp; }
+// Lookup view then call operator+(S &, int);
+// CHECK-LABEL: f3
+// CHECK: @llvm.hyper.lookup
+// CHECK: @_ZplR1Si
+int f3(struct S _Hyperobject*sp) { return *sp + 1; }

--- a/clang/test/Cilk/hyper-reference.cpp
+++ b/clang/test/Cilk/hyper-reference.cpp
@@ -1,0 +1,7 @@
+// RUN: %clang_cc1 %s -fopencilk -verify -fsyntax-only
+// expected-no-diagnostics
+extern void f(int &, int _Hyperobject &);
+void g(int _Hyperobject *p)
+{
+  f(*p, *p);
+}


### PR DESCRIPTION
Fixes #123.

With this change I was able to replace `*&*` with `*` in pbfs-simple/graph.cpp.