### PR TITLE
Fix some memory errors in Clang and LLVM

### DIFF
--- a/clang/lib/CodeGen/CGCilk.cpp
+++ b/clang/lib/CodeGen/CGCilk.cpp
@@ -431,12 +431,12 @@ llvm::Instruction *CodeGenFunction::EmitSyncRegionStart() {
 
 /// EmitCilkSyncStmt - Emit a _Cilk_sync node.
 void CodeGenFunction::EmitCilkSyncStmt(const CilkSyncStmt &S) {
-  llvm::BasicBlock *ContinueBlock = createBasicBlock("sync.continue");
-
   // Check if we are generating unreachable code.
   if (!HaveInsertPoint())
     // We don't need to generate actual code.
     return;
+
+  llvm::BasicBlock *ContinueBlock = createBasicBlock("sync.continue");
 
   // Generate a stoppoint if we are emitting debug info.
   EmitStopPoint(&S);

--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -550,6 +550,11 @@ void CodeGenFunction::FinishFunction(SourceLocation EndLoc) {
       ReturnValue = Address::invalid();
     }
   }
+
+  if (CurSyncRegion) {
+    PopSyncRegion();
+    assert(!CurSyncRegion && "Nested sync regions at end of function.");
+  }
 }
 
 /// ShouldInstrumentFunction - Return true if the current function should be

--- a/llvm/include/llvm/Transforms/Tapir/Outline.h
+++ b/llvm/include/llvm/Transforms/Tapir/Outline.h
@@ -34,7 +34,9 @@ class OutlineMaterializer : public ValueMaterializer {
 public:
   OutlineMaterializer(const Value *SrcSyncRegion = nullptr)
       : SrcSyncRegion(SrcSyncRegion) {}
-  virtual ~OutlineMaterializer() {}
+  virtual ~OutlineMaterializer() {
+    BlocksToRemap.clear();
+  }
 
   Value *materialize(Value *V) override;
 

--- a/llvm/lib/Transforms/Tapir/DRFScopedNoAliasAA.cpp
+++ b/llvm/lib/Transforms/Tapir/DRFScopedNoAliasAA.cpp
@@ -41,7 +41,7 @@ class DRFScopedNoAliasImpl {
 public:
   DRFScopedNoAliasImpl(Function &F, TaskInfo &TI, AliasAnalysis &AA,
                        LoopInfo *LI)
-      : F(F), TI(TI), AA(AA), LI(LI) {
+      : F(F), TI(TI), LI(LI) {
     TI.evaluateParallelState<MaybeParallelTasks>(MPTasks);
   }
 
@@ -62,7 +62,6 @@ private:
 
   Function &F;
   TaskInfo &TI;
-  AliasAnalysis &AA;
   LoopInfo *LI;
 
   MaybeParallelTasks MPTasks;

--- a/llvm/lib/Transforms/Tapir/LoopSpawningTI.cpp
+++ b/llvm/lib/Transforms/Tapir/LoopSpawningTI.cpp
@@ -1332,9 +1332,11 @@ Function *LoopSpawningImpl::createHelperForTapirLoop(
   // argument, undo the eariler temporarily mapping.
   if (!isa<Constant>(TL->getTripCount()) && !Args.count(TL->getTripCount())) {
     VMap.erase(TL->getTripCount());
-    // Delete the ArgEndMaterializer.
-    delete Mat;
   }
+
+  // Delete the ArgEndMaterializer or OutlineMaterializer.
+  if (Mat)
+    delete Mat;
 
   // Rewrite cloned IV's to start at their start-iteration arguments.
   updateClonedIVs(TL, Preheader, Args, VMap, IVArgIndex);

--- a/llvm/lib/Transforms/Utils/TapirUtils.cpp
+++ b/llvm/lib/Transforms/Utils/TapirUtils.cpp
@@ -712,15 +712,19 @@ void llvm::cloneEHBlocks(Function *F,
     // relevant loops.
     for (BasicBlock *EHBlock : EHBlocksToClone) {
       if (!DT->isReachableFromEntry(EHBlock)) {
+        Loop *L = nullptr;
         if (LI->isLoopHeader(EHBlock)) {
           // Delete the whole loop.
-          Loop *L = LI->getLoopFor(EHBlock);
+          L = LI->getLoopFor(EHBlock);
           if (Loop *ParentL = L->getParentLoop())
             ParentL->removeChildLoop(llvm::find(*ParentL, L));
           else
             LI->removeLoop(llvm::find(*LI, L));
         }
         LI->removeBlock(EHBlock);
+        // If EHBlock is a loop header, finish destroying the whole loop.
+        if (L)
+          LI->destroy(L);
       }
     }
   }
@@ -913,7 +917,8 @@ void llvm::SerializeDetach(DetachInst *DI, BasicBlock *ParentEntry,
   }
 
   // Handle any detached-rethrows in the task.
-  if (DI->hasUnwindDest()) {
+  bool HasUnwind = DI->hasUnwindDest();
+  if (HasUnwind) {
     assert(InlinedLPads && "Missing set of landing pads in task.");
     assert(DetachedRethrows && "Missing set of detached rethrows in task.");
     if (ReplaceWithTaskFrame) {
@@ -960,7 +965,7 @@ void llvm::SerializeDetach(DetachInst *DI, BasicBlock *ParentEntry,
 
   // Replace the detach with an unconditional branch to the task entry.
   Continue->removePredecessor(Spawner);
-  if (DI->hasUnwindDest())
+  if (HasUnwind)
     Unwind->removePredecessor(Spawner);
   ReplaceInstWithInst(DI, BranchInst::Create(TaskEntry));
 
@@ -972,7 +977,7 @@ void llvm::SerializeDetach(DetachInst *DI, BasicBlock *ParentEntry,
   if (DT) {
     if (ReattachDom && DT->dominates(Spawner, Continue))
       DT->changeImmediateDominator(Continue, ReattachDom);
-    if (DI->hasUnwindDest())
+    if (HasUnwind)
       DT->deleteEdge(Spawner, Unwind);
   }
 }


### PR DESCRIPTION
This PR fixes some memory leaks and a memory error found in parts of the compiler for handling Cilk or Tapir.