### PR TITLE
clangd support for Cilk

### DIFF
--- a/clang-tools-extra/clangd/Selection.cpp
+++ b/clang-tools-extra/clangd/Selection.cpp
@@ -708,10 +708,16 @@ public:
   bool TraverseCilkForStmt(CilkForStmt *S) {
     return traverseNode(S, [&] {
       if (S->getLoopVarStmt())
+        // Traverse the original init, condition, and increment, as these best
+        // reflect the syntax of the cilk_for loop.  We traverse these
+        // statements before the loop-variable declaration itself because, for
+        // simple cilk_for loops with compound-assignment increment statements,
+        // the loop-variable declaration will appear to cover these statements
+        // as well.
         return TraverseStmt(S->getOriginalInit()) &&
-               TraverseDecl(S->getLoopVariable()) &&
                TraverseStmt(S->getOriginalCond()) &&
-               TraverseStmt(S->getOriginalInc()) && TraverseStmt(S->getBody());
+               TraverseStmt(S->getOriginalInc()) &&
+               TraverseDecl(S->getLoopVariable()) && TraverseStmt(S->getBody());
       else
         return TraverseStmt(S->getInit()) &&
                TraverseStmt(reinterpret_cast<Stmt *>(S->getCond())) &&

--- a/clang-tools-extra/clangd/refactor/tweaks/ExtractFunction.cpp
+++ b/clang-tools-extra/clangd/refactor/tweaks/ExtractFunction.cpp
@@ -566,7 +566,7 @@ void CapturedZoneInfo::DeclInformation::markOccurence(
 
 bool isLoop(const Stmt *S) {
   return isa<ForStmt>(S) || isa<DoStmt>(S) || isa<WhileStmt>(S) ||
-         isa<CXXForRangeStmt>(S);
+         isa<CXXForRangeStmt>(S) || isa<CilkForStmt>(S);
 }
 
 // Captures information from Extraction Zone

--- a/clang/include/clang/AST/Decl.h
+++ b/clang/include/clang/AST/Decl.h
@@ -1073,6 +1073,10 @@ protected:
     unsigned ImplicitParamKind : 3;
 
     unsigned EscapingByref : 1;
+
+    /// Whether this variable is the loop-variable declaration in a simple Cilk
+    /// for statement.
+    unsigned SimpleCilkForLVDecl : 1;
   };
 
   union {
@@ -1477,6 +1481,17 @@ public:
   void setCXXForRangeDecl(bool FRD) {
     assert(!isa<ParmVarDecl>(this));
     NonParmVarDeclBits.CXXForRangeDecl = FRD;
+  }
+
+  /// Determine whether this variable is the loop-variable declaration in a
+  /// simple Cilk for statement.
+  bool isSimpleCilkForLVDecl() const {
+    return isa<ParmVarDecl>(this) ? false
+                                  : NonParmVarDeclBits.SimpleCilkForLVDecl;
+  }
+  void setSimpleCilkForLVDecl(bool CFID) {
+    assert(!isa<ParmVarDecl>(this));
+    NonParmVarDeclBits.SimpleCilkForLVDecl = CFID;
   }
 
   /// Determine whether this variable is a for-loop declaration for a

--- a/clang/include/clang/AST/StmtCilk.h
+++ b/clang/include/clang/AST/StmtCilk.h
@@ -95,20 +95,23 @@ public:
 /// CilkForStmt - This represents a '_Cilk_for(init;cond;inc)' stmt.
 class CilkForStmt : public Stmt {
   SourceLocation CilkForLoc;
-  enum { INIT, LIMIT, INITCOND, BEGINSTMT, ENDSTMT, COND, INC, LOOPVAR, BODY, END };
+  enum { INIT, LIMIT, INITCOND, BEGINSTMT, ENDSTMT, COND, INC, LOOPVAR,
+         OGCOND, OGINC, BODY, END };
   Stmt* SubExprs[END]; // SubExprs[INIT] is an expression or declstmt.
   SourceLocation LParenLoc, RParenLoc;
 
 public:
   CilkForStmt(Stmt *Init, DeclStmt *Limit, Expr *InitCond, DeclStmt *Begin,
               DeclStmt *End, Expr *Cond, Expr *Inc, DeclStmt *LoopVar,
-              Stmt *Body, SourceLocation CFL, SourceLocation LP,
-              SourceLocation RP);
+              Stmt *Body, Stmt *OgCond, Stmt *OgInc, SourceLocation CFL,
+              SourceLocation LP, SourceLocation RP);
 
   /// Build an empty _Cilk_for statement.
   explicit CilkForStmt(EmptyShell Empty) : Stmt(CilkForStmtClass, Empty) { }
 
   Stmt *getInit() { return SubExprs[INIT]; }
+
+  VarDecl *getLoopVariable();
 
   // /// Retrieve the variable declared in this "for" statement, if any.
   // ///
@@ -142,7 +145,12 @@ public:
   }
   Stmt *getBody() { return SubExprs[BODY]; }
 
+  Stmt *getOriginalInit();
+  Stmt *getOriginalCond() { return SubExprs[OGCOND]; }
+  Stmt *getOriginalInc() { return SubExprs[OGINC]; }
+
   const Stmt *getInit() const { return SubExprs[INIT]; }
+  const VarDecl *getLoopVariable() const;
   const DeclStmt *getLimitStmt() const {
     return cast_or_null<DeclStmt>(SubExprs[LIMIT]);
   }
@@ -162,6 +170,10 @@ public:
   }
   const Stmt *getBody() const { return SubExprs[BODY]; }
 
+  const Stmt *getOriginalInit() const;
+  const Stmt *getOriginalCond() const { return SubExprs[OGCOND]; }
+  const Stmt *getOriginalInc() const { return SubExprs[OGINC]; }
+
   void setInit(Stmt *S) { SubExprs[INIT] = S; }
   void setLimitStmt(Stmt *S) { SubExprs[LIMIT] = S; }
   void setInitCond(Expr *E) { SubExprs[INITCOND] = reinterpret_cast<Stmt*>(E); }
@@ -171,6 +183,9 @@ public:
   void setInc(Expr *E) { SubExprs[INC] = reinterpret_cast<Stmt*>(E); }
   void setLoopVarStmt(Stmt *S) { SubExprs[LOOPVAR] = S; }
   void setBody(Stmt *S) { SubExprs[BODY] = S; }
+
+  void setOriginalCond(Stmt *S) { SubExprs[OGCOND] = S; }
+  void setOriginalCnc(Stmt *S) { SubExprs[OGINC] = S; }
 
   SourceLocation getCilkForLoc() const { return CilkForLoc; }
   void setCilkForLoc(SourceLocation L) { CilkForLoc = L; }

--- a/clang/include/clang/AST/StmtCilk.h
+++ b/clang/include/clang/AST/StmtCilk.h
@@ -103,11 +103,11 @@ class CilkForStmt : public Stmt {
 public:
   CilkForStmt(Stmt *Init, DeclStmt *Limit, Expr *InitCond, DeclStmt *Begin,
               DeclStmt *End, Expr *Cond, Expr *Inc, DeclStmt *LoopVar,
-              Stmt *Body, Stmt *OgCond, Stmt *OgInc, SourceLocation CFL,
+              Stmt *Body, Expr *OgCond, Expr *OgInc, SourceLocation CFL,
               SourceLocation LP, SourceLocation RP);
 
   /// Build an empty _Cilk_for statement.
-  explicit CilkForStmt(EmptyShell Empty) : Stmt(CilkForStmtClass, Empty) { }
+  explicit CilkForStmt(EmptyShell Empty) : Stmt(CilkForStmtClass, Empty) {}
 
   Stmt *getInit() { return SubExprs[INIT]; }
 
@@ -130,24 +130,22 @@ public:
   //   return reinterpret_cast<DeclStmt*>(SubExprs[CONDVAR]);
   // }
 
-  DeclStmt *getLimitStmt() {
-    return cast_or_null<DeclStmt>(SubExprs[LIMIT]);
-  }
+  DeclStmt *getLimitStmt() { return cast_or_null<DeclStmt>(SubExprs[LIMIT]); }
   Expr *getInitCond() { return cast_or_null<Expr>(SubExprs[INITCOND]); }
   DeclStmt *getBeginStmt() {
     return cast_or_null<DeclStmt>(SubExprs[BEGINSTMT]);
   }
   DeclStmt *getEndStmt() { return cast_or_null<DeclStmt>(SubExprs[ENDSTMT]); }
-  Expr *getCond() { return reinterpret_cast<Expr*>(SubExprs[COND]); }
-  Expr *getInc()  { return reinterpret_cast<Expr*>(SubExprs[INC]); }
+  Expr *getCond() { return reinterpret_cast<Expr *>(SubExprs[COND]); }
+  Expr *getInc() { return reinterpret_cast<Expr *>(SubExprs[INC]); }
   DeclStmt *getLoopVarStmt() {
     return cast_or_null<DeclStmt>(SubExprs[LOOPVAR]);
   }
   Stmt *getBody() { return SubExprs[BODY]; }
 
   Stmt *getOriginalInit();
-  Stmt *getOriginalCond() { return SubExprs[OGCOND]; }
-  Stmt *getOriginalInc() { return SubExprs[OGINC]; }
+  Expr *getOriginalCond() { return reinterpret_cast<Expr *>(SubExprs[OGCOND]); }
+  Expr *getOriginalInc() { return reinterpret_cast<Expr *>(SubExprs[OGINC]); }
 
   const Stmt *getInit() const { return SubExprs[INIT]; }
   const VarDecl *getLoopVariable() const;
@@ -163,24 +161,32 @@ public:
   const DeclStmt *getEndStmt() const {
     return cast_or_null<DeclStmt>(SubExprs[ENDSTMT]);
   }
-  const Expr *getCond() const { return reinterpret_cast<Expr*>(SubExprs[COND]);}
-  const Expr *getInc()  const { return reinterpret_cast<Expr*>(SubExprs[INC]); }
+  const Expr *getCond() const {
+    return reinterpret_cast<Expr *>(SubExprs[COND]);
+  }
+  const Expr *getInc() const { return reinterpret_cast<Expr *>(SubExprs[INC]); }
   const DeclStmt *getLoopVarStmt() const {
     return cast_or_null<DeclStmt>(SubExprs[LOOPVAR]);
   }
   const Stmt *getBody() const { return SubExprs[BODY]; }
 
   const Stmt *getOriginalInit() const;
-  const Stmt *getOriginalCond() const { return SubExprs[OGCOND]; }
-  const Stmt *getOriginalInc() const { return SubExprs[OGINC]; }
+  const Expr *getOriginalCond() const {
+    return reinterpret_cast<Expr *>(SubExprs[OGCOND]);
+  }
+  const Expr *getOriginalInc() const {
+    return reinterpret_cast<Expr *>(SubExprs[OGINC]);
+  }
 
   void setInit(Stmt *S) { SubExprs[INIT] = S; }
   void setLimitStmt(Stmt *S) { SubExprs[LIMIT] = S; }
-  void setInitCond(Expr *E) { SubExprs[INITCOND] = reinterpret_cast<Stmt*>(E); }
+  void setInitCond(Expr *E) {
+    SubExprs[INITCOND] = reinterpret_cast<Stmt *>(E);
+  }
   void setBeginStmt(Stmt *S) { SubExprs[BEGINSTMT] = S; }
   void setEndStmt(Stmt *S) { SubExprs[ENDSTMT] = S; }
-  void setCond(Expr *E) { SubExprs[COND] = reinterpret_cast<Stmt*>(E); }
-  void setInc(Expr *E) { SubExprs[INC] = reinterpret_cast<Stmt*>(E); }
+  void setCond(Expr *E) { SubExprs[COND] = reinterpret_cast<Stmt *>(E); }
+  void setInc(Expr *E) { SubExprs[INC] = reinterpret_cast<Stmt *>(E); }
   void setLoopVarStmt(Stmt *S) { SubExprs[LOOPVAR] = S; }
   void setBody(Stmt *S) { SubExprs[BODY] = S; }
 
@@ -204,9 +210,7 @@ public:
   }
 
   // Iterators
-  child_range children() {
-    return child_range(&SubExprs[0], &SubExprs[END]);
-  }
+  child_range children() { return child_range(&SubExprs[0], &SubExprs[END]); }
 
   const_child_range children() const {
     return const_child_range(&SubExprs[0], &SubExprs[END]);

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -5263,7 +5263,8 @@ public:
                               DeclStmt *Begin, DeclStmt *End,
                               ConditionResult second, FullExprArg third,
                               SourceLocation RParenLoc, Stmt *Body,
-                              DeclStmt *LoopVar = nullptr);
+                              DeclStmt *LoopVar = nullptr,
+                              Stmt *OgCond = nullptr, Stmt *OgInc = nullptr);
 
   StmtResult BuildCilkForStmt(SourceLocation CilkForLoc,
                               SourceLocation LParenLoc,

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -5264,7 +5264,7 @@ public:
                               ConditionResult second, FullExprArg third,
                               SourceLocation RParenLoc, Stmt *Body,
                               DeclStmt *LoopVar = nullptr,
-                              Stmt *OgCond = nullptr, Stmt *OgInc = nullptr);
+                              Expr *OgCond = nullptr, Expr *OgInc = nullptr);
 
   StmtResult BuildCilkForStmt(SourceLocation CilkForLoc,
                               SourceLocation LParenLoc,

--- a/clang/include/clang/Tooling/Syntax/Nodes.h
+++ b/clang/include/clang/Tooling/Syntax/Nodes.h
@@ -327,6 +327,15 @@ public:
   Statement *getBody();
 };
 
