### PR TITLE
Passing parent stack frames to spawn-helper functions

### DIFF
--- a/llvm/include/llvm/Analysis/TapirTaskInfo.h
+++ b/llvm/include/llvm/Analysis/TapirTaskInfo.h
@@ -15,7 +15,6 @@
 #define LLVM_ANALYSIS_TAPIRTASKINFO_H
 
 #include "llvm/ADT/DenseMap.h"
-#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/GraphTraits.h"
 #include "llvm/ADT/PostOrderIterator.h"
 #include "llvm/ADT/SetVector.h"
@@ -29,7 +28,6 @@
 #include "llvm/IR/PassManager.h"
 #include "llvm/Pass.h"
 #include "llvm/Support/Allocator.h"
-#include <algorithm>
 #include <utility>
 
 namespace llvm {

--- a/llvm/include/llvm/Transforms/Tapir/CilkABI.h
+++ b/llvm/include/llvm/Transforms/Tapir/CilkABI.h
@@ -127,7 +127,7 @@ public:
                           DominatorTree &DT) override final;
 
   LoopOutlineProcessor *
-  getLoopOutlineProcessor(const TapirLoopInfo *TL) const override final;
+  getLoopOutlineProcessor(const TapirLoopInfo *TL) override final;
 };
 } // namespace llvm
 

--- a/llvm/include/llvm/Transforms/Tapir/OpenCilkABI.h
+++ b/llvm/include/llvm/Transforms/Tapir/OpenCilkABI.h
@@ -140,11 +140,10 @@ class OpenCilkABI final : public TapirTarget {
   Value *CreateStackFrame(Function &F);
   Value *GetOrCreateCilkStackFrame(Function &F);
 
-  CallInst *InsertStackFramePush(Function &F,
-                                 Instruction *TaskFrameCreate = nullptr,
-                                 bool Helper = false);
+  CallInst *InsertStackFramePush(Function &F, Instruction *TaskFrameCreate,
+                                 bool Helper, bool Spawner);
   void InsertStackFramePop(Function &F, bool PromoteCallsToInvokes,
-                           bool InsertPauseFrame, bool Helper);
+                           bool InsertPauseFrame, bool Helper, bool Spawner);
 
   void InsertDetach(Function &F, Instruction *DetachPt);
 
@@ -166,6 +165,9 @@ public:
   ArgStructMode getArgStructMode() const override final {
     return ArgStructMode::None;
   }
+  void setupTaskOutlineArgs(Function &F, ValueSet &HelperArgs,
+                            SmallVectorImpl<Value *> &HelperInputs,
+                            const ValueSet &TaskHelperArgs) override final;
   void addHelperAttributes(Function &F) override final;
 
   void remapAfterOutlining(BasicBlock *TFEntry,
@@ -190,7 +192,7 @@ public:
   bool processOrdinaryFunction(Function &F, BasicBlock *TFEntry) override final;
 
   LoopOutlineProcessor *
-  getLoopOutlineProcessor(const TapirLoopInfo *TL) const override final;
+  getLoopOutlineProcessor(const TapirLoopInfo *TL) override final;
 };
 } // namespace llvm
 

