### PR TITLE
Set memory(read) instead of readonly on strand_pure function definition

### DIFF
--- a/clang/lib/CodeGen/CGCall.cpp
+++ b/clang/lib/CodeGen/CGCall.cpp
@@ -2230,7 +2230,7 @@ void CodeGenModule::ConstructAttributeList(StringRef Name,
     }
     if (TargetDecl->hasAttr<StrandPureAttr>()) {
       FuncAttrs.addAttribute(llvm::Attribute::StrandPure);
-      FuncAttrs.addAttribute(llvm::Attribute::ReadOnly);
+      FuncAttrs.addMemoryAttr(llvm::MemoryEffects::readOnly());
       FuncAttrs.addAttribute(llvm::Attribute::NoUnwind);
     }
     if (TargetDecl->hasAttr<ReducerRegisterAttr>()) {


### PR DESCRIPTION
Without this change the IR Verifier fails on a function definition with the `strand_pure` C attribute.