### PR TITLE
Fix compiler crash due to jump threading

### DIFF
--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -1276,19 +1276,18 @@ static SmallVector<StringRef, 4> serializeSanitizerKinds(SanitizerSet S) {
   return Values;
 }
 
-static LangOptions::CilktoolKind parseCilktoolKind(StringRef FlagName,
-                                                   ArgList &Args,
-                                                   DiagnosticsEngine &Diags) {
+static LangOptions::CilktoolKind
+parseCilktoolKind(StringRef FlagName, ArgList &Args, DiagnosticsEngine &Diags) {
   if (Arg *A = Args.getLastArg(OPT_fcilktool_EQ)) {
     StringRef Val = A->getValue();
     LangOptions::CilktoolKind ParsedCilktool =
-      llvm::StringSwitch<LangOptions::CilktoolKind>(Val)
-      .Case("cilkscale", LangOptions::Cilktool_Cilkscale)
-      .Case("cilkscale-instructions",
-            LangOptions::Cilktool_Cilkscale_InstructionCount)
-      .Case("cilkscale-benchmark",
-            LangOptions::Cilktool_Cilkscale_Benchmark)
-      .Default(LangOptions::Cilktool_None);
+        llvm::StringSwitch<LangOptions::CilktoolKind>(Val)
+            .Case("cilkscale", LangOptions::Cilktool_Cilkscale)
+            .Case("cilkscale-instructions",
+                  LangOptions::Cilktool_Cilkscale_InstructionCount)
+            .Case("cilkscale-benchmark",
+                  LangOptions::Cilktool_Cilkscale_Benchmark)
+            .Default(LangOptions::Cilktool_None);
     if (ParsedCilktool == LangOptions::Cilktool_None)
       Diags.Report(diag::err_drv_invalid_value) << FlagName << Val;
     else
@@ -1297,8 +1296,9 @@ static LangOptions::CilktoolKind parseCilktoolKind(StringRef FlagName,
   return LangOptions::Cilktool_None;
 }
 
-static Optional<StringRef> serializeCilktoolKind(LangOptions::CilktoolKind K) {
-  Optional<StringRef> CilktoolStr;
+static std::optional<StringRef>
+serializeCilktoolKind(LangOptions::CilktoolKind K) {
+  std::optional<StringRef> CilktoolStr;
   switch (K) {
   case LangOptions::Cilktool_Cilkscale:
     CilktoolStr = "cilkscale";
@@ -1321,13 +1321,13 @@ parseCSIExtensionPoint(StringRef FlagName, ArgList &Args,
   if (Arg *A = Args.getLastArg(OPT_fcsi_EQ)) {
     StringRef Val = A->getValue();
     LangOptions::CSIExtensionPoint ParsedExt =
-      llvm::StringSwitch<LangOptions::CSIExtensionPoint>(Val)
-      .Case("first",           LangOptions::CSI_EarlyAsPossible)
-      .Case("early",           LangOptions::CSI_ModuleOptimizerEarly)
-      .Case("last",            LangOptions::CSI_OptimizerLast)
-      .Case("tapirlate",       LangOptions::CSI_TapirLate)
-      .Case("aftertapirloops", LangOptions::CSI_TapirLoopEnd)
-      .Default(LangOptions::CSI_None);
+        llvm::StringSwitch<LangOptions::CSIExtensionPoint>(Val)
+            .Case("first", LangOptions::CSI_EarlyAsPossible)
+            .Case("early", LangOptions::CSI_ModuleOptimizerEarly)
+            .Case("last", LangOptions::CSI_OptimizerLast)
+            .Case("tapirlate", LangOptions::CSI_TapirLate)
+            .Case("aftertapirloops", LangOptions::CSI_TapirLoopEnd)
+            .Default(LangOptions::CSI_None);
     if (ParsedExt == LangOptions::CSI_None) {
       Diags.Report(diag::err_drv_invalid_value) << FlagName << Val;
       return LangOptions::CSI_None;
@@ -1339,9 +1339,9 @@ parseCSIExtensionPoint(StringRef FlagName, ArgList &Args,
   return LangOptions::CSI_None;
 }
 
-static Optional<StringRef>
+static std::optional<StringRef>
 serializeCSIExtensionPoint(LangOptions::CSIExtensionPoint X) {
-  Optional<StringRef> CSIExtPtStr;
+  std::optional<StringRef> CSIExtPtStr;
   switch (X) {
   case LangOptions::CSI_EarlyAsPossible:
     CSIExtPtStr = "first";
@@ -1455,7 +1455,7 @@ void CompilerInvocation::GenerateCodeGenArgs(
   else if (!Opts.DirectAccessExternalData && LangOpts->PICLevel == 0)
     GenerateArg(Args, OPT_fno_direct_access_external_data, SA);
 
-  if (Optional<StringRef> TapirTargetStr =
+  if (std::optional<StringRef> TapirTargetStr =
           serializeTapirTarget(Opts.getTapirTarget()))
     GenerateArg(Args, OPT_ftapir_EQ, *TapirTargetStr, SA);
 
@@ -3421,10 +3421,10 @@ void CompilerInvocation::GenerateLangArgs(const LangOptions &Opts,
       GenerateArg(Args, OPT_pic_is_pie, SA);
     for (StringRef Sanitizer : serializeSanitizerKinds(Opts.Sanitize))
       GenerateArg(Args, OPT_fsanitize_EQ, Sanitizer, SA);
-    if (Optional<StringRef> CSIExtPt = serializeCSIExtensionPoint(
+    if (std::optional<StringRef> CSIExtPt = serializeCSIExtensionPoint(
             Opts.getComprehensiveStaticInstrumentation()))
       GenerateArg(Args, OPT_fcsi_EQ, *CSIExtPt, SA);
-    if (Optional<StringRef> Cilktool =
+    if (std::optional<StringRef> Cilktool =
             serializeCilktoolKind(Opts.getCilktool()))
       GenerateArg(Args, OPT_fcilktool_EQ, *Cilktool, SA);
 
@@ -3628,10 +3628,11 @@ void CompilerInvocation::GenerateLangArgs(const LangOptions &Opts,
   else if (Opts.DefaultFPContractMode == LangOptions::FPM_FastHonorPragmas)
     GenerateArg(Args, OPT_ffp_contract, "fast-honor-pragmas", SA);
 
-  if (Optional<StringRef> CSIExtPt = serializeCSIExtensionPoint(
+  if (std::optional<StringRef> CSIExtPt = serializeCSIExtensionPoint(
           Opts.getComprehensiveStaticInstrumentation()))
     GenerateArg(Args, OPT_fcsi_EQ, *CSIExtPt, SA);
-  if (Optional<StringRef> Cilktool = serializeCilktoolKind(Opts.getCilktool()))
+  if (std::optional<StringRef> Cilktool =
+          serializeCilktoolKind(Opts.getCilktool()))
     GenerateArg(Args, OPT_fcilktool_EQ, *Cilktool, SA);
 
   for (StringRef Sanitizer : serializeSanitizerKinds(Opts.Sanitize))

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -1265,17 +1265,17 @@ TSTToUnaryTransformType(DeclSpec::TST SwitchTST) {
   }
 }
 
-static Optional<unsigned> DeclContainsHyperobject(const RecordDecl *Decl);
+static std::optional<unsigned> DeclContainsHyperobject(const RecordDecl *Decl);
 
 // It is forbidden to add new bits to the Type class so there is no
 // room for a cached or precomputed flag.  Do a deep search on every
 // hyperobject type creation.
-static Optional<unsigned> ContainsHyperobject(QualType Outer) {
+static std::optional<unsigned> ContainsHyperobject(QualType Outer) {
   const Type *T = Outer.getCanonicalType().getTypePtr();
   if (T->isVariablyModifiedType())
     return diag::variable_length_hyperobject;
   if (T->isDependentType())
-    return Optional<unsigned>();
+    return std::optional<unsigned>();
   QualType Inner;
   switch (T->getTypeClass()) {
   case Type::Hyperobject:
@@ -1321,7 +1321,7 @@ static Optional<unsigned> ContainsHyperobject(QualType Outer) {
           return diag::confusing_hyperobject;
         }
       }
-      return Optional<unsigned>();
+      return std::optional<unsigned>();
     }
     if (const RecordDecl *Def = Decl->getDefinition())
       return DeclContainsHyperobject(Def);
@@ -1356,16 +1356,16 @@ static Optional<unsigned> ContainsHyperobject(QualType Outer) {
   case Type::Builtin:
   case Type::TemplateTypeParm:
   default:
-    return Optional<unsigned>();
+    return std::optional<unsigned>();
   }
   return ContainsHyperobject(Inner);
 }
 
-static Optional<unsigned> DeclContainsHyperobject(const RecordDecl *Decl) {
+static std::optional<unsigned> DeclContainsHyperobject(const RecordDecl *Decl) {
   for (const FieldDecl *FD : Decl->fields())
-    if (Optional<unsigned> O = ContainsHyperobject(FD->getType()))
+    if (std::optional<unsigned> O = ContainsHyperobject(FD->getType()))
       return O;
-  return Optional<unsigned>();
+  return std::optional<unsigned>();
 }
 
 /// Convert the specified declspec to the appropriate type
@@ -2472,7 +2472,7 @@ QualType Sema::BuildHyperobjectType(QualType Element, Expr *Identity,
   QualType Result = Element;
   if (!RequireCompleteType(Loc, Element, CompleteTypeKind::Normal,
                            diag::incomplete_hyperobject)) {
-    if (Optional<unsigned> Code = ContainsHyperobject(Result))
+    if (std::optional<unsigned> Code = ContainsHyperobject(Result))
       Diag(Loc, *Code) << Result;
   }
 

--- a/llvm/include/llvm/Transforms/Scalar/JumpThreading.h
+++ b/llvm/include/llvm/Transforms/Scalar/JumpThreading.h
@@ -89,6 +89,7 @@ class JumpThreadingPass : public PassInfoMixin<JumpThreadingPass> {
 #else
   SmallSet<AssertingVH<const BasicBlock>, 16> LoopHeaders;
 #endif
+  DenseMap<const BasicBlock *, SmallPtrSet<const BasicBlock *, 16>> TapirTasks;
 
   unsigned BBDupThreshold;
   unsigned DefaultBBDupThreshold;
@@ -110,6 +111,7 @@ public:
   }
 
   void findLoopHeaders(Function &F);
+  void findTapirTasks(Function &F, DominatorTree &DT);
   bool processBlock(BasicBlock *BB);
   bool maybeMergeBasicBlockIntoOnlyPred(BasicBlock *BB);
   void updateSSA(BasicBlock *BB, BasicBlock *NewBB,

--- a/llvm/lib/Transforms/Scalar/JumpThreading.cpp
+++ b/llvm/lib/Transforms/Scalar/JumpThreading.cpp
@@ -420,6 +420,8 @@ bool JumpThreadingPass::runImpl(Function &F, TargetLibraryInfo *TLI_,
   if (!ThreadAcrossLoopHeaders)
     findLoopHeaders(F);
 
+  findTapirTasks(F, DT);
+
   bool EverChanged = false;
   bool Changed;
   do {
@@ -628,6 +630,32 @@ void JumpThreadingPass::findLoopHeaders(Function &F) {
 
   for (const auto &Edge : Edges)
     LoopHeaders.insert(Edge.second);
+}
+
+/// findTapirTasks - We must be careful when threading the continuation of a
+/// Tapir task, in order to make sure that reattaches always go to the
+/// continuation of their associated detaches.  To ensure this we first record
+/// all the associations between detaches and reattaches.
+void JumpThreadingPass::findTapirTasks(Function &F, DominatorTree &DT) {
+  for (const BasicBlock &BB : F) {
+    if (const DetachInst *DI = dyn_cast<DetachInst>(BB.getTerminator())) {
+      // Scan the predecessors of the detach continuation for reattaches that
+      // pair with this detach.
+      const BasicBlock *Detached = DI->getDetached();
+      for (const BasicBlock *PredBB : predecessors(DI->getContinue()))
+        if (isa<ReattachInst>(PredBB->getTerminator()) &&
+            DT.dominates(Detached, PredBB))
+          TapirTasks[&BB].insert(PredBB);
+
+      if (DI->hasUnwindDest())
+        // Scan the predecessors of the detach unwind for detached-rethrows that
+        // pair with this detach.
+        for (const BasicBlock *PredBB : predecessors(DI->getUnwindDest()))
+          if (isDetachedRethrow(PredBB->getTerminator()) &&
+              DT.dominates(Detached, PredBB))
+            TapirTasks[&BB].insert(PredBB);
+    }
+  }
 }
 
 /// getKnownConstant - Helper method to determine if we can thread over a
@@ -1723,6 +1751,43 @@ bool JumpThreadingPass::processThreadableEdges(Value *Cond, BasicBlock *BB,
 
     PredToDestList.emplace_back(Pred, DestBB);
   }
+
+  // For Tapir, remove any edges from detaches, reattaches, or detached-rethrows
+  // if we are trying to thread only a subset of the the associated detaches,
+  // reattaches, and detached-rethrows among the predecesors.
+  erase_if(
+      PredToDestList,
+      [&](const std::pair<BasicBlock *, BasicBlock *> &PredToDest) {
+        // Bail if the predecessor is not terminated by a detach.
+        if (isa<DetachInst>(PredToDest.first->getTerminator())) {
+          // If we are threading through a detach-continue or detach-unwind,
+          // check that all associated reattaches and detached-rethrows are also
+          // predecessors in PredToDestList.
+          for (const BasicBlock *TaskPred : TapirTasks[PredToDest.first]) {
+            if (isa<ReattachInst>(TaskPred->getTerminator()) ||
+                isDetachedRethrow(TaskPred->getTerminator())) {
+              return none_of(
+                  PredToDestList,
+                  [&](const std::pair<BasicBlock *, BasicBlock *> &PredToDest) {
+                    return TaskPred == PredToDest.first;
+                  });
+            }
+          }
+        } else if (isa<ReattachInst>(PredToDest.first->getTerminator()) ||
+                   isDetachedRethrow(PredToDest.first->getTerminator())) {
+          // If we have a reattach or detached-rethrow predecessor, check that
+          // the associated detach is also a predecessor in PredToDestList.
+          const BasicBlock *ReattachPred = PredToDest.first;
+          return none_of(
+              PredToDestList,
+              [&](const std::pair<BasicBlock *, BasicBlock *> &PredToDest) {
+                return isa<DetachInst>(PredToDest.first->getTerminator()) &&
+                    TapirTasks.count(PredToDest.first) &&
+                    TapirTasks[PredToDest.first].contains(ReattachPred);
+              });
+        }
+        return false;
+      });
 
   // If all edges were unthreadable, we fail.
   if (PredToDestList.empty())

--- a/llvm/test/Transforms/Tapir/jump-threading-detach-continue-2.ll
+++ b/llvm/test/Transforms/Tapir/jump-threading-detach-continue-2.ll
@@ -1,0 +1,107 @@
+; Check that jump threading does not thread a detach-continue edge if
+; it does not also thread the corresponding reattach-continue edge.
+;
+; RUN: opt < %s -passes="cgscc(devirt<4>(inline,function<eager-inv>(loop(indvars,loop-unroll-full),gvn<>,instcombine,loop-mssa(licm<allowspeculation>)))),function<eager-inv>(loop-stripmine,jump-threading)" -S | FileCheck %s
+
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+%class.anon.1003 = type { ptr, ptr, ptr, ptr }
+
+define linkonce_odr ptr @_ZSt3minImERKT_S2_S2_(ptr %__a, ptr %__b) {
+entry:
+  %0 = load i64, ptr %__a, align 8
+  %cmp.not = icmp eq i64 %0, 0
+  %__b.__a = select i1 %cmp.not, ptr %__a, ptr %__b
+  ret ptr %__b.__a
+}
+
+; Function Attrs: nounwind willreturn memory(argmem: readwrite)
+declare token @llvm.syncregion.start() #0
+
+define linkonce_odr void @_ZN21delta_compressed_leafIjE14parallel_splitILb1ELb0ELb0EZZN4CPMAI10PMA_traitsIS0_L8HeadForm0ELm0ELb0ELb0ELb0ELm4096ELb1E19overwrite_on_insertISt5tupleIJRjEES6_IJjEEEEE9grow_listEmENKUlvE0_clEvEUlmE_10empty_typeSF_EEvmmmPjmT2_T3_T4_m(i64 %num_leaves) personality ptr null {
+entry:
+  call void @_ZN13ParallelTools12parallel_forIZN21delta_compressed_leafIjE14parallel_splitILb1ELb0ELb0EZZN4CPMAI10PMA_traitsIS2_L8HeadForm0ELm0ELb0ELb0ELb0ELm4096ELb1E19overwrite_on_insertISt5tupleIJRjEES8_IJjEEEEE9grow_listEmENKUlvE0_clEvEUlmE_10empty_typeSH_EEvmmmPjmT2_T3_T4_mEUlmE_EEvmmT_(i64 1, i64 %num_leaves, ptr byval(%class.anon.1003) null)
+  ret void
+}
+
+define linkonce_odr void @_ZN13ParallelTools12parallel_forIZN21delta_compressed_leafIjE14parallel_splitILb1ELb0ELb0EZZN4CPMAI10PMA_traitsIS2_L8HeadForm0ELm0ELb0ELb0ELb0ELm4096ELb1E19overwrite_on_insertISt5tupleIJRjEES8_IJjEEEEE9grow_listEmENKUlvE0_clEvEUlmE_10empty_typeSH_EEvmmmPjmT2_T3_T4_mEUlmE_EEvmmT_(i64 %start, i64 %end, ptr %f) {
+entry:
+  %syncreg = call token @llvm.syncregion.start()
+  %cmp = icmp ugt i64 %end, %start
+  br i1 %cmp, label %pfor.ph, label %common.ret
+
+pfor.ph:                                          ; preds = %entry
+  %sub = sub i64 %end, %start
+  br label %pfor.cond
+
+pfor.cond:                                        ; preds = %pfor.inc, %pfor.ph
+  %__begin.0 = phi i64 [ 0, %pfor.ph ], [ %inc, %pfor.inc ]
+  detach within %syncreg, label %pfor.body.entry, label %pfor.inc
+
+pfor.body.entry:                                  ; preds = %pfor.cond
+  call void @_ZZN21delta_compressed_leafIjE14parallel_splitILb1ELb0ELb0EZZN4CPMAI10PMA_traitsIS0_L8HeadForm0ELm0ELb0ELb0ELb0ELm4096ELb1E19overwrite_on_insertISt5tupleIJRjEES6_IJjEEEEE9grow_listEmENKUlvE0_clEvEUlmE_10empty_typeSF_EEvmmmPjmT2_T3_T4_mENKUlmE_clEm(ptr %f, i64 %__begin.0)
+  reattach within %syncreg, label %pfor.inc
+
+pfor.inc:                                         ; preds = %pfor.body.entry, %pfor.cond
+  %inc = add i64 %__begin.0, 1
+  %cmp3 = icmp ult i64 %inc, %sub
+  br i1 %cmp3, label %pfor.cond, label %common.ret
+
+common.ret:                                       ; preds = %pfor.inc, %entry
+  ret void
+}
+
+define linkonce_odr void @_ZZN21delta_compressed_leafIjE14parallel_splitILb1ELb0ELb0EZZN4CPMAI10PMA_traitsIS0_L8HeadForm0ELm0ELb0ELb0ELb0ELm4096ELb1E19overwrite_on_insertISt5tupleIJRjEES6_IJjEEEEE9grow_listEmENKUlvE0_clEvEUlmE_10empty_typeSF_EEvmmmPjmT2_T3_T4_mENKUlmE_clEm(ptr %this, i64 %i) {
+entry:
+  %i.addr111 = alloca [0 x [0 x [0 x i64]]], i32 0, align 8
+  store i64 %i, ptr %i.addr111, align 8
+  %0 = load ptr, ptr %this, align 8
+  %call = call ptr @_ZSt3minImERKT_S2_S2_(ptr %i.addr111, ptr %0)
+  %1 = load i64, ptr %call, align 8
+  %add.ptr = getelementptr i8, ptr null, i64 %1
+  %add.ptr2 = getelementptr i8, ptr %add.ptr, i64 -1
+  store i8 0, ptr null, align 4294967296
+  br i1 poison, label %if.then, label %for.cond
+
+if.then:                                          ; preds = %entry
+  store i1 false, ptr null, align 4294967296
+  store ptr null, ptr null, align 4294967296
+  br label %for.cond
+
+for.cond:                                         ; preds = %for.inc, %if.then, %entry
+  %j.0 = phi i8 [ %inc, %for.inc ], [ 0, %if.then ], [ 0, %entry ]
+  %cmp6 = icmp ult i8 %j.0, 5
+  br i1 %cmp6, label %for.body, label %cleanup
+
+for.body:                                         ; preds = %for.cond
+  %conv5 = zext i8 %j.0 to i64
+  %arrayidx = getelementptr i8, ptr %add.ptr2, i64 %conv5
+  %2 = load i8, ptr %arrayidx, align 1
+  %cmp9 = icmp sgt i8 %2, 0
+  br i1 %cmp9, label %if.then10, label %for.inc
+
+if.then10:                                        ; preds = %for.body
+  br label %cleanup
+
+for.inc:                                          ; preds = %for.body
+  %inc = add i8 %j.0, 1
+  br label %for.cond
+
+cleanup:                                          ; preds = %if.then10, %for.cond
+  ret void
+}
+
+; CHECK: define linkonce_odr void @_ZN21delta_compressed_leafIjE14parallel_splitILb1ELb0ELb0EZZN4CPMAI10PMA_traitsIS0_L8HeadForm0ELm0ELb0ELb0ELb0ELm4096ELb1E19overwrite_on_insertISt5tupleIJRjEES6_IJjEEEEE9grow_listEmENKUlvE0_clEvEUlmE_10empty_typeSF_EEvmmmPjmT2_T3_T4_m(
+
+; CHECK: pfor.ph.i.new.strpm.detachloop:
+; CHECK-NEXT: detach within %[[SYNCREG_I:.+]], label %[[DETACHED:.+]], label %[[DETACH_CONT:.+]]
+
+; CHECK: pfor.cond.i.strpm.detachloop.reattach.split:
+; CHECK-NEXT: reattach within %[[SYNCREG_I]], label %[[DETACH_CONT]]
+
+
+; uselistorder directives
+uselistorder ptr null, { 0, 1, 2, 3, 4, 6, 7, 8, 5 }
+
+attributes #0 = { nounwind willreturn memory(argmem: readwrite) }


### PR DESCRIPTION
This PR fixes a compiler crash where jump threading would break an invariant of the Tapir CFG.

This PR also replaces some uses of the deprecated `Optional` class in Cilk-related code  with `std::optional`.