### PR TITLE
[github, cmake] Remove macOS workflow workarounds that are no longer

### DIFF
--- a/.github/workflows/llvm-project-tests.yml
+++ b/.github/workflows/llvm-project-tests.yml
@@ -25,11 +25,6 @@ concurrency:
   group: llvm-project-${{ github.workflow }}-${{ inputs.projects}}${{ github.ref }}
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
-env:
-  # Workaround for https://github.com/actions/virtual-environments/issues/5900.
-  # This should be a no-op for non-mac OSes
-  CPLUS_INCLUDE_PATH: /usr/local/Cellar/llvm@15/15.0.7/include/c++/v1:/usr/local/Cellar/llvm/15.0.7_1/include/c++/v1:/Library/Developer/CommandLineTools/SDKs/MacOSX12.1.sdk/usr/include
-
 jobs:
   lit-tests:
     name: Lit Tests
@@ -51,11 +46,6 @@ jobs:
         uses: llvm/actions/setup-windows@main
         with:
           arch: amd64
-      - name: Check macOS (for debugging)
-        if: startsWith(matrix.os, 'macos')
-        run: |
-          ls /Library/Developer/CommandLineTools/SDKs
-          find /usr/local -name "cmath*"
       # On Windows, starting with win19/20220814.1, cmake choose the 32-bit
       # python3.10.6 libraries instead of the 64-bit libraries when building
       # lldb.  Using this setup-python action to make 3.10 the default

--- a/cmake/Modules/CMakePolicy.cmake
+++ b/cmake/Modules/CMakePolicy.cmake
@@ -1,5 +1,10 @@
 # CMake policy settings shared between LLVM projects
 
+# CMP0094: Use LOCATION for Find_Python lookup strategy.
+# New in CMake 3.15: https://cmake.org/cmake/help/latest/policy/CMP0094.html
+if(POLICY CMP0094)
+  cmake_policy(SET CMP0094 NEW)
+endif()
 # CMP0114: ExternalProject step targets fully adopt their steps.
 # New in CMake 3.19: https://cmake.org/cmake/help/latest/policy/CMP0114.html
 if(POLICY CMP0114)


### PR DESCRIPTION
necessary.  Set CMake policy for Python-lookup behavior to work with latest GitHub macOS runner.

This PR fixes test failures recently observed on the GitHub Actions macOS runner.