### PR TITLE
Fix handling of `cilk_for` loops with template-type induction variables, and other fixes

### DIFF
--- a/clang/lib/Driver/ToolChains/Darwin.cpp
+++ b/clang/lib/Driver/ToolChains/Darwin.cpp
@@ -3459,10 +3459,7 @@ void DarwinClang::AddLinkTapirRuntime(const ArgList &Args,
   case TapirTargetID::OpenCilk: {
     bool StaticOpenCilk = Args.hasArg(options::OPT_static_libopencilk);
     bool UseAsan = getSanitizerArgs(Args).needsAsanRt();
-
     auto RLO = RLO_AlwaysLink;
-    if (!StaticOpenCilk)
-      RLO = RuntimeLinkOptions(RLO | RLO_AddRPath);
 
     // If pedigrees are enabled, link the OpenCilk pedigree library.
     if (Args.hasArg(options::OPT_fopencilk_enable_pedigrees))
@@ -3482,6 +3479,11 @@ void DarwinClang::AddLinkTapirRuntime(const ArgList &Args,
                              UseAsan ? "opencilk-asan-personality-c"
                                      : "opencilk-personality-c",
                              RLO, !StaticOpenCilk);
+
+    if (!StaticOpenCilk)
+      // Add rpath flag for linking the final Tapir runtime library, to avoid
+      // warnings about ignoring duplicate rpaths.
+      RLO = RuntimeLinkOptions(RLO | RLO_AddRPath);
 
     // Link the opencilk runtime.  We do this after linking the personality
     // function, to ensure that symbols are resolved correctly when using static

--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -3530,6 +3530,15 @@ StmtResult Sema::HandleSimpleCilkForStmt(SourceLocation CilkForLoc,
   VarDecl *LoopVar = dyn_cast<VarDecl>(LoopVarDS->getSingleDecl());
   if (!LoopVar)
     return StmtEmpty();
+  QualType LoopVarTy = LoopVar->getType();
+
+  if (LoopVarTy->isDependentType()) {
+    // Delay handling this loop until LoopVarTy is derived, so that difference
+    // types can be properly derived.
+    return new (Context)
+        CilkForStmt(First, nullptr, nullptr, nullptr, nullptr, Condition,
+                    Increment, nullptr, Body, CilkForLoc, LParenLoc, RParenLoc);
+  }
 
   // Get the loop variable initialization.
   Expr *LoopVarInit = LoopVar->getInit();
@@ -3540,7 +3549,7 @@ StmtResult Sema::HandleSimpleCilkForStmt(SourceLocation CilkForLoc,
   }
 
   // Get the loop-limit expression, which the loop variable is compared against.
-  // TODO: Generlize this logic to handle complex conditions, e.g., class
+  // TODO: Generalize this logic to handle complex conditions, e.g., class
   // methods instead of integer binary operators.
   BinaryOperator *Cond = dyn_cast_or_null<BinaryOperator>(Condition);
   if (!Cond || !Cond->isComparisonOp())
@@ -3613,7 +3622,6 @@ StmtResult Sema::HandleSimpleCilkForStmt(SourceLocation CilkForLoc,
 
   // Create a declaration for the initialization of this loop, to ensure its
   // evaluated just once.
-  QualType LoopVarTy = LoopVar->getType();
   SourceLocation InitLoc = LoopVarInit->getBeginLoc();
   // Add declaration to store the old loop var initialization.
   VarDecl *InitVar = BuildForRangeVarDecl(*this, InitLoc,

--- a/clang/test/Cilk/cilkfor-bounds.cpp
+++ b/clang/test/Cilk/cilkfor-bounds.cpp
@@ -965,23 +965,23 @@ void down_ne_stride_flip(size_t start, size_t end, size_t stride) {
 // CHECK: [[PFORCONDCLEANUP]]:
 // CHECK-NEXT: sync within %[[SYNCREG]]
 
-// CHECK: ![[LOOPMD]] = distinct !{![[LOOPMD]], ![[SPAWNSTRATEGY:.+]]}
+// CHECK: ![[LOOPMD]] = distinct !{![[LOOPMD]], ![[MUSTPROGRESS:[0-9]+]], ![[SPAWNSTRATEGY:[0-9]+]]}
 // CHECK: ![[SPAWNSTRATEGY]] = !{!"tapir.loop.spawn.strategy", i32 1}
-// CHECK: ![[LOOPMD2]] = distinct !{![[LOOPMD2]], ![[SPAWNSTRATEGY]]}
-// CHECK: ![[LOOPMD3]] = distinct !{![[LOOPMD3]], ![[SPAWNSTRATEGY]]}
-// CHECK: ![[LOOPMD4]] = distinct !{![[LOOPMD4]], ![[SPAWNSTRATEGY]]}
-// CHECK: ![[LOOPMD5]] = distinct !{![[LOOPMD5]], ![[SPAWNSTRATEGY]]}
-// CHECK: ![[LOOPMD6]] = distinct !{![[LOOPMD6]], ![[SPAWNSTRATEGY]]}
-// CHECK: ![[LOOPMD7]] = distinct !{![[LOOPMD7]], ![[SPAWNSTRATEGY]]}
-// CHECK: ![[LOOPMD8]] = distinct !{![[LOOPMD8]], ![[SPAWNSTRATEGY]]}
-// CHECK: ![[LOOPMD9]] = distinct !{![[LOOPMD9]], ![[SPAWNSTRATEGY]]}
-// CHECK: ![[LOOPMD10]] = distinct !{![[LOOPMD10]], ![[SPAWNSTRATEGY]]}
-// CHECK: ![[LOOPMD11]] = distinct !{![[LOOPMD11]], ![[SPAWNSTRATEGY]]}
-// CHECK: ![[LOOPMD12]] = distinct !{![[LOOPMD12]], ![[SPAWNSTRATEGY]]}
-// CHECK: ![[LOOPMD13]] = distinct !{![[LOOPMD13]], ![[SPAWNSTRATEGY]]}
-// CHECK: ![[LOOPMD14]] = distinct !{![[LOOPMD14]], ![[SPAWNSTRATEGY]]}
-// CHECK: ![[LOOPMD15]] = distinct !{![[LOOPMD15]], ![[SPAWNSTRATEGY]]}
-// CHECK: ![[LOOPMD16]] = distinct !{![[LOOPMD16]], ![[SPAWNSTRATEGY]]}
-// CHECK: ![[LOOPMD17]] = distinct !{![[LOOPMD17]], ![[SPAWNSTRATEGY]]}
-// CHECK: ![[LOOPMD18]] = distinct !{![[LOOPMD18]], ![[SPAWNSTRATEGY]]}
-// CHECK: ![[LOOPMD19]] = distinct !{![[LOOPMD19]], ![[SPAWNSTRATEGY]]}
+// CHECK: ![[LOOPMD2]] = distinct !{![[LOOPMD2]], ![[MUSTPROGRESS]], ![[SPAWNSTRATEGY]]}
+// CHECK: ![[LOOPMD3]] = distinct !{![[LOOPMD3]], ![[MUSTPROGRESS]], ![[SPAWNSTRATEGY]]}
+// CHECK: ![[LOOPMD4]] = distinct !{![[LOOPMD4]], ![[MUSTPROGRESS]], ![[SPAWNSTRATEGY]]}
+// CHECK: ![[LOOPMD5]] = distinct !{![[LOOPMD5]], ![[MUSTPROGRESS]], ![[SPAWNSTRATEGY]]}
+// CHECK: ![[LOOPMD6]] = distinct !{![[LOOPMD6]], ![[MUSTPROGRESS]], ![[SPAWNSTRATEGY]]}
+// CHECK: ![[LOOPMD7]] = distinct !{![[LOOPMD7]], ![[MUSTPROGRESS]], ![[SPAWNSTRATEGY]]}
+// CHECK: ![[LOOPMD8]] = distinct !{![[LOOPMD8]], ![[MUSTPROGRESS]], ![[SPAWNSTRATEGY]]}
+// CHECK: ![[LOOPMD9]] = distinct !{![[LOOPMD9]], ![[MUSTPROGRESS]], ![[SPAWNSTRATEGY]]}
+// CHECK: ![[LOOPMD10]] = distinct !{![[LOOPMD10]], ![[MUSTPROGRESS]], ![[SPAWNSTRATEGY]]}
+// CHECK: ![[LOOPMD11]] = distinct !{![[LOOPMD11]], ![[MUSTPROGRESS]], ![[SPAWNSTRATEGY]]}
+// CHECK: ![[LOOPMD12]] = distinct !{![[LOOPMD12]], ![[MUSTPROGRESS]], ![[SPAWNSTRATEGY]]}
+// CHECK: ![[LOOPMD13]] = distinct !{![[LOOPMD13]], ![[MUSTPROGRESS]], ![[SPAWNSTRATEGY]]}
+// CHECK: ![[LOOPMD14]] = distinct !{![[LOOPMD14]], ![[MUSTPROGRESS]], ![[SPAWNSTRATEGY]]}
+// CHECK: ![[LOOPMD15]] = distinct !{![[LOOPMD15]], ![[MUSTPROGRESS]], ![[SPAWNSTRATEGY]]}
+// CHECK: ![[LOOPMD16]] = distinct !{![[LOOPMD16]], ![[MUSTPROGRESS]], ![[SPAWNSTRATEGY]]}
+// CHECK: ![[LOOPMD17]] = distinct !{![[LOOPMD17]], ![[MUSTPROGRESS]], ![[SPAWNSTRATEGY]]}
+// CHECK: ![[LOOPMD18]] = distinct !{![[LOOPMD18]], ![[MUSTPROGRESS]], ![[SPAWNSTRATEGY]]}
+// CHECK: ![[LOOPMD19]] = distinct !{![[LOOPMD19]], ![[MUSTPROGRESS]], ![[SPAWNSTRATEGY]]}

--- a/clang/test/Cilk/cilkfor-bounds.cpp
+++ b/clang/test/Cilk/cilkfor-bounds.cpp
@@ -26,15 +26,11 @@ void up(size_t start, size_t end) {
 // CHECK-NEXT: %[[ENDLIMIT:.+]] = load i64, ptr %[[LIMIT]]
 // CHECK-NEXT: %[[ENDINIT:.+]] = load i64, ptr %[[INIT]]
 // CHECK-NEXT: %[[ENDSUB:.+]] = sub i64 %[[ENDLIMIT]], %[[ENDINIT]]
-// CHECK-NEXT: %[[ENDSUB1:.+]] = sub i64 %[[ENDSUB]], 1
-// CHECK-NEXT: %[[ENDDIV:.+]] = udiv i64 %[[ENDSUB1]], 1
-// CHECK-NEXT: %[[ENDADD:.+]] = add i64 %[[ENDDIV]], 1
-// CHECK-NEXT: store i64 %[[ENDADD]], ptr %[[END:.+]], align 8
+// CHECK-NEXT: store i64 %[[ENDSUB]], ptr %[[END:.+]], align 8
 
 // CHECK: %[[INITITER:.+]] = load i64, ptr %[[INIT]]
 // CHECK-NEXT: %[[BEGINITER:.+]] = load i64, ptr %[[BEGIN]]
-// CHECK-NEXT: %[[ITERMUL:.+]] = mul i64 %[[BEGINITER]], 1
-// CHECK-NEXT: %[[ITERADD:.+]] = add i64 %[[INITITER]], %[[ITERMUL]]
+// CHECK-NEXT: %[[ITERADD:.+]] = add i64 %[[INITITER]], %[[BEGINITER]]
 // CHECK-NEXT: detach within %[[SYNCREG:.+]], label %[[DETACHED:.+]], label %[[PFORINC:.+]]
 
 // CHECK: [[DETACHED]]:
@@ -74,13 +70,11 @@ void up_leq(size_t start, size_t end) {
 // CHECK-NEXT: %[[ENDLIMIT:.+]] = load i64, ptr %[[LIMIT]]
 // CHECK-NEXT: %[[ENDINIT:.+]] = load i64, ptr %[[INIT]]
 // CHECK-NEXT: %[[ENDSUB:.+]] = sub i64 %[[ENDLIMIT]], %[[ENDINIT]]
-// CHECK-NEXT: %[[ENDDIV:.+]] = udiv i64 %[[ENDSUB]], 1
-// CHECK-NEXT: store i64 %[[ENDDIV]], ptr %[[END:.+]], align 8
+// CHECK-NEXT: store i64 %[[ENDSUB]], ptr %[[END:.+]], align 8
 
 // CHECK: %[[INITITER:.+]] = load i64, ptr %[[INIT]]
 // CHECK-NEXT: %[[BEGINITER:.+]] = load i64, ptr %[[BEGIN]]
-// CHECK-NEXT: %[[ITERMUL:.+]] = mul i64 %[[BEGINITER]], 1
-// CHECK-NEXT: %[[ITERADD:.+]] = add i64 %[[INITITER]], %[[ITERMUL]]
+// CHECK-NEXT: %[[ITERADD:.+]] = add i64 %[[INITITER]], %[[BEGINITER]]
 // CHECK-NEXT: detach within %[[SYNCREG:.+]], label %[[DETACHED:.+]], label %[[PFORINC:.+]]
 
 // CHECK: [[DETACHED]]:
@@ -120,15 +114,11 @@ void up_flip(size_t start, size_t end) {
 // CHECK-NEXT: %[[ENDLIMIT:.+]] = load i64, ptr %[[LIMIT]]
 // CHECK-NEXT: %[[ENDINIT:.+]] = load i64, ptr %[[INIT]]
 // CHECK-NEXT: %[[ENDSUB:.+]] = sub i64 %[[ENDLIMIT]], %[[ENDINIT]]
-// CHECK-NEXT: %[[ENDSUB1:.+]] = sub i64 %[[ENDSUB]], 1
-// CHECK-NEXT: %[[ENDDIV:.+]] = udiv i64 %[[ENDSUB1]], 1
-// CHECK-NEXT: %[[ENDADD:.+]] = add i64 %[[ENDDIV]], 1
-// CHECK-NEXT: store i64 %[[ENDADD]], ptr %[[END:.+]], align 8
+// CHECK-NEXT: store i64 %[[ENDSUB]], ptr %[[END:.+]], align 8
 
 // CHECK: %[[INITITER:.+]] = load i64, ptr %[[INIT]]
 // CHECK-NEXT: %[[BEGINITER:.+]] = load i64, ptr %[[BEGIN]]
-// CHECK-NEXT: %[[ITERMUL:.+]] = mul i64 %[[BEGINITER]], 1
-// CHECK-NEXT: %[[ITERADD:.+]] = add i64 %[[INITITER]], %[[ITERMUL]]
+// CHECK-NEXT: %[[ITERADD:.+]] = add i64 %[[INITITER]], %[[BEGINITER]]
 // CHECK-NEXT: detach within %[[SYNCREG:.+]], label %[[DETACHED:.+]], label %[[PFORINC:.+]]
 
 // CHECK: [[DETACHED]]:
@@ -168,13 +158,11 @@ void up_flip_geq(size_t start, size_t end) {
 // CHECK-NEXT: %[[ENDLIMIT:.+]] = load i64, ptr %[[LIMIT]]
 // CHECK-NEXT: %[[ENDINIT:.+]] = load i64, ptr %[[INIT]]
 // CHECK-NEXT: %[[ENDSUB:.+]] = sub i64 %[[ENDLIMIT]], %[[ENDINIT]]
-// CHECK-NEXT: %[[ENDDIV:.+]] = udiv i64 %[[ENDSUB]], 1
-// CHECK-NEXT: store i64 %[[ENDDIV]], ptr %[[END:.+]], align 8
+// CHECK-NEXT: store i64 %[[ENDSUB]], ptr %[[END:.+]], align 8
 
 // CHECK: %[[INITITER:.+]] = load i64, ptr %[[INIT]]
 // CHECK-NEXT: %[[BEGINITER:.+]] = load i64, ptr %[[BEGIN]]
-// CHECK-NEXT: %[[ITERMUL:.+]] = mul i64 %[[BEGINITER]], 1
-// CHECK-NEXT: %[[ITERADD:.+]] = add i64 %[[INITITER]], %[[ITERMUL]]
+// CHECK-NEXT: %[[ITERADD:.+]] = add i64 %[[INITITER]], %[[BEGINITER]]
 // CHECK-NEXT: detach within %[[SYNCREG:.+]], label %[[DETACHED:.+]], label %[[PFORINC:.+]]
 
 // CHECK: [[DETACHED]]:
@@ -506,15 +494,11 @@ void down(size_t start, size_t end) {
 // CHECK-NEXT: %[[ENDINIT:.+]] = load i64, ptr %[[INIT]]
 // CHECK-NEXT: %[[ENDLIMIT:.+]] = load i64, ptr %[[LIMIT]]
 // CHECK-NEXT: %[[ENDSUB:.+]] = sub i64 %[[ENDINIT]], %[[ENDLIMIT]]
-// CHECK-NEXT: %[[ENDSUB1:.+]] = sub i64 %[[ENDSUB]], 1
-// CHECK-NEXT: %[[ENDDIV:.+]] = udiv i64 %[[ENDSUB1]], 1
-// CHECK-NEXT: %[[ENDADD:.+]] = add i64 %[[ENDDIV]], 1
-// CHECK-NEXT: store i64 %[[ENDADD]], ptr %[[END:.+]], align 8
+// CHECK-NEXT: store i64 %[[ENDSUB]], ptr %[[END:.+]], align 8
 
 // CHECK: %[[INITITER:.+]] = load i64, ptr %[[INIT]]
 // CHECK-NEXT: %[[BEGINITER:.+]] = load i64, ptr %[[BEGIN]]
-// CHECK-NEXT: %[[ITERMUL:.+]] = mul i64 %[[BEGINITER]], 1
-// CHECK-NEXT: %[[ITERADD:.+]] = sub i64 %[[INITITER]], %[[ITERMUL]]
+// CHECK-NEXT: %[[ITERADD:.+]] = sub i64 %[[INITITER]], %[[BEGINITER]]
 // CHECK-NEXT: detach within %[[SYNCREG:.+]], label %[[DETACHED:.+]], label %[[PFORINC:.+]]
 
 // CHECK: [[DETACHED]]:
@@ -554,13 +538,11 @@ void down_geq(size_t start, size_t end) {
 // CHECK-NEXT: %[[ENDINIT:.+]] = load i64, ptr %[[INIT]]
 // CHECK-NEXT: %[[ENDLIMIT:.+]] = load i64, ptr %[[LIMIT]]
 // CHECK-NEXT: %[[ENDSUB:.+]] = sub i64 %[[ENDINIT]], %[[ENDLIMIT]]
-// CHECK-NEXT: %[[ENDDIV:.+]] = udiv i64 %[[ENDSUB]], 1
-// CHECK-NEXT: store i64 %[[ENDDIV]], ptr %[[END:.+]], align 8
+// CHECK-NEXT: store i64 %[[ENDSUB]], ptr %[[END:.+]], align 8
 
 // CHECK: %[[INITITER:.+]] = load i64, ptr %[[INIT]]
 // CHECK-NEXT: %[[BEGINITER:.+]] = load i64, ptr %[[BEGIN]]
-// CHECK-NEXT: %[[ITERMUL:.+]] = mul i64 %[[BEGINITER]], 1
-// CHECK-NEXT: %[[ITERADD:.+]] = sub i64 %[[INITITER]], %[[ITERMUL]]
+// CHECK-NEXT: %[[ITERADD:.+]] = sub i64 %[[INITITER]], %[[BEGINITER]]
 // CHECK-NEXT: detach within %[[SYNCREG:.+]], label %[[DETACHED:.+]], label %[[PFORINC:.+]]
 
 // CHECK: [[DETACHED]]:
@@ -600,15 +582,11 @@ void down_flip(size_t start, size_t end) {
 // CHECK-NEXT: %[[ENDINIT:.+]] = load i64, ptr %[[INIT]]
 // CHECK-NEXT: %[[ENDLIMIT:.+]] = load i64, ptr %[[LIMIT]]
 // CHECK-NEXT: %[[ENDSUB:.+]] = sub i64 %[[ENDINIT]], %[[ENDLIMIT]]
-// CHECK-NEXT: %[[ENDSUB1:.+]] = sub i64 %[[ENDSUB]], 1
-// CHECK-NEXT: %[[ENDDIV:.+]] = udiv i64 %[[ENDSUB1]], 1
-// CHECK-NEXT: %[[ENDADD:.+]] = add i64 %[[ENDDIV]], 1
-// CHECK-NEXT: store i64 %[[ENDADD]], ptr %[[END:.+]], align 8
+// CHECK-NEXT: store i64 %[[ENDSUB]], ptr %[[END:.+]], align 8
 
 // CHECK: %[[INITITER:.+]] = load i64, ptr %[[INIT]]
 // CHECK-NEXT: %[[BEGINITER:.+]] = load i64, ptr %[[BEGIN]]
-// CHECK-NEXT: %[[ITERMUL:.+]] = mul i64 %[[BEGINITER]], 1
-// CHECK-NEXT: %[[ITERADD:.+]] = sub i64 %[[INITITER]], %[[ITERMUL]]
+// CHECK-NEXT: %[[ITERADD:.+]] = sub i64 %[[INITITER]], %[[BEGINITER]]
 // CHECK-NEXT: detach within %[[SYNCREG:.+]], label %[[DETACHED:.+]], label %[[PFORINC:.+]]
 
 // CHECK: [[DETACHED]]:
@@ -648,13 +626,11 @@ void down_flip_leq(size_t start, size_t end) {
 // CHECK-NEXT: %[[ENDINIT:.+]] = load i64, ptr %[[INIT]]
 // CHECK-NEXT: %[[ENDLIMIT:.+]] = load i64, ptr %[[LIMIT]]
 // CHECK-NEXT: %[[ENDSUB:.+]] = sub i64 %[[ENDINIT]], %[[ENDLIMIT]]
-// CHECK-NEXT: %[[ENDDIV:.+]] = udiv i64 %[[ENDSUB]], 1
-// CHECK-NEXT: store i64 %[[ENDDIV]], ptr %[[END:.+]], align 8
+// CHECK-NEXT: store i64 %[[ENDSUB]], ptr %[[END:.+]], align 8
 
 // CHECK: %[[INITITER:.+]] = load i64, ptr %[[INIT]]
 // CHECK-NEXT: %[[BEGINITER:.+]] = load i64, ptr %[[BEGIN]]
-// CHECK-NEXT: %[[ITERMUL:.+]] = mul i64 %[[BEGINITER]], 1
-// CHECK-NEXT: %[[ITERADD:.+]] = sub i64 %[[INITITER]], %[[ITERMUL]]
+// CHECK-NEXT: %[[ITERADD:.+]] = sub i64 %[[INITITER]], %[[BEGINITER]]
 // CHECK-NEXT: detach within %[[SYNCREG:.+]], label %[[DETACHED:.+]], label %[[PFORINC:.+]]
 
 // CHECK: [[DETACHED]]:

--- a/clang/test/Cilk/cilkfor-iv-dependent-type.cpp
+++ b/clang/test/Cilk/cilkfor-iv-dependent-type.cpp
@@ -1,0 +1,33 @@
+// RUN: %clang_cc1 %s -std=c++20 -fopencilk -disable-llvm-passes -S -emit-llvm -o - | FileCheck %s
+
+template <class index_t> void foo() {
+  _Cilk_for(index_t row = 0; row < 1024; row++) { void; }
+}
+
+int main() { foo<int>(); }
+
+// CHECK-LABEL: define {{.*}}void @_Z3fooIiEvv()
+// CHECK: entry:
+// CHECK: %[[INIT_LOAD:.+]] = load i32, ptr %__init
+// CHECK-NEXT: %[[LIMIT_LOAD:.+]] = load i32, ptr %__limit
+// CHECK-NEXT: %[[CMP:.+]] = icmp slt i32 %[[INIT_LOAD]], %[[LIMIT_LOAD]]
+// CHECK-NEXT: br i1 %[[CMP]], label %pfor.ph, label %pfor.end
+
+// CHECK: pfor.ph:
+// CHECK: store i32 0, ptr %__begin
+// CHECK-NEXT: %[[LIMIT_LOAD2:.+]] = load i32, ptr %__limit
+// CHECK-NEXT: %[[INIT_LOAD2:.+]] = load i32, ptr %__init
+// CHECK-NEXT: %[[SUB:.+]] = sub nsw i32 %[[LIMIT_LOAD2]], %[[INIT_LOAD2]]
+// CHECK-NEXT: store i32 %[[SUB]], ptr %__end
+// CHECK-NEXT: br label %pfor.cond
+
+// CHECK: pfor.detach:
+// CHECK-NEXT: %[[INIT_LOAD3:.+]] = load i32, ptr %__init
+// CHECK-NEXT: %[[BEGIN_LOAD:.+]] = load i32, ptr %__begin
+// CHECK-NEXT: %[[ADD:.+]] = add nsw i32 %[[INIT_LOAD3]], %[[BEGIN_LOAD]]
+// CHECK-NEXT: detach within %{{.+}}, label %pfor.body.entry, label %pfor.inc
+
+// CHECK: pfor.body.entry:
+// CHECK-NEXT: %[[ROW:.+]] = alloca i32
+// CHECK-NEXT: store i32 %[[ADD]], ptr %[[ROW]]
+// CHECK-NEXT: br label %pfor.body

--- a/clang/test/Cilk/tapirloopattrs.c
+++ b/clang/test/Cilk/tapirloopattrs.c
@@ -26,14 +26,15 @@ void parfor_unroll_vec(double *restrict y, double *restrict x, double a, int n) 
 // CHECK: !llvm.loop [[LOOPID2:![0-9]+]]
 // CHECK: !llvm.loop [[LOOPID3:![0-9]+]]
 
-// CHECK: [[LOOPID1]] = distinct !{[[LOOPID1]], [[TAPIR_SPAWN_STRATEGY:![0-9]+]], [[NOVEC:![0-9]+]]}
+// CHECK: [[LOOPID1]] = distinct !{[[LOOPID1]], [[MUSTPROGRESS:![0-9]+]], [[TAPIR_SPAWN_STRATEGY:![0-9]+]], [[NOVEC:![0-9]+]]}
+// CHECK: [[MUSTPROGRESS]] = !{!"llvm.loop.mustprogress"}
 // CHECK: [[TAPIR_SPAWN_STRATEGY]] = !{!"tapir.loop.spawn.strategy", i32 1}
 // CHECK: [[NOVEC]] = !{!"llvm.loop.vectorize.width", i32 1}
 
-// CHECK: [[LOOPID2]] = distinct !{[[LOOPID2]], [[MUSTPROGRESS:![0-9]+]], [[VECATTRS:!.+]], [[VECFOLLOWALL1:![0-9]+]]}
+// CHECK: [[LOOPID2]] = distinct !{[[LOOPID2]], [[MUSTPROGRESS]], [[VECATTRS:!.+]], [[VECFOLLOWALL1:![0-9]+]]}
 // CHECK: [[VECFOLLOWALL1]] = !{!"llvm.loop.vectorize.followup_all", [[VECFOLLOW1:![0-9]+]]}
 // CHECK: [[VECFOLLOW1]] = distinct !{[[VECFOLLOW1]], [[MUSTPROGRESS]], [[VECFOLLOWATTRS:!.+]]}
 
-// CHECK: [[LOOPID3]] = distinct !{[[LOOPID3]], [[TAPIR_SPAWN_STRATEGY]], [[VECATTRS]], [[VECFOLLOWALL2:![0-9]+]]}
+// CHECK: [[LOOPID3]] = distinct !{[[LOOPID3]], [[MUSTPROGRESS]], [[TAPIR_SPAWN_STRATEGY]], [[VECATTRS]], [[VECFOLLOWALL2:![0-9]+]]}
 // CHECK: [[VECFOLLOWALL2]] = !{!"llvm.loop.vectorize.followup_all", [[VECFOLLOW2:![0-9]+]]}
-// CHECK: [[VECFOLLOW2]] = distinct !{[[VECFOLLOW2]], [[TAPIR_SPAWN_STRATEGY]], [[VECFOLLOWATTRS]]}
+// CHECK: [[VECFOLLOW2]] = distinct !{[[VECFOLLOW2]], [[MUSTPROGRESS]], [[TAPIR_SPAWN_STRATEGY]], [[VECFOLLOWATTRS]]}


### PR DESCRIPTION
This PR addresses the following:
- Fix issue OpenCilk/opencilk-project#220 with the handling of template-type induction variables in simple `cilk_for` loops.
- Simplify the code generation of simple `cilk_for` loops.
- Fix warnings on macOS about redundant rpath flags.
- Bring `cilk_for` loop code-generation in line with that of ordinary `for` loops in clang 16, with respect to loop attributes.