### PR TITLE
[CGCilk] Fix code generation of normal cleanup destination slot aroun…

### DIFF
--- a/clang/lib/CodeGen/CodeGenFunction.h
+++ b/clang/lib/CodeGen/CodeGenFunction.h
@@ -1638,7 +1638,6 @@ public:
     llvm::BasicBlock *OldEHResumeBlock = nullptr;
     llvm::Value *OldExceptionSlot = nullptr;
     llvm::AllocaInst *OldEHSelectorSlot = nullptr;
-    Address OldNormalCleanupDest = Address::invalid();
 
     // Taskframe created separately from detach.
     llvm::Value *TaskFrame = nullptr;

--- a/clang/test/Cilk/cilkscope-try-normal-cleanup.cpp
+++ b/clang/test/Cilk/cilkscope-try-normal-cleanup.cpp
@@ -1,0 +1,29 @@
+// RUN: %clang_cc1 %s -x c++ -O1 -fcxx-exceptions -fexceptions -fopencilk -mllvm -use-opencilk-runtime-bc=false -mllvm -debug-abi-calls=true -verify -S -emit-llvm -o - | FileCheck %s
+// expected-no-diagnostics
+extern int maybe_throws(int);
+
+// CHECK-LABEL: _Z9function4v
+int function4()
+{
+  _Cilk_scope {
+    try {
+// CHECK: i32 @_Z12maybe_throwsi
+// CHECK-NEXT: to label %[[NORMAL:.+]] unwind label %[[LPAD:.+]]
+      maybe_throws(1);
+// CHECK: [[LPAD]]:
+// CHECK: invoke
+// CHECK-NEXT: to label %[[NORMAL]] unwind label %[[LPAD1:.+]]
+      return 1;
+    } catch (...) {
+// CHECK: [[NORMAL]]:
+// CHECK-NEXT: %[[RETVAL:.+]] = phi i32
+// CHECK-DAG: [ 2, %[[LPAD]] ]
+// CHECK-DAG: [ 1, %entry ]
+// CHECK: ret i32 %[[RETVAL]]
+      return 2;
+    }
+  }
+// This return is unreachable.
+// CHECK-NOT: ret i32 3
+  return 3;
+}


### PR DESCRIPTION
…d unassociated taskframes.

This PR fixes issue OpenCilk/opencilk-project#287.  In that issue, multiple normal cleanup destination slots were getting created for the unassociated taskframe.  But the uses of those different slots were not connected to manage normal cleanups.  It seems that clang's codegen does not easily support associating multiple such slots for normal cleanups.

This change makes unassociated taskframes use a preexisting normal cleanup slot allocated outside of the taskframe.  Although this isn't ideal, in case the taskframe ends up outlined into a new function, it is semantically correct, because an unassociated taskframe executes serially with respect to their parent.