--- a/llvm/lib/Transforms/Tapir/CilkABI.cpp
+++ b/llvm/lib/Transforms/Tapir/CilkABI.cpp
@@ -1784,7 +1784,7 @@ void CilkABI::postProcessFunction(Function &F, bool ProcessingTapirLoops) {
 void CilkABI::postProcessHelper(Function &F) {}
 
 LoopOutlineProcessor *
-CilkABI::getLoopOutlineProcessor(const TapirLoopInfo *TL) const {
+CilkABI::getLoopOutlineProcessor(const TapirLoopInfo *TL) {
   if (UseRuntimeCilkFor)
     return new RuntimeCilkFor(M);
   return nullptr;

--- a/llvm/lib/Transforms/Tapir/LoweringUtils.cpp
+++ b/llvm/lib/Transforms/Tapir/LoweringUtils.cpp
@@ -471,7 +471,7 @@ llvm::createTaskArgsStruct(const ValueSet &Inputs, Task *T,
 /// Organize the set \p Inputs of values in \p F into a set \p Fixed of values
 /// that can be used as inputs to a helper function.
 void llvm::fixupInputSet(Function &F, const ValueSet &Inputs, ValueSet &Fixed) {
-  // Scan for any sret parameters in TaskInputs and add them first.  These
+  // Scan for any sret parameters in Inputs and add them first.  These
   // parameters must appear first or second in the prototype of the Helper
   // function.
   Value *SRetInput = nullptr;
@@ -497,17 +497,19 @@ void llvm::fixupInputSet(Function &F, const ValueSet &Inputs, ValueSet &Fixed) {
   for (Value *V : Inputs)
     if (V != SRetInput)
       InputsToSort.push_back(V);
-  LLVM_DEBUG({
-    dbgs() << "After sorting:\n";
-    for (Value *V : InputsToSort)
-      dbgs() << "\t" << *V << "\n";
-  });
+
   const DataLayout &DL = F.getParent()->getDataLayout();
   std::sort(InputsToSort.begin(), InputsToSort.end(),
             [&DL](const Value *A, const Value *B) {
               return DL.getTypeSizeInBits(A->getType()) >
-                DL.getTypeSizeInBits(B->getType());
+                     DL.getTypeSizeInBits(B->getType());
             });
+
+  LLVM_DEBUG({
+    dbgs() << "inputs after fixup:\n";
+    for (Value *V : InputsToSort)
+      dbgs() << "\t" << *V << "\n";
+  });
 
   // Add the remaining inputs.
   for (Value *V : InputsToSort)

--- a/llvm/lib/Transforms/Tapir/Outline.cpp
+++ b/llvm/lib/Transforms/Tapir/Outline.cpp
@@ -325,7 +325,11 @@ Function *llvm::CreateHelper(
   for (Value *I : Inputs) {
     if (VMap.count(I) == 0) {       // Is this argument preserved?
       DestI->setName(I->getName()+NameSuffix); // Copy the name over...
-      VMap[I] = &*DestI++;          // Add mapping to VMap
+      if (isa<Constant>(I))
+        // Don't add this constant input to the VMap, so it won't get remapped
+        DestI++;
+      else
+        VMap[I] = &*DestI++;          // Add mapping to VMap
     }
     // Check for any vector arguments, and record the maximum width of any
     // vector argument we find.
@@ -550,6 +554,8 @@ void llvm::AddAlignmentAssumptions(
   for (Value *ArgVal : Args) {
     // Ignore arguments to non-pointer types
     if (!ArgVal->getType()->isPointerTy()) continue;
+    // Ignore constant pointer arguments
+    if (isa<Constant>(ArgVal)) continue;
     Argument *Arg = cast<Argument>(VMap[ArgVal]);
     // Ignore arguments to non-pointer types
     if (!Arg->getType()->isPointerTy()) continue;

--- a/llvm/lib/Transforms/Tapir/TapirToTarget.cpp
+++ b/llvm/lib/Transforms/Tapir/TapirToTarget.cpp
@@ -102,7 +102,7 @@ TapirToTargetImpl::outlineAllTasks(Function &F,
   DenseMap<Spindle *, SmallVector<Value *, 8>> HelperInputs;
 
   for (Spindle *TF : AllTaskFrames) {
-    // At this point, all subtaskframess of TF must have been processed.
+    // At this point, all subtaskframes of TF must have been processed.
     // Replace the tasks with calls to their outlined helper functions.
     for (Spindle *SubTF : TF->subtaskframes())
       TFToOutline[SubTF].replaceReplCall(

--- a/llvm/test/Transforms/Tapir/outline-helper-debug.ll
+++ b/llvm/test/Transforms/Tapir/outline-helper-debug.ll
@@ -116,7 +116,7 @@ cleanup:                                          ; preds = %sync.continue, %pfo
 ; CHECK-NEXT: br i1 %{{.+}}, label %[[CLEANUP_SPLIT:.+]], label %det.cont
 
 ; CHECK: [[CLEANUP_SPLIT]]:
-; CHECK-NEXT: call {{.*}}void @main.outline_pfor.end.otd1(ptr %x), !dbg ![[DBGMD:[0-9]+]]
+; CHECK-NEXT: call {{.*}}void @main.outline_pfor.end.otd1(ptr %x, ptr %{{.+}}), !dbg ![[DBGMD:[0-9]+]]
 
 ; CHECK: pfor.end:
 ; CHECK: detach within %syncreg6, label %det.achd, label %det.cont, !dbg ![[DBGMD]]

--- a/llvm/test/Transforms/Tapir/outline-shared-unreachable.ll
+++ b/llvm/test/Transforms/Tapir/outline-shared-unreachable.ll
@@ -33,10 +33,10 @@ unreachable:                                      ; preds = %entry.unreachable_c
 
 ; CHECK: define void @_ZN9LAMMPS_NS6Verlet14run_stencil_mdEiRNSt3__13mapIiNS1_6vectorIiNS1_9allocatorIiEEEENS1_4lessIiEENS4_INS1_4pairIKiS6_EEEEEESE_RNS2_IiiS8_NS4_INS9_ISA_iEEEEEESI_PPdSK_()
 ; CHECK: pfor.detach:
-; CHECK: invoke fastcc void @_ZN9LAMMPS_NS6Verlet14run_stencil_mdEiRNSt3__13mapIiNS1_6vectorIiNS1_9allocatorIiEEEENS1_4lessIiEENS4_INS1_4pairIKiS6_EEEEEESE_RNS2_IiiS8_NS4_INS9_ISA_iEEEEEESI_PPdSK_.outline_pfor.body.otd1()
+; CHECK: invoke fastcc void @_ZN9LAMMPS_NS6Verlet14run_stencil_mdEiRNSt3__13mapIiNS1_6vectorIiNS1_9allocatorIiEEEENS1_4lessIiEENS4_INS1_4pairIKiS6_EEEEEESE_RNS2_IiiS8_NS4_INS9_ISA_iEEEEEESI_PPdSK_.outline_pfor.body.otd1(ptr {{.*}}%{{.+}})
 ; CHECK: to label %pfor.detach unwind label %lpad714.loopexit
 
-; CHECK: define internal fastcc void @_ZN9LAMMPS_NS6Verlet14run_stencil_mdEiRNSt3__13mapIiNS1_6vectorIiNS1_9allocatorIiEEEENS1_4lessIiEENS4_INS1_4pairIKiS6_EEEEEESE_RNS2_IiiS8_NS4_INS9_ISA_iEEEEEESI_PPdSK_.outline_pfor.body.otd1()
+; CHECK: define internal fastcc void @_ZN9LAMMPS_NS6Verlet14run_stencil_mdEiRNSt3__13mapIiNS1_6vectorIiNS1_9allocatorIiEEEENS1_4lessIiEENS4_INS1_4pairIKiS6_EEEEEESE_RNS2_IiiS8_NS4_INS9_ISA_iEEEEEESI_PPdSK_.outline_pfor.body.otd1(ptr {{.*}}%{{.+}})
 ; CHECK: pfor.detach.otd1:
 ; CHECK: br label %pfor.body.otd1
 

--- a/llvm/test/Transforms/Tapir/spawner-memory-effects.ll
+++ b/llvm/test/Transforms/Tapir/spawner-memory-effects.ll
@@ -35,7 +35,7 @@ det.cont192:                                      ; preds = %det.achd190, %entry
 
 ; CHECK: define internal fastcc void @_Z12generateNodePP5rangePP5eventS0_ii.outline_det.achd190.otd1(ptr {{.*}}%boxes.otd1, ptr
 ; CHECK-NOT: readnone
-; CHECK: %leftEvents.otd1)
+; CHECK: %leftEvents.otd1
 
 ; Function Attrs: nounwind willreturn memory(argmem: readwrite)
 declare token @llvm.taskframe.create() #0

--- a/llvm/test/Transforms/Tapir/unlink-unreachable-detach-unwind.ll
+++ b/llvm/test/Transforms/Tapir/unlink-unreachable-detach-unwind.ll
@@ -68,7 +68,7 @@ pfor.inc907:                                      ; preds = %pfor.inc907, %pfor.
 
 ; CHECK: pfor.detach470:
 ; CHECK-NOT: detach within
-; CHECK: invoke fastcc void @_ZN9LAMMPS_NS6Verlet14run_stencil_mdEiPNSt3__16vectorIiNS1_9allocatorIiEEEES6_PiS7_PPdS9_.outline_pfor.body.entry472.otd1()
+; CHECK: invoke fastcc void @_ZN9LAMMPS_NS6Verlet14run_stencil_mdEiPNSt3__16vectorIiNS1_9allocatorIiEEEES6_PiS7_PPdS9_.outline_pfor.body.entry472.otd1(ptr %{{.+}})
 ; CHECK-NEXT: to label %pfor.detach470 unwind label %lpad651
 
 ; Function Attrs: nounwind willreturn memory(argmem: readwrite)


### PR DESCRIPTION
This PR drafts compiler changes to pass a pointer to the `__cilkrts_stack_frame` in a parent spawning function, along with other compile-time information, to a spawn helper.  This change allows the spawn helper to access the parent stack frame more efficiently and enables a variety of optimizations to reduce spawn overhead.

This PR provides the necessary compiler changes for PR OpenCilk/cheetah#29.