### PR TITLE
Only pop a cleanup scope in ~TaskFrameScope if one was pushed

### DIFF
--- a/clang/lib/CodeGen/CGCilk.cpp
+++ b/clang/lib/CodeGen/CGCilk.cpp
@@ -371,7 +371,7 @@ CodeGenFunction::TaskFrameScope::TaskFrameScope(CodeGenFunction &CGF)
 CodeGenFunction::TaskFrameScope::~TaskFrameScope() {
   if (LangOptions::Cilk_none == CGF.getLangOpts().getCilk())
     return;
-  if (!CGF.CurSyncRegion)
+  if (!TaskFrame)
     return;
 
   // Pop the taskframe.

--- a/clang/test/Cilk/266.cpp
+++ b/clang/test/Cilk/266.cpp
@@ -1,0 +1,15 @@
+// RUN: %clang_cc1 -triple x86_64-apple-macosx14.0.0 -emit-llvm -S -fopencilk -disable-llvm-passes -fcxx-exceptions -fexceptions -x c++ %s -o /dev/null
+// expected-no-diagnostics
+// Bug 266: unnecessary sync in catch block crashes compiler
+
+extern int f();
+
+// Nothing really to check here.  If it compiles, great.
+void try_catch() {
+  try {
+    f();
+  } catch (int x) {
+    _Cilk_sync;
+  }
+}
+


### PR DESCRIPTION
Fixes #266.