### PR TITLE
Fix some bugs with task-simplify and function inlining

### DIFF
--- a/clang/test/Cilk/hyper-destruct2.cpp
+++ b/clang/test/Cilk/hyper-destruct2.cpp
@@ -16,8 +16,8 @@ struct Outer {
 };
 
 // Make sure the appropriate variant of ~Inner() is emitted.
-// CHECK: {{^}}define{{.*}} void @_ZN5OuterD2Ev
-// CHECK: call void @_ZN5InnerIcED2Ev
-// CHECK: {{^}}define linkonce_odr void @_ZN5InnerIcED2Ev
+// CHECK: {{^}}define{{.*}} {{void|ptr}} @_ZN5OuterD2Ev
+// CHECK: call{{.*}} {{void|ptr}} @_ZN5InnerIcED2Ev
+// CHECK: {{^}}define linkonce_odr{{.*}} {{void|ptr}} @_ZN5InnerIcED2Ev
 
 Outer::~Outer() { }

--- a/llvm/include/llvm/Transforms/Utils/TapirUtils.h
+++ b/llvm/include/llvm/Transforms/Utils/TapirUtils.h
@@ -103,7 +103,8 @@ bool MoveStaticAllocasInBlock(BasicBlock *Entry, BasicBlock *Block,
 
 /// Inline any taskframe.resume markers associated with the given taskframe.  If
 /// \p DT is provided, then it will be updated to reflect the CFG changes.
-void InlineTaskFrameResumes(Value *TaskFrame, DominatorTree *DT = nullptr);
+void InlineTaskFrameResumes(Value *TaskFrame, DominatorTree *DT = nullptr,
+                            TaskInfo *TI = nullptr);
 
 /// Clone exception-handling blocks EHBlocksToClone, with predecessors
 /// EHBlockPreds in a given task.  Updates EHBlockPreds to point at the cloned
@@ -131,7 +132,8 @@ void SerializeDetach(DetachInst *DI, BasicBlock *ParentEntry,
                      SmallPtrSetImpl<LandingPadInst *> *InlinedLPads,
                      SmallVectorImpl<Instruction *> *DetachedRethrows,
                      bool ReplaceWithTaskFrame = false,
-                     DominatorTree *DT = nullptr, LoopInfo *LI = nullptr);
+                     DominatorTree *DT = nullptr, TaskInfo *TI = nullptr,
+                     LoopInfo *LI = nullptr);
 
 /// Analyze a task T for serialization.  Gets the reattaches, landing pads, and
 /// detached rethrows that need special handling during serialization.
@@ -145,7 +147,7 @@ void AnalyzeTaskForSerialization(
 /// Serialize the detach DI that spawns task T.  If \p DT is provided, then it
 /// will be updated to reflect the CFG changes.
 void SerializeDetach(DetachInst *DI, Task *T, bool ReplaceWithTaskFrame = false,
-                     DominatorTree *DT = nullptr);
+                     DominatorTree *DT = nullptr, TaskInfo *TI = nullptr);
 
 /// Get the entry basic block to the detached context that contains
 /// the specified block.

--- a/llvm/include/llvm/Transforms/Utils/TaskSimplify.h
+++ b/llvm/include/llvm/Transforms/Utils/TaskSimplify.h
@@ -31,7 +31,7 @@ public:
 bool simplifySyncs(Task *T, MaybeParallelTasks &MPTasks);
 
 /// Simplify the specified task T.
-bool simplifyTask(Task *T);
+bool simplifyTask(Task *T, TaskInfo &TI, DominatorTree &DT);
 
 /// Simplify the taskframes analyzed by TapirTaskInfo TI.
 bool simplifyTaskFrames(TaskInfo &TI, DominatorTree &DT);

--- a/llvm/lib/Transforms/Tapir/LoopStripMine.cpp
+++ b/llvm/lib/Transforms/Tapir/LoopStripMine.cpp
@@ -1099,7 +1099,7 @@ Loop *llvm::StripMineLoop(Loop *L, unsigned Count, bool AllowExpensiveTripCount,
     SerializeDetach(ClonedDI, ParentEntry, EHCont, EHContLPadVal,
                     ClonedReattaches, &ClonedEHBlocks, &ClonedEHBlockPreds,
                     &ClonedInlinedLPads, &ClonedDetachedRethrows,
-                    NeedToInsertTaskFrame, DT, LI);
+                    NeedToInsertTaskFrame, DT, nullptr, LI);
   }
 
   // Detach the stripmined loop.

--- a/llvm/lib/Transforms/Utils/InlineFunction.cpp
+++ b/llvm/lib/Transforms/Utils/InlineFunction.cpp
@@ -675,8 +675,8 @@ static void HandleInlinedTasksHelper(
     }
 
     // Promote any calls in the block to invokes.
