### PR TITLE
Gold linker, build fixes

### DIFF
--- a/flang/include/flang/Frontend/CodeGenOptions.def
+++ b/flang/include/flang/Frontend/CodeGenOptions.def
@@ -40,5 +40,8 @@ ENUM_CODEGENOPT(DebugInfo,  llvm::codegenoptions::DebugInfoKind, 4,  llvm::codeg
 ENUM_CODEGENOPT(VecLib, llvm::driver::VectorLibrary, 3, llvm::driver::VectorLibrary::NoLibrary) ///< Vector functions library to use
 ENUM_CODEGENOPT(FramePointer, llvm::FramePointerKind, 2, llvm::FramePointerKind::None) ///< Enable the usage of frame pointers
 
+/// Tapir target runtime library to use.
+ENUM_CODEGENOPT(TapirTarget, TapirTargetID, 8, TapirTargetID::Last_TapirTargetID)
+
 #undef CODEGENOPT
 #undef ENUM_CODEGENOPT

--- a/flang/include/flang/Frontend/CodeGenOptions.h
+++ b/flang/include/flang/Frontend/CodeGenOptions.h
@@ -29,6 +29,8 @@
 
 namespace Fortran::frontend {
 
+using TapirTargetID = llvm::TapirTargetID;
+
 /// Bitfields of CodeGenOptions, split out from CodeGenOptions to ensure
 /// that this large collection of bitfields is a trivial class type.
 class CodeGenOptionsBase {
@@ -128,6 +130,9 @@ public:
   /// they want to explain why they decided to apply or not apply a given
   /// transformation.
   OptRemark OptimizationRemarkAnalysis;
+
+  /// Path to OpenCilk runtime bitcode file.
+  std::string OpenCilkABIBitcodeFile;
 
   // Define accessors/mutators for code generation options of enumeration type.
 #define CODEGENOPT(Name, Bits, Default)

--- a/llvm/tools/gold/gold-plugin.cpp
+++ b/llvm/tools/gold/gold-plugin.cpp
@@ -226,14 +226,14 @@ namespace options {
   static std::string opencilk_abi_bitcode_file;
 
   static TapirTargetID parseTapirTarget(StringRef tapirTarget) {
-    return StringSwitch<TapirTargetID>(tapirTarget)
+    return llvm::StringSwitch<TapirTargetID>(tapirTarget)
         .Case("none", TapirTargetID::None)
         .Case("serial", TapirTargetID::Serial)
         .Case("cheetah", TapirTargetID::Cheetah)
         .Case("cilkplus", TapirTargetID::Cilk)
-        .Case("cuda", TapirTargetID::Cuda)
+        .Case("lambda", TapirTargetID::Lambda)
+        .Case("omptask", TapirTargetID::OMPTask)
         .Case("opencilk", TapirTargetID::OpenCilk)
-        .Case("openmp", TapirTargetID::OpenMP)
         .Case("qthreads", TapirTargetID::Qthreads)
         .Default(TapirTargetID::Last_TapirTargetID);
   }


### PR DESCRIPTION
This PR fixes the Gold linker to use the current set of Tapir targets.

This PR also fixes build issues with other LLVM subprojects, specifically, flang.