### PR TITLE
Use lighter weight map accesses

### DIFF
--- a/llvm/include/llvm/Transforms/Tapir/OpenCilkABI.h
+++ b/llvm/include/llvm/Transforms/Tapir/OpenCilkABI.h
@@ -26,7 +26,8 @@ class OpenCilkABI final : public TapirTarget {
   ValueToValueMapTy DetachCtxToStackFrame;
   SmallPtrSet<Function *, 8> Processed;
   SmallPtrSet<CallBase *, 8> CallsToInline;
-  DenseMap<BasicBlock *, SmallVector<IntrinsicInst *, 4>> TapirRTCalls;
+  using CallVector = SmallVector<IntrinsicInst *, 4>;
+  DenseMap<BasicBlock *, CallVector> TapirRTCalls;
   ValueToValueMapTy DefaultSyncLandingpad;
 
   StringRef RuntimeBCPath = "";
@@ -141,7 +142,7 @@ class OpenCilkABI final : public TapirTarget {
   }
 
   void GetTapirRTCalls(Spindle *TaskFrame, bool IsRootTask, TaskInfo &TI);
-  void LowerTapirRTCalls(Function &F, BasicBlock *TFEntry);
+  void LowerTapirRTCalls(Function &F, CallVector &Calls);
 
   Value *CreateStackFrame(Function &F);
   Value *GetOrCreateCilkStackFrame(Function &F);


### PR DESCRIPTION
Try not to look up a map entry more than once in the same function.  Avoid `operator[]`, which creates a new map entry, when a lookup is sufficient.

This is tested using the llvm-lit tests and one test program.