-    if (BasicBlock *NewBB = HandleCallsInBlockInlinedThroughInvoke(
-            BB, UnwindEdge)) {
+    if (BasicBlock *NewBB =
+            HandleCallsInBlockInlinedThroughInvoke(BB, UnwindEdge)) {
       // If this is the topmost invocation of HandleInlinedTasksHelper, update
       // any PHI nodes in the exceptional block to indicate that there is now a
       // new entry in them.
@@ -745,7 +745,7 @@ static void HandleInlinedTasksHelper(
           Invoke.addIncomingPHIValuesFor(SubTaskUnwindEdge);
         }
 
-      } else if (Visited.insert(DI->getUnwindDest()).second) {
+      } else if (!Visited.contains(DI->getUnwindDest())) {
         // If the detach-unwind isn't dead, add it to the worklist.
         Worklist.push_back(DI->getUnwindDest());
       }

--- a/llvm/lib/Transforms/Utils/TapirUtils.cpp
+++ b/llvm/lib/Transforms/Utils/TapirUtils.cpp
@@ -2260,7 +2260,8 @@ void llvm::eraseTaskFrame(Value *TaskFrame, DominatorTree *DT) {
   for (User *U : TaskFrame->users()) {
     if (Instruction *UI = dyn_cast<Instruction>(U))
       if (isTapirIntrinsic(Intrinsic::taskframe_use, UI) ||
-          isTapirIntrinsic(Intrinsic::taskframe_end, UI))
+          isTapirIntrinsic(Intrinsic::taskframe_end, UI) ||
+          isTapirIntrinsic(Intrinsic::taskframe_resume, UI))
         ToErase.push_back(UI);
   }
 

--- a/llvm/lib/Transforms/Utils/TaskSimplify.cpp
+++ b/llvm/lib/Transforms/Utils/TaskSimplify.cpp
@@ -12,6 +12,7 @@
 
 #include "llvm/Transforms/Utils/TaskSimplify.h"
 #include "llvm/ADT/PostOrderIterator.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/Statistic.h"
 #include "llvm/Analysis/AssumptionCache.h"
 #include "llvm/Analysis/CFG.h"
@@ -23,7 +24,9 @@
 #include "llvm/Analysis/ScalarEvolution.h"
 #include "llvm/Analysis/TapirTaskInfo.h"
 #include "llvm/Analysis/TargetTransformInfo.h"
+#include "llvm/IR/Dominators.h"
 #include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Instruction.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/Intrinsics.h"
 #include "llvm/IR/LegacyPassManager.h"
@@ -114,10 +117,11 @@ static bool removeRedundantSyncs(MaybeParallelTasks &MPTasks, Task *T) {
   return Changed;
 }
 
-static bool syncIsDiscriminating(const Value *SyncSR,
+static bool syncIsDiscriminating(const SyncInst *Sync,
                                  SmallPtrSetImpl<const Task *> &MPTasks) {
+  const Value *SyncSR = Sync->getSyncRegion();
   for (const Task *MPTask : MPTasks)
-    if (!MPTask->encloses(cast<Instruction>(SyncSR)->getParent()) &&
+    if (!MPTask->encloses(Sync->getParent()) &&
         SyncSR != MPTask->getDetach()->getSyncRegion())
       return true;
   return false;
@@ -134,12 +138,13 @@ static bool removeRedundantSyncRegions(MaybeParallelTasks &MPTasks, Task *T) {
 
   // Find the unique sync regions in this task.
   SmallPtrSet<Value *, 1> UniqueSyncRegs;
-  Instruction *FirstSyncRegion = nullptr;
+  // It's possible for a sync region to not be an instruction only when
+  // debugging reduced test cases.
+  Value *FirstSyncRegion = nullptr;
   for (Task *SubT : T->subtasks()) {
     UniqueSyncRegs.insert(SubT->getDetach()->getSyncRegion());
     if (!FirstSyncRegion)
-      FirstSyncRegion = cast<Instruction>(
-          SubT->getDetach()->getSyncRegion());
+      FirstSyncRegion = SubT->getDetach()->getSyncRegion();
   }
   NumUniqueSyncRegs += UniqueSyncRegs.size();
   // Skip this task if there's only one unique sync region.
@@ -162,7 +167,7 @@ static bool removeRedundantSyncRegions(MaybeParallelTasks &MPTasks, Task *T) {
     // Iterate over outgoing edges of S to find discriminating syncs.
     for (Spindle::SpindleEdge &Edge : S->out_edges())
       if (const SyncInst *Y = dyn_cast<SyncInst>(Edge.second->getTerminator()))
-        if (syncIsDiscriminating(Y->getSyncRegion(), LocalTaskList)) {
+        if (syncIsDiscriminating(Y, LocalTaskList)) {
           ++NumDiscriminatingSyncs;
           LLVM_DEBUG(dbgs() << "Found discriminating sync " << *Y << "\n");
           NonRedundantSyncRegs.insert(Y->getSyncRegion());
@@ -179,8 +184,9 @@ static bool removeRedundantSyncRegions(MaybeParallelTasks &MPTasks, Task *T) {
       Changed = true;
       SR->replaceAllUsesWith(FirstSyncRegion);
       // Ensure that the first sync region is in the entry block of T.
-      if (FirstSyncRegion->getParent() != T->getEntry())
-        FirstSyncRegion->moveAfter(&*T->getEntry()->getFirstInsertionPt());
+      if (Instruction *SyncRegI = dyn_cast<Instruction>(FirstSyncRegion))
+        if (SyncRegI->getParent() != T->getEntry())
+          SyncRegI->moveAfter(&*T->getEntry()->getFirstInsertionPt());
     }
   }
 
@@ -342,7 +348,7 @@ static bool canRemoveTaskFrame(const Spindle *TF, MaybeParallelTasks &MPTasks,
       // so would cause these syncs to sync tasks spawned in the parent
       // taskframe.
       if (const SyncInst *SI = dyn_cast<SyncInst>(BB->getTerminator()))
-        if (syncIsDiscriminating(SI->getSyncRegion(), LocalTaskList)) {
+        if (syncIsDiscriminating(SI, LocalTaskList)) {
           LLVM_DEBUG(dbgs()
                      << "Can't remove taskframe with distinguishing sync: "
                      << *TFCreate << "\n");
@@ -512,6 +518,30 @@ static bool iterativelySimplifyCFG(Function &F, const TargetTransformInfo &TTI,
   return Changed;
 }
 
+static bool removeDeadTapirIntrinsics(Function &F) {
+  SmallVector<Instruction *, 4> ToErase;
+  for (BasicBlock &B : F) {
+    for (Instruction &I : B) {
+      // Look for any now-unused tapir.runtime.start intrinsics
+      if (isTapirIntrinsic(Intrinsic::tapir_runtime_start, &I)) {
+        if (!llvm::any_of(I.users(), [&](const User *U) {
+              return isa<Instruction>(U) &&
+                     isTapirIntrinsic(Intrinsic::tapir_runtime_end,
+                                      cast<Instruction>(U));
+            }))
+          ToErase.push_back(&I);
+      }
+    }
+  }
+
+  if (ToErase.empty())
+    return false;
+
+  for (Instruction *I : ToErase)
+    I->eraseFromParent();
+  return true;
+}
+
 static bool simplifyFunctionCFG(Function &F, const TargetTransformInfo &TTI,
                                 DominatorTree *DT,
                                 const SimplifyCFGOptions &Options) {
@@ -519,6 +549,7 @@ static bool simplifyFunctionCFG(Function &F, const TargetTransformInfo &TTI,
 
   bool EverChanged = removeUnreachableBlocks(F, DT ? &DTU : nullptr);
   EverChanged |= iterativelySimplifyCFG(F, TTI, DT ? &DTU : nullptr, Options);
+  EverChanged |= removeDeadTapirIntrinsics(F);
 
   // If neither pass changed anything, we're done.
   if (!EverChanged) return false;
@@ -534,6 +565,7 @@ static bool simplifyFunctionCFG(Function &F, const TargetTransformInfo &TTI,
   do {
     EverChanged = iterativelySimplifyCFG(F, TTI, DT ? &DTU : nullptr, Options);
     EverChanged |= removeUnreachableBlocks(F, DT ? &DTU : nullptr);
+    EverChanged |= removeDeadTapirIntrinsics(F);
   } while (EverChanged);
 
   return true;

--- a/llvm/test/Transforms/Tapir/inline-detach-unwind.ll
+++ b/llvm/test/Transforms/Tapir/inline-detach-unwind.ll
@@ -1,0 +1,81 @@
+; Check that detach-unwind blocks are properly inlined when they are reachable only from the detach instruction itself.
+;
+; RUN: opt < %s -passes="cgscc(devirt<4>(inline))" -S | FileCheck %s
+target datalayout = "e-m:o-i64:64-i128:128-n32:64-S128"
+target triple = "arm64-apple-macosx15.0.0"
+
+; CHECK: define void @_ZNK5Graph17pbfs_walk_PennantEP7PennantIiERH3BagIiEjPj()
+
+; CHECK: pfor.cond:
+; CHECK-NEXT: detach within none, label %pfor.body.entry, label %pfor.cond unwind label %lpad59
+
+; CHECK: pfor.body.entry:
+; CHECK: br label %[[INLINED_PFOR_COND:.+]]
+
+; CHECK: [[INLINED_PFOR_COND]]:
+; CHECK: detach within {{.+}}, label %{{.+}}, label %{{.+}} unwind label %[[INLINED_DETACH_UNWIND:.+]]
+
+; CHECK: [[INLINED_DETACH_UNWIND]]:
+; CHECK-NOT: resume
+; CHECK: br label %[[UNWIND_TO_PARENT:.+]]
+
+; CHECK: [[UNWIND_TO_PARENT]]:
+; CHECK: invoke void @llvm.taskframe.resume.sl_p0i32s(token
+; CHECK-NEXT: to label %{{.+}} unwind label %lpad49
+
+define void @_ZNK5Graph17pbfs_walk_PennantEP7PennantIiERH3BagIiEjPj() personality ptr null {
+entry:
+  %0 = call token @llvm.tapir.runtime.start()
+  br label %pfor.cond
+
+pfor.cond:                                        ; preds = %pfor.preattach, %pfor.cond, %entry
+  detach within none, label %pfor.body.entry, label %pfor.cond unwind label %lpad59
+
+pfor.body.entry:                                  ; preds = %pfor.cond
+  invoke fastcc void @_ZL14pbfs_proc_NodePKiiRH3BagIiEjPjS0_S0_(ptr null, i32 0, ptr null, i32 0, ptr null, ptr null, ptr null)
+          to label %pfor.preattach unwind label %lpad49
+
+pfor.preattach:                                   ; preds = %pfor.body.entry
+  reattach within none, label %pfor.cond
+
+lpad49:                                           ; preds = %pfor.body.entry
+  %1 = landingpad { ptr, i32 }
+          cleanup
+  unreachable
+
+lpad59:                                           ; preds = %pfor.cond
+  %2 = landingpad { ptr, i32 }
+          cleanup
+  call void @llvm.tapir.runtime.end(token %0)
+  resume { ptr, i32 } zeroinitializer
+}
+
+define fastcc void @_ZL14pbfs_proc_NodePKiiRH3BagIiEjPjS0_S0_(ptr %n, i32 %fillSize, ptr %next, i32 %newdist, ptr %distances, ptr %nodes, ptr %edges) personality ptr null {
+entry:
+  br label %pfor.cond
+
+pfor.cond:                                        ; preds = %pfor.cond, %entry
+  detach within none, label %pfor.body.entry, label %pfor.cond unwind label %lpad20
+
+pfor.body.entry:                                  ; preds = %pfor.cond
+  br label %for.cond
+
+for.cond:                                         ; preds = %for.cond, %pfor.body.entry
+  br label %for.cond
+
+lpad20:                                           ; preds = %pfor.cond
+  %0 = landingpad { ptr, i32 }
+          cleanup
+  resume { ptr, i32 } zeroinitializer
+}
+
+; Function Attrs: nounwind willreturn memory(argmem: readwrite)
+declare token @llvm.tapir.runtime.start() #0
+
+; Function Attrs: nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.tapir.runtime.end(token) #0
+
+; uselistorder directives
+uselistorder ptr null, { 7, 8, 0, 2, 3, 4, 5, 6, 9, 10, 1 }
+
+attributes #0 = { nounwind willreturn memory(argmem: readwrite) }

--- a/llvm/test/Transforms/Tapir/inline-spawn-lpads.ll
+++ b/llvm/test/Transforms/Tapir/inline-spawn-lpads.ll
@@ -370,6 +370,7 @@ eh.resume:                                        ; preds = %lpad
 ; CHECK-NEXT: %[[LPADIVAL:.+]] = landingpad [[LPADTYPE]]
 ; CHECK-NEXT: catch ptr @_ZTIc
 ; CHECK-NEXT: catch ptr @_ZTIi
+; CHECK: call i32 @llvm.eh.typeid.for(ptr @_ZTIc)
 ; CHECK: br i1 %{{.+}}, label %[[CATCHI:.+]], label %[[RESUMEI:.+]]
 
 ; CHECK: [[CATCHI]]:
@@ -377,7 +378,7 @@ eh.resume:                                        ; preds = %lpad
 ; CHECK: br label %[[EXITI:.+]]
 
 ; CHECK: [[RESUMEI]]:
-; CHECK-NEXT: resume [[LPADTYPE]] %[[LPADIVAL]]
+; CHECK: br label %[[LPADBODY:.+]]
 
 ; CHECK: [[UNREACHABLEI]]:
 ; CHECK-NEXT: unreachable
@@ -385,8 +386,21 @@ eh.resume:                                        ; preds = %lpad
 ; CHECK: [[EXITI]]:
 ; CHECK-NEXT: br label %[[TRYCONT:.+]]
 
+; CHECK: [[LPADBODY]]:
+; CHECK-NEXT: %[[EH_LPADBODY:.+]] = phi [[LPADTYPE]]
+; CHECK: [ %[[LPADIVAL]], %[[RESUMEI]] ]
+; CHECK: call i32 @llvm.eh.typeid.for(ptr @_ZTIi)
+; CHECK: br i1 %{{.+}}, label %[[CATCH:.+]], label %[[RESUME:.+]]
+
+; CHECK: [[CATCH]]:
+; CHECK: call void @_Z7catch_ii(
+; CHECK: br label %[[TRYCONT]]
+
 ; CHECK: [[TRYCONT]]:
 ; CHECK-NEXT: ret void
+
+; CHECK: [[RESUME]]:
+; CHECK-NEXT: resume [[LPADTYPE]] %[[EH_LPADBODY]]
 
 attributes #0 = { uwtable "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { nounwind readnone }

--- a/llvm/test/Transforms/Tapir/nested-serialize-detach.ll
+++ b/llvm/test/Transforms/Tapir/nested-serialize-detach.ll
@@ -1,0 +1,98 @@
+; Check that nested detaches can be serialized.
+;
+; RUN: opt < %s -passes="function<eager-inv>(task-simplify)" -S | FileCheck %s
+target datalayout = "e-m:o-i64:64-i128:128-n32:64-S128"
+target triple = "arm64-apple-macosx15.0.0"
+
+; Function Attrs: nounwind willreturn memory(argmem: readwrite)
+declare token @llvm.syncregion.start() #0
+
+; Function Attrs: willreturn memory(argmem: readwrite)
+declare void @llvm.sync.unwind(token) #1
+
+; Function Attrs: willreturn memory(argmem: readwrite)
+declare void @llvm.detached.rethrow.sl_p0i32s(token, { ptr, i32 }) #1
+
+; Function Attrs: nounwind willreturn memory(argmem: readwrite)
+declare token @llvm.taskframe.create() #0
+
+; CHECK: define void @_ZNK5Graph17pbfs_walk_PennantEP7PennantIiERH3BagIiEjPj()
+; CHECK-NEXT: entry:
+; CHECK-NOT: detach within
+; CHECK: unreachable
+
+define void @_ZNK5Graph17pbfs_walk_PennantEP7PennantIiERH3BagIiEjPj() personality ptr null {
+entry:
+  %syncreg = tail call token @llvm.syncregion.start()
+  %syncreg45 = tail call token @llvm.syncregion.start()
+  %0 = tail call token @llvm.tapir.runtime.start()
+  detach within %syncreg45, label %pfor.body.entry.tf, label %pfor.inc unwind label %lpad59.loopexit
+
+pfor.body.entry.tf:                               ; preds = %entry
+  %tf.i = tail call token @llvm.taskframe.create()
+  %syncreg.i = tail call token @llvm.syncregion.start()
+  detach within %syncreg.i, label %pfor.cond.i.strpm.detachloop.entry, label %pfor.cond.cleanup.i unwind label %lpad4924.loopexit.split-lp
+
+pfor.cond.i.strpm.detachloop.entry:               ; preds = %pfor.body.entry.tf
+  %syncreg.i.strpm.detachloop = tail call token @llvm.syncregion.start()
+  detach within none, label %pfor.body.entry.i.strpm.outer.1, label %pfor.inc.i.strpm.outer.1 unwind label %lpad4924.loopexit.strpm
+
+pfor.body.entry.i.strpm.outer.1:                  ; preds = %pfor.cond.i.strpm.detachloop.entry
+  invoke void @llvm.detached.rethrow.sl_p0i32s(token none, { ptr, i32 } zeroinitializer)
+          to label %lpad4924.unreachable unwind label %lpad4924.loopexit.strpm
+
+pfor.inc.i.strpm.outer.1:                         ; preds = %pfor.cond.i.strpm.detachloop.entry
+  sync within none, label %pfor.cond.i.strpm.detachloop.reattach.split
+
+pfor.cond.i.strpm.detachloop.reattach.split:      ; preds = %pfor.inc.i.strpm.outer.1
+  reattach within %syncreg.i, label %pfor.cond.cleanup.i
+
+pfor.cond.cleanup.i:                              ; preds = %pfor.cond.i.strpm.detachloop.reattach.split, %pfor.body.entry.tf
+  sync within %syncreg.i, label %sync.continue.i
+
+sync.continue.i:                                  ; preds = %pfor.cond.cleanup.i
+  invoke void @llvm.sync.unwind(token none)
+          to label %pfor.preattach unwind label %lpad4924.loopexit.split-lp
+
+lpad4924.loopexit.strpm:                          ; preds = %pfor.body.entry.i.strpm.outer.1, %pfor.cond.i.strpm.detachloop.entry
+  %lpad.strpm = landingpad { ptr, i32 }
+          cleanup
+  invoke void @llvm.detached.rethrow.sl_p0i32s(token %syncreg.i, { ptr, i32 } zeroinitializer)
+          to label %lpad4924.loopexit.strpm.unreachable unwind label %lpad4924.loopexit.split-lp
+
+lpad4924.loopexit.strpm.unreachable:              ; preds = %lpad4924.loopexit.strpm
+  unreachable
+
+lpad4924.loopexit.split-lp:                       ; preds = %lpad4924.loopexit.strpm, %sync.continue.i, %pfor.body.entry.tf
+  %lpad.loopexit.split-lp = landingpad { ptr, i32 }
+          cleanup
+  call void @llvm.detached.rethrow.sl_p0i32s(token none, { ptr, i32 } zeroinitializer)
+  unreachable
+
+lpad4924.unreachable:                             ; preds = %pfor.body.entry.i.strpm.outer.1
+  unreachable
+
+pfor.preattach:                                   ; preds = %sync.continue.i
+  reattach within %syncreg45, label %pfor.inc
+
+pfor.inc:                                         ; preds = %pfor.preattach, %entry
+  ret void
+
+lpad59.loopexit:                                  ; preds = %entry
+  %lpad.loopexit28 = landingpad { ptr, i32 }
+          cleanup
+  tail call void @llvm.tapir.runtime.end(token %0)
+  resume { ptr, i32 } zeroinitializer
+}
+
+; Function Attrs: nounwind willreturn memory(argmem: readwrite)
+declare token @llvm.tapir.runtime.start() #0
+
+; Function Attrs: nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.tapir.runtime.end(token) #0
+
+; uselistorder directives
+uselistorder ptr null, { 1, 2, 0 }
+
+attributes #0 = { nounwind willreturn memory(argmem: readwrite) }
+attributes #1 = { willreturn memory(argmem: readwrite) }

--- a/llvm/test/Transforms/Tapir/remove-dead-runtime-start-after-unreachable-blocks.ll
+++ b/llvm/test/Transforms/Tapir/remove-dead-runtime-start-after-unreachable-blocks.ll
@@ -1,0 +1,48 @@
+; Check that dead tapir.runtime.start intrinsics are removed after removing unreachable blocks.
+;
+; RUN: opt < %s -passes="function<eager-inv>(task-simplify)" -S | FileCheck %s
+target datalayout = "e-m:o-i64:64-i128:128-n32:64-S128"
+target triple = "arm64-apple-macosx15.0.0"
+
+; CHECK: define void @_ZNK5Graph17pbfs_walk_PennantEP7PennantIiERH3BagIiEjPj()
+; CHECK-NEXT: entry:
+; CHECK-NEXT: call ptr @_Znwm
+; CHECK-NEXT: unreachable
+
+define void @_ZNK5Graph17pbfs_walk_PennantEP7PennantIiERH3BagIiEjPj() personality ptr null {
+entry:
+  %0 = tail call token @llvm.tapir.runtime.start()
+  detach within none, label %pfor.body.entry.tf, label %pfor.inc unwind label %lpad59.loopexit
+
+pfor.body.entry.tf:                               ; preds = %entry
+  %call.i15.i26.1 = call ptr @_Znwm()
+  unreachable
+
+pfor.inc:                                         ; preds = %entry
+  sync within none, label %sync.continue
+
+common.ret:                                       ; preds = %sync.continue, %lpad59.loopexit
+  ret void
+
+lpad59.loopexit:                                  ; preds = %entry
+  %lpad.loopexit28 = landingpad { ptr, i32 }
+          cleanup
+  br label %common.ret
+
+sync.continue:                                    ; preds = %pfor.inc
+  tail call void @llvm.tapir.runtime.end(token %0)
+  br label %common.ret
+}
+
+; Function Attrs: nounwind willreturn memory(argmem: readwrite)
+declare token @llvm.tapir.runtime.start() #0
+
+; Function Attrs: nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.tapir.runtime.end(token) #0
+
+declare ptr @_Znwm()
+
+; uselistorder directives
+uselistorder ptr null, { 1, 2, 0 }
+
+attributes #0 = { nounwind willreturn memory(argmem: readwrite) }

--- a/llvm/test/Transforms/Tapir/simplify-none-syncregion.ll
+++ b/llvm/test/Transforms/Tapir/simplify-none-syncregion.ll
@@ -1,0 +1,44 @@
+; Check that task-simplify handles sync regions that are not instructions, specifically when debugging.
+;
+; RUN: opt < %s -passes="function<eager-inv>(task-simplify)" -S | FileCheck %s
+target datalayout = "e-m:o-i64:64-i128:128-n32:64-S128"
+target triple = "arm64-apple-macosx15.0.0"
+
+; CHECK: define void @_ZNK5Graph17pbfs_walk_PennantEP7PennantIiERH3BagIiEjPj()
+; CHECK-NEXT: entry:
+; CHECK-NEXT: unreachable
+
+define void @_ZNK5Graph17pbfs_walk_PennantEP7PennantIiERH3BagIiEjPj() personality ptr null {
+entry:
+  %0 = tail call token @llvm.tapir.runtime.start()
+  detach within none, label %pfor.body.entry.tf, label %pfor.inc unwind label %lpad59.loopexit
+
+pfor.body.entry.tf:                               ; preds = %entry
+  unreachable
+
+pfor.inc:                                         ; preds = %entry
+  sync within none, label %sync.continue
+
+common.ret:                                       ; preds = %sync.continue, %lpad59.loopexit
+  ret void
+
+lpad59.loopexit:                                  ; preds = %entry
+  %lpad.loopexit28 = landingpad { ptr, i32 }
+          cleanup
+  br label %common.ret
+
+sync.continue:                                    ; preds = %pfor.inc
+  tail call void @llvm.tapir.runtime.end(token %0)
+  br label %common.ret
+}
+
+; Function Attrs: nounwind willreturn memory(argmem: readwrite)
+declare token @llvm.tapir.runtime.start() #0
+
+; Function Attrs: nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.tapir.runtime.end(token) #0
+
+; uselistorder directives
+uselistorder ptr null, { 1, 2, 0 }
+
+attributes #0 = { nounwind willreturn memory(argmem: readwrite) }

--- a/llvm/test/Transforms/Tapir/simplify-taskframe-with-resume.ll
+++ b/llvm/test/Transforms/Tapir/simplify-taskframe-with-resume.ll
@@ -1,0 +1,123 @@
+; Check that taskframes using in taskframe.resume calls are properly simplified.
+;
+; RUN: opt < %s -passes="function<eager-inv>(task-simplify)" -S | FileCheck %s
+target datalayout = "e-m:o-i64:64-i128:128-n32:64-S128"
+target triple = "arm64-apple-macosx15.0.0"
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg, ptr nocapture) #0
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg, ptr nocapture) #0
+
+; Function Attrs: nounwind reducer_register willreturn memory(inaccessiblemem: readwrite)
+declare void @llvm.reducer.register.i64(ptr, i64, ptr, ptr) #1
+
+; Function Attrs: nounwind willreturn memory(argmem: readwrite)
+declare token @llvm.syncregion.start() #2
+
+; Function Attrs: willreturn memory(argmem: readwrite)
+declare void @llvm.sync.unwind(token) #3
+
+; Function Attrs: hyper_view injective nounwind strand_pure willreturn memory(inaccessiblemem: read)
+declare ptr @llvm.hyper.lookup.i64(ptr, i64, ptr, ptr) #4
+
+; Function Attrs: willreturn memory(argmem: readwrite)
+declare void @llvm.detached.rethrow.sl_p0i32s(token, { ptr, i32 }) #3
+
+; Function Attrs: nounwind reducer_unregister willreturn memory(inaccessiblemem: readwrite)
+declare void @llvm.reducer.unregister(ptr) #5
+
+; Function Attrs: nounwind willreturn memory(argmem: readwrite)
+declare token @llvm.taskframe.create() #2
+
+; CHECK: define void @_ZNK5Graph17pbfs_walk_PennantEP7PennantIiERH3BagIiEjPj()
+; CHECK-NOT: %tf.i = tail call token @llvm.taskframe.create()
+; CHECK-NOT: {{call|invoke}} void @llvm.taskframe.resume.sl_p0i32s(token
+
+; Function Attrs: inlinehint mustprogress ssp uwtable(sync)
+define void @_ZNK5Graph17pbfs_walk_PennantEP7PennantIiERH3BagIiEjPj() #6 personality ptr null {
+entry:
+  %syncreg = tail call token @llvm.syncregion.start()
+  %syncreg45 = tail call token @llvm.syncregion.start()
+  %0 = tail call token @llvm.tapir.runtime.start()
+  detach within %syncreg45, label %pfor.body.entry.tf, label %pfor.inc unwind label %lpad59.loopexit
+
+pfor.body.entry.tf:                               ; preds = %entry
+  %tf.i = tail call token @llvm.taskframe.create()
+  %syncreg.i = tail call token @llvm.syncregion.start()
+  detach within %syncreg.i, label %pfor.cond.i.strpm.detachloop.entry, label %pfor.cond.cleanup.i unwind label %lpad4924.loopexit.strpm.detachloop.unwind
+
+pfor.cond.i.strpm.detachloop.entry:               ; preds = %pfor.body.entry.tf
+  %syncreg.i.strpm.detachloop = tail call token @llvm.syncregion.start()
+  reattach within %syncreg.i, label %pfor.cond.cleanup.i
+
+pfor.cond.cleanup.i:                              ; preds = %pfor.cond.i.strpm.detachloop.entry, %pfor.body.entry.tf
+  sync within %syncreg.i, label %sync.continue.i
+
+lpad4924.loopexit.strpm.detachloop.unwind:        ; preds = %pfor.body.entry.tf
+  %lpad.strpm.detachloop.unwind = landingpad { ptr, i32 }
+          cleanup
+  call void @llvm.taskframe.resume.sl_p0i32s(token %tf.i, { ptr, i32 } %lpad.strpm.detachloop.unwind)
+  unreachable
+
+sync.continue.i:                                  ; preds = %pfor.cond.cleanup.i
+  reattach within %syncreg45, label %pfor.inc
+
+pfor.inc:                                         ; preds = %sync.continue.i, %entry
+  sync within %syncreg45, label %sync.continue
+
+lpad59.loopexit:                                  ; preds = %entry
+  %lpad.loopexit28 = landingpad { ptr, i32 }
+          cleanup
+  ret void
+
+sync.continue:                                    ; preds = %pfor.inc
+  tail call void @llvm.tapir.runtime.end(token %0)
+  ret void
+}
+
+; Function Attrs: nounwind willreturn memory(argmem: readwrite)
+declare token @llvm.tapir.runtime.start() #2
+
+; Function Attrs: willreturn memory(argmem: readwrite)
+declare void @llvm.taskframe.resume.sl_p0i32s(token, { ptr, i32 }) #3
+
+; Function Attrs: nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.tapir.runtime.end(token) #2
+
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.memcpy.p0.p0.i64(ptr noalias nocapture writeonly, ptr noalias nocapture readonly, i64, i1 immarg) #7
+
+; Function Attrs: nobuiltin allocsize(0)
+declare noundef nonnull ptr @_Znwm(i64 noundef) #8
+
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare i32 @llvm.smax.i32(i32, i32) #9
+
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare i32 @llvm.umax.i32(i32, i32) #9
+
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset.p0.i64(ptr nocapture writeonly, i8, i64, i1 immarg) #10
+
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare i32 @llvm.umin.i32(i32, i32) #9
+
+; Function Attrs: nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.taskframe.end(token) #2
+
+; uselistorder directives
+uselistorder ptr null, { 1, 2, 0 }
+
+attributes #0 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #1 = { nounwind reducer_register willreturn memory(inaccessiblemem: readwrite) }
+attributes #2 = { nounwind willreturn memory(argmem: readwrite) }
+attributes #3 = { willreturn memory(argmem: readwrite) }
+attributes #4 = { hyper_view injective nounwind strand_pure willreturn memory(inaccessiblemem: read) }
+attributes #5 = { nounwind reducer_unregister willreturn memory(inaccessiblemem: readwrite) }
+attributes #6 = { inlinehint mustprogress ssp uwtable(sync) "frame-pointer"="non-leaf" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="apple-m1" "target-features"="+aes,+complxnum,+crc,+dotprod,+fp-armv8,+fp16fml,+fullfp16,+jsconv,+lse,+neon,+pauth,+ras,+rcpc,+rdm,+sha2,+sha3,+v8.1a,+v8.2a,+v8.3a,+v8.4a,+v8.5a,+v8a,+zcm,+zcz" }
+attributes #7 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
+attributes #8 = { nobuiltin allocsize(0) "frame-pointer"="non-leaf" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="apple-m1" "target-features"="+aes,+complxnum,+crc,+dotprod,+fp-armv8,+fp16fml,+fullfp16,+jsconv,+lse,+neon,+pauth,+ras,+rcpc,+rdm,+sha2,+sha3,+v8.1a,+v8.2a,+v8.3a,+v8.4a,+v8.5a,+v8a,+zcm,+zcz" }
+attributes #9 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #10 = { nocallback nofree nounwind willreturn memory(argmem: write) }


### PR DESCRIPTION
This PR fixes a crash that can occur in the task-simplify pass when serializing nested tasks.  This PR addresses this crash by using a new, initial interface to dynamically maintain the TaskInfo analysis during the task-serialization process.

In addition, this PR fixes function inlining to properly inline resume statements reachable from the exceptional return of a spawned task.

Finally, this PR adjusts the task-simplify code to avoid problems that only arise when handling reduced LLVM test cases.