### PR TITLE
[Tapir] Add IPO to link components for TapirOpts library.

### DIFF
--- a/llvm/lib/Transforms/Tapir/CMakeLists.txt
+++ b/llvm/lib/Transforms/Tapir/CMakeLists.txt
@@ -31,6 +31,7 @@ add_llvm_component_library(LLVMTapirOpts
   LINK_COMPONENTS
   Analysis
   Core
+  IPO
   IRReader
   Linker
   MC


### PR DESCRIPTION
fixes OpenCilk/opencilk-project#234