+/// cilk_for (<init>; <cond>; <increment>) <body>
+class CilkForStatement final : public Statement {
+public:
+  CilkForStatement() : Statement(NodeKind::CilkForStatement) {}
+  static bool classof(const Node *N);
+  Leaf *getForKeyword();
+  Statement *getBody();
+};
+
 /// Expression in a statement position, e.g. functions calls inside compound
 /// statements or inside a loop body.
 class ExpressionStatement final : public Statement {

--- a/clang/include/clang/Tooling/Syntax/Nodes.td
+++ b/clang/include/clang/Tooling/Syntax/Nodes.td
@@ -232,6 +232,7 @@ def ContinueStatement : External<Statement> {}
 def BreakStatement : External<Statement> {}
 def ReturnStatement : External<Statement> {}
 def RangeBasedForStatement : External<Statement> {}
+def CilkForStatement : External<Statement> {}
 def ExpressionStatement : External<Statement> {}
 def CompoundStatement : External<Statement> {}
 

--- a/clang/lib/AST/ASTImporter.cpp
+++ b/clang/lib/AST/ASTImporter.cpp
@@ -6986,15 +6986,18 @@ ExpectedStmt ASTNodeImporter::VisitCilkForStmt(CilkForStmt *S) {
   auto ToInc = importChecked(Err, S->getInc());
   auto ToLoopVarStmt = importChecked(Err, S->getLoopVarStmt());
   auto ToBody = importChecked(Err, S->getBody());
+  auto ToOgCond = importChecked(Err, S->getOriginalCond());
+  auto ToOgInc = importChecked(Err, S->getOriginalInc());
   auto ToCilkForLoc = importChecked(Err, S->getCilkForLoc());
   auto ToLParenLoc = importChecked(Err, S->getLParenLoc());
   auto ToRParenLoc = importChecked(Err, S->getRParenLoc());
   if (Err)
     return std::move(Err);
 
-  return new (Importer.getToContext()) CilkForStmt(
-      ToInit, ToLimitStmt, ToInitCond, ToBeginStmt, ToEndStmt, ToCond, ToInc,
-      ToLoopVarStmt, ToBody, ToCilkForLoc, ToLParenLoc, ToRParenLoc);
+  return new (Importer.getToContext())
+      CilkForStmt(ToInit, ToLimitStmt, ToInitCond, ToBeginStmt, ToEndStmt,
+                  ToCond, ToInc, ToLoopVarStmt, ToBody, ToOgCond, ToOgInc,
+                  ToCilkForLoc, ToLParenLoc, ToRParenLoc);
 }
 
 ExpectedStmt ASTNodeImporter::VisitCilkScopeStmt(CilkScopeStmt *S) {

--- a/clang/lib/AST/DeclPrinter.cpp
+++ b/clang/lib/AST/DeclPrinter.cpp
@@ -896,7 +896,7 @@ void DeclPrinter::VisitVarDecl(VarDecl *D) {
   Expr *Init = D->getInit();
   if (!Policy.SuppressInitializers && Init) {
     bool ImplicitInit = false;
-    if (D->isCXXForRangeDecl()) {
+    if (D->isCXXForRangeDecl() || D->isSimpleCilkForLVDecl()) {
       // FIXME: We should print the range expression instead.
       ImplicitInit = true;
     } else if (CXXConstructExpr *Construct =

--- a/clang/lib/AST/Stmt.cpp
+++ b/clang/lib/AST/Stmt.cpp
@@ -1443,8 +1443,8 @@ bool CapturedStmt::capturesVariable(const VarDecl *Var) const {
 // CilkForStmt
 CilkForStmt::CilkForStmt(Stmt *Init, DeclStmt *Limit, Expr *InitCond,
                          DeclStmt *BeginStmt, DeclStmt *EndStmt, Expr *Cond,
-                         Expr *Inc, DeclStmt *LoopVar, Stmt *Body,
-                         SourceLocation CFL, SourceLocation LP,
+                         Expr *Inc, DeclStmt *LoopVar, Stmt *Body, Stmt *OgCond,
+                         Stmt *OgInc, SourceLocation CFL, SourceLocation LP,
                          SourceLocation RP)
     : Stmt(CilkForStmtClass), CilkForLoc(CFL), LParenLoc(LP), RParenLoc(RP) {
   SubExprs[INIT] = Init;
@@ -1456,4 +1456,27 @@ CilkForStmt::CilkForStmt(Stmt *Init, DeclStmt *Limit, Expr *InitCond,
   SubExprs[INC] = Inc;
   SubExprs[LOOPVAR] = LoopVar;
   SubExprs[BODY] = Body;
+  SubExprs[OGCOND] = OgCond;
+  SubExprs[OGINC] = OgInc;
+}
+
+VarDecl *CilkForStmt::getLoopVariable() {
+  Decl *LV = cast<DeclStmt>(getLoopVarStmt())->getSingleDecl();
+  assert(LV && "No simple loop variable in CilkForStmt");
+  return cast<VarDecl>(LV);
+}
+
+const VarDecl *CilkForStmt::getLoopVariable() const {
+  return const_cast<CilkForStmt *>(this)->getLoopVariable();
+}
+
+Stmt *CilkForStmt::getOriginalInit() {
+  Decl *IV = cast<DeclStmt>(getInit())->getSingleDecl();
+  if (!IV)
+    return getInit();
+  return cast<VarDecl>(IV)->getInit();
+}
+
+const Stmt *CilkForStmt::getOriginalInit() const {
+  return const_cast<CilkForStmt *>(this)->getOriginalInit();
 }

--- a/clang/lib/AST/Stmt.cpp
+++ b/clang/lib/AST/Stmt.cpp
@@ -1443,8 +1443,8 @@ bool CapturedStmt::capturesVariable(const VarDecl *Var) const {
 // CilkForStmt
 CilkForStmt::CilkForStmt(Stmt *Init, DeclStmt *Limit, Expr *InitCond,
                          DeclStmt *BeginStmt, DeclStmt *EndStmt, Expr *Cond,
-                         Expr *Inc, DeclStmt *LoopVar, Stmt *Body, Stmt *OgCond,
-                         Stmt *OgInc, SourceLocation CFL, SourceLocation LP,
+                         Expr *Inc, DeclStmt *LoopVar, Stmt *Body, Expr *OgCond,
+                         Expr *OgInc, SourceLocation CFL, SourceLocation LP,
                          SourceLocation RP)
     : Stmt(CilkForStmtClass), CilkForLoc(CFL), LParenLoc(LP), RParenLoc(RP) {
   SubExprs[INIT] = Init;

--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -3800,8 +3800,10 @@ StmtResult Sema::HandleSimpleCilkForStmt(SourceLocation CilkForLoc,
       StrideIsUnit
           ? BeginRef.get()
           : BuildBinOp(S, LoopVarLoc, BO_Mul, BeginRef.get(), Stride).get());
-  if (!NewLoopVarInit.isInvalid())
+  if (!NewLoopVarInit.isInvalid()) {
     AddInitializerToDecl(LoopVar, NewLoopVarInit.get(), /*DirectInit=*/false);
+    LoopVar->setSimpleCilkForLVDecl(true);
+  }
 
   return new (Context) CilkForStmt(
       NewInit.get(), cast<DeclStmt>(LimitDecl.get()), InitCond.get(),

--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -3931,7 +3931,7 @@ Sema::ActOnCilkForStmt(SourceLocation CilkForLoc, SourceLocation LParenLoc,
                        Stmt *First, DeclStmt *Limit, ConditionResult InitCond,
                        DeclStmt *Begin, DeclStmt *End, ConditionResult Second,
                        FullExprArg Third, SourceLocation RParenLoc, Stmt *Body,
-                       DeclStmt *LoopVar, Stmt *OgCond, Stmt *OgInc) {
+                       DeclStmt *LoopVar, Expr *OgCond, Expr *OgInc) {
   if (CheckCilkForInit(*this, CilkForLoc, First))
     return StmtResult();
 

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -1464,8 +1464,8 @@ public:
                                 Sema::ConditionResult InitCond, Stmt *Begin,
                                 Stmt *End, Sema::ConditionResult Cond,
                                 Sema::FullExprArg Inc, SourceLocation RParenLoc,
-                                Stmt *LoopVar, Stmt *Body, Stmt *OgCond,
-                                Stmt *OgInc) {
+                                Stmt *LoopVar, Stmt *Body, Expr *OgCond,
+                                Expr *OgInc) {
     return getSema().ActOnCilkForStmt(
         ForLoc, LParenLoc, Init, cast_or_null<DeclStmt>(Limit), InitCond,
         cast_or_null<DeclStmt>(Begin), cast_or_null<DeclStmt>(End), Cond, Inc,
@@ -15537,10 +15537,10 @@ TreeTransform<Derived>::TransformCilkForStmt(CilkForStmt *S) {
   }
 
   // Transform the original init, condition, and increment statements
-  StmtResult OgCond = getDerived().TransformStmt(S->getOriginalCond());
+  ExprResult OgCond = getDerived().TransformExpr(S->getOriginalCond());
   if (OgCond.isInvalid())
     return StmtError();
-  StmtResult OgInc = getDerived().TransformStmt(S->getOriginalInc());
+  ExprResult OgInc = getDerived().TransformExpr(S->getOriginalInc());
   if (OgInc.isInvalid())
     return StmtError();
 

--- a/clang/lib/Serialization/ASTReaderDecl.cpp
+++ b/clang/lib/Serialization/ASTReaderDecl.cpp
@@ -1606,6 +1606,7 @@ ASTDeclReader::RedeclarableResult ASTDeclReader::VisitVarDeclImpl(VarDecl *VD) {
     VD->NonParmVarDeclBits.PreviousDeclInSameBlockScope = Record.readInt();
     VD->NonParmVarDeclBits.ImplicitParamKind = Record.readInt();
     VD->NonParmVarDeclBits.EscapingByref = Record.readInt();
+    VD->NonParmVarDeclBits.SimpleCilkForLVDecl = Record.readInt();
     HasDeducedType = Record.readInt();
   }
 

--- a/clang/lib/Serialization/ASTWriterDecl.cpp
+++ b/clang/lib/Serialization/ASTWriterDecl.cpp
@@ -1073,6 +1073,7 @@ void ASTDeclWriter::VisitVarDecl(VarDecl *D) {
     else
       Record.push_back(0);
     Record.push_back(D->isEscapingByref());
+    Record.push_back(D->isSimpleCilkForLVDecl());
     HasDeducedType = D->getType()->getContainedDeducedType();
     Record.push_back(HasDeducedType);
   }
@@ -2332,6 +2333,7 @@ void ASTWriter::WriteDeclAbbrevs() {
   Abv->Add(BitCodeAbbrevOp(0));                         // isPrevDeclInSameScope
   Abv->Add(BitCodeAbbrevOp(0));                         // ImplicitParamKind
   Abv->Add(BitCodeAbbrevOp(0));                         // EscapingByref
+  Abv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 1)); // isSimpleCilkForLVDecl
   Abv->Add(BitCodeAbbrevOp(0));                         // HasDeducedType
   Abv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 3)); // Linkage
   Abv->Add(BitCodeAbbrevOp(0));                         // ModulesCodeGen

--- a/clang/lib/Tooling/Syntax/Synthesis.cpp
+++ b/clang/lib/Tooling/Syntax/Synthesis.cpp
@@ -138,6 +138,8 @@ syntax::Tree *allocateTree(syntax::Arena &A, syntax::NodeKind Kind) {
     return new (A.getAllocator()) syntax::ReturnStatement;
   case syntax::NodeKind::RangeBasedForStatement:
     return new (A.getAllocator()) syntax::RangeBasedForStatement;
+  case syntax::NodeKind::CilkForStatement:
+    return new (A.getAllocator()) syntax::CilkForStatement;
   case syntax::NodeKind::ExpressionStatement:
     return new (A.getAllocator()) syntax::ExpressionStatement;
   case syntax::NodeKind::CompoundStatement:

--- a/clang/test/Cilk/cilkfor-unused-expr-test.cpp
+++ b/clang/test/Cilk/cilkfor-unused-expr-test.cpp
@@ -1,0 +1,32 @@
+// RUN: %clang_cc1 %s -fopencilk -verify -fsyntax-only
+// expected-no-diagnostics
+
+typedef long long int64_t;
+
+template <bool transpose>
+__attribute__((always_inline)) static int64_t a_index(int64_t ii, int64_t m,
+                                                      int64_t jj, int64_t n) {
+  return transpose ? ((jj * m) + ii) : ((ii * n) + jj);
+}
+
+#define ARG_INDEX(arg, ii, m, jj, n, transpose)                                \
+  (arg[a_index<transpose>(ii, m, jj, n)])
+
+template <typename F>
+void matmul_ploops(F *__restrict__ out, const F *__restrict__ lhs,
+		   const F *__restrict__ rhs, int64_t m, int64_t n,
+		   int64_t k) {
+  _Cilk_for(int64_t i = 0; i < m; ++i) {
+    _Cilk_for(int64_t j = 0; j < n; ++j) {
+      out[j * m + i] = 0.0;
+      for (int64_t l = 0; l < k; ++l)
+	out[j * m + i] += ARG_INDEX(lhs, l, k, i, m, true) *
+	  ARG_INDEX(rhs, j, n, l, k, true);
+    }
+  }
+}
+
+template void matmul_ploops<float>(float *__restrict__ out,
+                                   const float *__restrict__ lhs,
+                                   const float *__restrict__ rhs, int64_t m,
+                                   int64_t n, int64_t k);


### PR DESCRIPTION
This PR adds support to clangd for Cilk parallel-control-flow keywords, `cilk_for`, `cilk_spawn`, `cilk_scope`, and `cilk_sync`.  The changes allow features of modern IDEs, including VS Code and others that use clangd, to work properly around these Cilk keywords.

Documentation on how to configure VS Code to use OpenCilk's version of clangd can be found here: https://github.com/neboat/vscode-opencilk.