### PR TITLE
Increase __cilkrts_stack_frame alignment to ABI stack alignment

### DIFF
--- a/llvm/include/llvm/Transforms/Tapir/OpenCilkABI.h
+++ b/llvm/include/llvm/Transforms/Tapir/OpenCilkABI.h
@@ -60,7 +60,12 @@ class OpenCilkABI final : public TapirTarget {
   FunctionCallee CilkRTSCilkForGrainsize32 = nullptr;
   FunctionCallee CilkRTSCilkForGrainsize64 = nullptr;
 
-  MaybeAlign StackFrameAlign{8};
+  // The alignment of __cilkrts_stack_frame.  This value will be increased
+  // to the ABI-prescribed stack pointer alignment of the module.  This has
+  // no runtime cost.  The bitcode file may request even greater alignment
+  // by defining a variable __cilkrts_stack_frame_align.  This may have a
+  // runtime cost by forcing overalignment of stack pointers.
+  MaybeAlign StackFrameAlign;
 
   // Accessors for CilkRTS ABI functions. When a bitcode file is loaded, these
   // functions should return the function defined in the bitcode file.


### PR DESCRIPTION
All the `__cilkrts_stack_frame` objects are allocated on the stack.  Increasing their alignment to the ABI stack alignment might allow the compiler to generate better code.  The cost is possibly allocating an extra word because the size of an object is a multiple of its alignment.  This alignment is only used within a module.  The runtime will use the alignment dictated by C code.

On mainstream targets this will increase alignment from 8 to 16 bytes.