### PR TITLE
Fix default-hook synthesis on Cilksan's instrumentation pass

### DIFF
--- a/llvm/lib/Transforms/Instrumentation/CilkSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/CilkSanitizer.cpp
@@ -4270,6 +4270,8 @@ bool CilkSanitizerImpl::instrumentDetach(DetachInst *DI, unsigned SyncRegNum,
   {
     // Instrument the entry point of the detached task.
     IRBuilder<> IRB(&*getFirstInsertionPtInDetachedBlock(DetachedBlock));
+    if (!IRB.getCurrentDebugLocation())
+      IRB.SetCurrentDebugLocation(searchForDebugLoc(&*IRB.GetInsertPoint()));
     uint64_t LocalID = TaskFED.add(*DetachedBlock);
     Value *TaskID = TaskFED.localToGlobalId(LocalID, IDBuilder);
     CsiTaskProperty Prop;
@@ -4336,6 +4338,8 @@ bool CilkSanitizerImpl::instrumentDetach(DetachInst *DI, unsigned SyncRegNum,
           CriticalEdgeSplittingOptions(&DT, &LI).setSplitDetachContinue());
 
     IRBuilder<> IRB(&*ContinueBlock->getFirstInsertionPt());
+    if (!IRB.getCurrentDebugLocation())
+      IRB.SetCurrentDebugLocation(searchForDebugLoc(&*IRB.GetInsertPoint()));
     uint64_t LocalID = DetachContinueFED.add(*ContinueBlock);
     Value *ContinueID = DetachContinueFED.localToGlobalId(LocalID, IDBuilder);
     CsiDetachContinueProperty ContProp;

--- a/llvm/test/Transforms/Tapir/CilkSanitizer/cabs-fstat64.ll
+++ b/llvm/test/Transforms/Tapir/CilkSanitizer/cabs-fstat64.ll
@@ -1,0 +1,188 @@
+; Check synthesis of Cilksan hooks for cabs and fstat64.
+; Although both of these functions return values, their Cilksan hooks should return void.
+;
+; RUN: opt < %s -passes="cilksan" -cilksan-bc-path=%S/null-bitcode.bc -S | FileCheck %s
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+module asm ".globl _ZSt21ios_base_library_initv"
+
+%"class.std::basic_ostream" = type { ptr, %"class.std::basic_ios" }
+%"class.std::basic_ios" = type { %"class.std::ios_base", ptr, i8, i8, ptr, ptr, ptr, ptr }
+%"class.std::ios_base" = type { ptr, i64, i64, i32, i32, i32, ptr, %"struct.std::ios_base::_Words", [8 x %"struct.std::ios_base::_Words"], i32, ptr, %"class.std::locale" }
+%"struct.std::ios_base::_Words" = type { ptr, i64 }
+%"class.std::locale" = type { ptr }
+%struct.stat64 = type { i64, i64, i64, i32, i32, i32, i32, i64, i64, i64, i64, %struct.timespec, %struct.timespec, %struct.timespec, [3 x i64] }
+%struct.timespec = type { i64, i64 }
+%"class.std::ctype" = type <{ %"class.std::locale::facet.base", [4 x i8], ptr, i8, [7 x i8], ptr, ptr, ptr, i8, [256 x i8], [256 x i8], i8, [6 x i8] }>
+%"class.std::locale::facet.base" = type <{ ptr, i32 }>
+
+@_ZSt4cout = external global %"class.std::basic_ostream", align 8
+
+; Function Attrs: mustprogress norecurse sanitize_cilk uwtable
+define dso_local noundef i32 @main() local_unnamed_addr #0 {
+entry:
+  %buf = alloca %struct.stat64, align 8
+  %call.i.i = tail call noundef double @cabs(double noundef 1.000000e+00, double noundef 2.000000e+00) #5
+  %call.i = tail call noundef nonnull align 8 dereferenceable(8) ptr @_ZNSo9_M_insertIdEERSoT_(ptr noundef nonnull align 8 dereferenceable(8) @_ZSt4cout, double noundef %call.i.i)
+  %vtable.i = load ptr, ptr %call.i, align 8, !tbaa !5
+  %vbase.offset.ptr.i = getelementptr i8, ptr %vtable.i, i64 -24
+  %vbase.offset.i = load i64, ptr %vbase.offset.ptr.i, align 8
+  %add.ptr.i = getelementptr inbounds i8, ptr %call.i, i64 %vbase.offset.i
+  %_M_ctype.i.i = getelementptr inbounds %"class.std::basic_ios", ptr %add.ptr.i, i64 0, i32 5
+  %0 = load ptr, ptr %_M_ctype.i.i, align 8, !tbaa !8
+  %tobool.not.i.i.i = icmp eq ptr %0, null
+  br i1 %tobool.not.i.i.i, label %if.then.i.i.i, label %_ZSt13__check_facetISt5ctypeIcEERKT_PS3_.exit.i.i
+
+if.then.i.i.i:                                    ; preds = %entry
+  tail call void @_ZSt16__throw_bad_castv() #6
+  unreachable
+
+_ZSt13__check_facetISt5ctypeIcEERKT_PS3_.exit.i.i: ; preds = %entry
+  %_M_widen_ok.i.i.i = getelementptr inbounds %"class.std::ctype", ptr %0, i64 0, i32 8
+  %1 = load i8, ptr %_M_widen_ok.i.i.i, align 8, !tbaa !20
+  %tobool.not.i1.i.i = icmp eq i8 %1, 0
+  br i1 %tobool.not.i1.i.i, label %if.end.i.i.i, label %if.then.i2.i.i
+
+if.then.i2.i.i:                                   ; preds = %_ZSt13__check_facetISt5ctypeIcEERKT_PS3_.exit.i.i
+  %arrayidx.i.i.i = getelementptr inbounds %"class.std::ctype", ptr %0, i64 0, i32 9, i64 10
+  %2 = load i8, ptr %arrayidx.i.i.i, align 1, !tbaa !23
+  br label %_ZSt4endlIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_.exit
+
+if.end.i.i.i:                                     ; preds = %_ZSt13__check_facetISt5ctypeIcEERKT_PS3_.exit.i.i
+  tail call void @_ZNKSt5ctypeIcE13_M_widen_initEv(ptr noundef nonnull align 8 dereferenceable(570) %0)
+  %vtable.i.i.i = load ptr, ptr %0, align 8, !tbaa !5
+  %vfn.i.i.i = getelementptr inbounds ptr, ptr %vtable.i.i.i, i64 6
+  %3 = load ptr, ptr %vfn.i.i.i, align 8
+  %call.i.i.i = tail call noundef signext i8 %3(ptr noundef nonnull align 8 dereferenceable(570) %0, i8 noundef signext 10)
+  br label %_ZSt4endlIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_.exit
+
+_ZSt4endlIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_.exit: ; preds = %if.then.i2.i.i, %if.end.i.i.i
+  %retval.0.i.i.i = phi i8 [ %2, %if.then.i2.i.i ], [ %call.i.i.i, %if.end.i.i.i ]
+  %call1.i = tail call noundef nonnull align 8 dereferenceable(8) ptr @_ZNSo3putEc(ptr noundef nonnull align 8 dereferenceable(8) %call.i, i8 noundef signext %retval.0.i.i.i)
+  %call.i.i4 = tail call noundef nonnull align 8 dereferenceable(8) ptr @_ZNSo5flushEv(ptr noundef nonnull align 8 dereferenceable(8) %call1.i)
+  call void @llvm.lifetime.start.p0(i64 144, ptr nonnull %buf) #5
+  %call3 = call i32 @fstat64(i32 noundef 0, ptr noundef nonnull %buf) #5
+  %4 = load i64, ptr %buf, align 8, !tbaa !24
+  %call.i2 = tail call noundef nonnull align 8 dereferenceable(8) ptr @_ZNSo9_M_insertImEERSoT_(ptr noundef nonnull align 8 dereferenceable(8) @_ZSt4cout, i64 noundef %4)
+  %vtable.i5 = load ptr, ptr %call.i2, align 8, !tbaa !5
+  %vbase.offset.ptr.i6 = getelementptr i8, ptr %vtable.i5, i64 -24
+  %vbase.offset.i7 = load i64, ptr %vbase.offset.ptr.i6, align 8
+  %add.ptr.i8 = getelementptr inbounds i8, ptr %call.i2, i64 %vbase.offset.i7
+  %_M_ctype.i.i9 = getelementptr inbounds %"class.std::basic_ios", ptr %add.ptr.i8, i64 0, i32 5
+  %5 = load ptr, ptr %_M_ctype.i.i9, align 8, !tbaa !8
+  %tobool.not.i.i.i10 = icmp eq ptr %5, null
+  br i1 %tobool.not.i.i.i10, label %if.then.i.i.i23, label %_ZSt13__check_facetISt5ctypeIcEERKT_PS3_.exit.i.i11
+
+if.then.i.i.i23:                                  ; preds = %_ZSt4endlIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_.exit
+  tail call void @_ZSt16__throw_bad_castv() #6
+  unreachable
+
+_ZSt13__check_facetISt5ctypeIcEERKT_PS3_.exit.i.i11: ; preds = %_ZSt4endlIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_.exit
+  %_M_widen_ok.i.i.i12 = getelementptr inbounds %"class.std::ctype", ptr %5, i64 0, i32 8
+  %6 = load i8, ptr %_M_widen_ok.i.i.i12, align 8, !tbaa !20
+  %tobool.not.i1.i.i13 = icmp eq i8 %6, 0
+  br i1 %tobool.not.i1.i.i13, label %if.end.i.i.i19, label %if.then.i2.i.i14
+
+if.then.i2.i.i14:                                 ; preds = %_ZSt13__check_facetISt5ctypeIcEERKT_PS3_.exit.i.i11
+  %arrayidx.i.i.i15 = getelementptr inbounds %"class.std::ctype", ptr %5, i64 0, i32 9, i64 10
+  %7 = load i8, ptr %arrayidx.i.i.i15, align 1, !tbaa !23
+  br label %_ZSt4endlIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_.exit24
+
+if.end.i.i.i19:                                   ; preds = %_ZSt13__check_facetISt5ctypeIcEERKT_PS3_.exit.i.i11
+  tail call void @_ZNKSt5ctypeIcE13_M_widen_initEv(ptr noundef nonnull align 8 dereferenceable(570) %5)
+  %vtable.i.i.i20 = load ptr, ptr %5, align 8, !tbaa !5
+  %vfn.i.i.i21 = getelementptr inbounds ptr, ptr %vtable.i.i.i20, i64 6
+  %8 = load ptr, ptr %vfn.i.i.i21, align 8
+  %call.i.i.i22 = tail call noundef signext i8 %8(ptr noundef nonnull align 8 dereferenceable(570) %5, i8 noundef signext 10)
+  br label %_ZSt4endlIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_.exit24
+
+_ZSt4endlIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_.exit24: ; preds = %if.then.i2.i.i14, %if.end.i.i.i19
+  %retval.0.i.i.i16 = phi i8 [ %7, %if.then.i2.i.i14 ], [ %call.i.i.i22, %if.end.i.i.i19 ]
+  %call1.i17 = tail call noundef nonnull align 8 dereferenceable(8) ptr @_ZNSo3putEc(ptr noundef nonnull align 8 dereferenceable(8) %call.i2, i8 noundef signext %retval.0.i.i.i16)
+  %call.i.i18 = tail call noundef nonnull align 8 dereferenceable(8) ptr @_ZNSo5flushEv(ptr noundef nonnull align 8 dereferenceable(8) %call1.i17)
+  call void @llvm.lifetime.end.p0(i64 144, ptr nonnull %buf) #5
+  ret i32 0
+}
+
+; CHECK: define {{.*}}i32 @main()
+; CHECK: %[[CABS_CALL:.+]] = {{.*}}call {{.*}}double @cabs(double noundef 1.000000e+00, double noundef 2.000000e+00)
+; CHECK-NEXT: call {{.*}}void @__csan_cabs(i64 %{{.+}}, i64 %{{.+}}, i8 0, i64 0, double %[[CABS_CALL]], double 1.000000e+00, double 2.000000e+00)
+; CHECK: %call3 = call {{.*}}i32 @fstat64(i32 noundef 0, ptr {{.*}}%[[BUF:.+]])
+; CHECK-NEXT: call {{.*}}void @__csan_fstat64(i64 %{{.+}}, i64 %{{.+}}, i8 1, i64 0, i32 %call3, i32 0, ptr {{.*}}%[[BUF]])
+
+; CHECK: define {{.*}}void @__csan_cabs(i64 %0, i64 %1, i8 %2, i64 %3, double %4, double %5, double %6)
+; CHECK-NEXT: entry:
+; CHECK-NEXT: call void @__csan_default_libhook(i64 %0, i64 %1, i8 %2)
+; CHECK-NEXT: ret void
+; CHECK-NEXT: }
+
+; CHECK: define {{.*}}void @__csan_fstat64(i64 %0, i64 %1, i8 %2, i64 %3, i32 %4, i32 %5, ptr %6)
+; CHECK-NEXT: entry:
+; CHECK-NEXT: call void @__csan_default_libhook(i64 %0, i64 %1, i8 %2)
+; CHECK-NEXT: ret void
+; CHECK-NEXT: }
+
+; Function Attrs: mustprogress nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg, ptr nocapture) #1
+
+; Function Attrs: mustprogress nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg, ptr nocapture) #1
+
+; Function Attrs: nofree nounwind
+declare noundef i32 @fstat64(i32 noundef, ptr nocapture noundef) local_unnamed_addr #2
+
+; Function Attrs: nofree nounwind
+declare double @cabs(double noundef, double noundef) local_unnamed_addr #2
+
+declare noundef nonnull align 8 dereferenceable(8) ptr @_ZNSo9_M_insertIdEERSoT_(ptr noundef nonnull align 8 dereferenceable(8), double noundef) local_unnamed_addr #3
+
+declare noundef nonnull align 8 dereferenceable(8) ptr @_ZNSo3putEc(ptr noundef nonnull align 8 dereferenceable(8), i8 noundef signext) local_unnamed_addr #3
+
+declare noundef nonnull align 8 dereferenceable(8) ptr @_ZNSo5flushEv(ptr noundef nonnull align 8 dereferenceable(8)) local_unnamed_addr #3
+
+; Function Attrs: cold noreturn
+declare void @_ZSt16__throw_bad_castv() local_unnamed_addr #4
+
+declare void @_ZNKSt5ctypeIcE13_M_widen_initEv(ptr noundef nonnull align 8 dereferenceable(570)) local_unnamed_addr #3
+
+declare noundef nonnull align 8 dereferenceable(8) ptr @_ZNSo9_M_insertImEERSoT_(ptr noundef nonnull align 8 dereferenceable(8), i64 noundef) local_unnamed_addr #3
+
+attributes #0 = { mustprogress norecurse sanitize_cilk uwtable "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #1 = { mustprogress nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { nofree nounwind "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #3 = { "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #4 = { cold noreturn "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #5 = { nounwind }
+attributes #6 = { cold noreturn }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 8, !"PIC Level", i32 2}
+!2 = !{i32 7, !"PIE Level", i32 2}
+!3 = !{i32 7, !"uwtable", i32 2}
+!4 = !{!"clang version 18.1.8 (git@github.com:neboat/opencilk-project.git c3cd84365e099ab6dfa4b484475ef66f33f16eab)"}
+!5 = !{!6, !6, i64 0}
+!6 = !{!"vtable pointer", !7, i64 0}
+!7 = !{!"Simple C++ TBAA"}
+!8 = !{!9, !15, i64 240}
+!9 = !{!"_ZTSSt9basic_iosIcSt11char_traitsIcEE", !10, i64 0, !15, i64 216, !12, i64 224, !19, i64 225, !15, i64 232, !15, i64 240, !15, i64 248, !15, i64 256}
+!10 = !{!"_ZTSSt8ios_base", !11, i64 8, !11, i64 16, !13, i64 24, !14, i64 28, !14, i64 32, !15, i64 40, !16, i64 48, !12, i64 64, !17, i64 192, !15, i64 200, !18, i64 208}
+!11 = !{!"long", !12, i64 0}
+!12 = !{!"omnipotent char", !7, i64 0}
+!13 = !{!"_ZTSSt13_Ios_Fmtflags", !12, i64 0}
+!14 = !{!"_ZTSSt12_Ios_Iostate", !12, i64 0}
+!15 = !{!"any pointer", !12, i64 0}
+!16 = !{!"_ZTSNSt8ios_base6_WordsE", !15, i64 0, !11, i64 8}
+!17 = !{!"int", !12, i64 0}
+!18 = !{!"_ZTSSt6locale", !15, i64 0}
+!19 = !{!"bool", !12, i64 0}
+!20 = !{!21, !12, i64 56}
+!21 = !{!"_ZTSSt5ctypeIcE", !22, i64 0, !15, i64 16, !19, i64 24, !15, i64 32, !15, i64 40, !15, i64 48, !12, i64 56, !12, i64 57, !12, i64 313, !12, i64 569}
+!22 = !{!"_ZTSNSt6locale5facetE", !17, i64 8}
+!23 = !{!12, !12, i64 0}
+!24 = !{!25, !11, i64 0}
+!25 = !{!"_ZTS6stat64", !11, i64 0, !11, i64 8, !11, i64 16, !17, i64 24, !17, i64 28, !17, i64 32, !17, i64 36, !11, i64 40, !11, i64 48, !11, i64 56, !11, i64 64, !26, i64 72, !26, i64 88, !26, i64 104, !12, i64 120}
+!26 = !{!"_ZTS8timespec", !11, i64 0, !11, i64 8}

--- a/llvm/test/Transforms/Tapir/CilkSanitizer/hyper-lookup-synthesized-hooks.ll
+++ b/llvm/test/Transforms/Tapir/CilkSanitizer/hyper-lookup-synthesized-hooks.ll
@@ -1,0 +1,125 @@
+; Check synthesis of hooks for hyper.lookup calls.
+;
+; RUN: opt < %s -passes="cilksan" -cilksan-bc-path=%S/null-bitcode.bc -S | FileCheck %s
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+$_Z8sum_initIdEvPv = comdat any
+
+$_Z10sum_reduceIdEvPvS0_ = comdat any
+
+; Function Attrs: mustprogress sanitize_cilk uwtable
+define dso_local void @_Z3runv() local_unnamed_addr #0 personality ptr @__gxx_personality_v0 {
+entry:
+  %sumAParRelError = alloca double, align 8
+  call void @llvm.lifetime.start.p0(i64 8, ptr nonnull %sumAParRelError) #7
+  store double 0.000000e+00, ptr %sumAParRelError, align 8, !tbaa !5
+  call void @llvm.reducer.register.i64(ptr nonnull %sumAParRelError, i64 8, ptr nonnull @_Z8sum_initIdEvPv, ptr nonnull @_Z10sum_reduceIdEvPvS0_)
+  %0 = call ptr @llvm.hyper.lookup.i64(ptr nonnull %sumAParRelError, i64 8, ptr nonnull @_Z8sum_initIdEvPv, ptr nonnull @_Z10sum_reduceIdEvPvS0_)
+  %1 = load double, ptr %0, align 8, !tbaa !5
+  invoke void @_Z1hd(double noundef %1)
+          to label %invoke.cont unwind label %lpad
+
+invoke.cont:                                      ; preds = %entry
+  %2 = call ptr @llvm.hyper.lookup.i64(ptr nonnull %sumAParRelError, i64 8, ptr nonnull @_Z8sum_initIdEvPv, ptr nonnull @_Z10sum_reduceIdEvPvS0_)
+  %3 = load double, ptr %2, align 8, !tbaa !5
+  invoke void @_Z1hd(double noundef %3)
+          to label %invoke.cont1 unwind label %lpad
+
+invoke.cont1:                                     ; preds = %invoke.cont
+  call void @llvm.reducer.unregister(ptr nonnull %sumAParRelError)
+  call void @llvm.lifetime.end.p0(i64 8, ptr nonnull %sumAParRelError) #7
+  ret void
+
+lpad:                                             ; preds = %invoke.cont, %entry
+  %4 = landingpad { ptr, i32 }
+          cleanup
+  call void @llvm.reducer.unregister(ptr nonnull %sumAParRelError)
+  call void @llvm.lifetime.end.p0(i64 8, ptr nonnull %sumAParRelError) #7
+  resume { ptr, i32 } %4
+}
+
+; Check insertion of __csan_llvm_hyper_lookup calls and use of their return values.
+
+; CHECK: define dso_local void @_Z3runv()
+
+; CHECK: %[[HYPER_LOOKUP:.+]] = call ptr @llvm.hyper.lookup.i64(ptr nonnull %sumAParRelError
+; CHECK: %[[CSAN_HYPER_LOOKUP:.+]] = call {{.*}}ptr @__csan_llvm_hyper_lookup_i64(i64 %{{.*}}, i64 %{{.*}}, i8 3, i64 0, ptr %[[HYPER_LOOKUP]],
+; CHECK: call void @__csan_load(i64 %{{.*}}, ptr %[[CSAN_HYPER_LOOKUP]],
+; CHECK-NEXT: %[[VIEW_LOAD:.+]] = load double, ptr %[[CSAN_HYPER_LOOKUP]]
+
+; CHECK: invoke void @_Z1hd(double noundef %[[VIEW_LOAD]])
+
+; CHECK: %[[HYPER_LOOKUP_2:.+]] = call ptr @llvm.hyper.lookup.i64(ptr nonnull %sumAParRelError
+; CHECK: %[[CSAN_HYPER_LOOKUP_2:.+]] = call {{.*}}ptr @__csan_llvm_hyper_lookup_i64(i64 %{{.*}}, i64 %{{.*}}, i8 3, i64 0, ptr %[[HYPER_LOOKUP_2]],
+; CHECK: call void @__csan_load(i64 %{{.*}}, ptr %[[CSAN_HYPER_LOOKUP_2]],
+; CHECK-NEXT: %[[VIEW_LOAD_2:.+]] = load double, ptr %[[CSAN_HYPER_LOOKUP_2]]
+
+; CHECK: invoke void @_Z1hd(double noundef %[[VIEW_LOAD_2]])
+
+
+; Check that synthesized __csan_llvm_hyper_lookup function simply calls the default hook and returns the return-value parameter.
+
+; CHECK: define {{.*}}ptr @__csan_llvm_hyper_lookup_i64(i64 %0, i64 %1, i8 %2, i64 %3, ptr %4, ptr %5, i64 %6, ptr %7, ptr %8)
+; CHECK-NEXT: entry:
+; CHECK-NEXT: call {{.*}}void @__csan_default_libhook(i64 %0, i64 %1, i8 %2)
+; CHECK-NEXT: ret ptr %4
+; CHECK-NEXT: }
+
+; Function Attrs: mustprogress nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg, ptr nocapture) #1
+
+; Function Attrs: mustprogress nounwind sanitize_cilk uwtable
+define linkonce_odr dso_local void @_Z8sum_initIdEvPv(ptr noundef %v) #2 comdat {
+entry:
+  store double 0.000000e+00, ptr %v, align 8, !tbaa !5
+  ret void
+}
+
+; Function Attrs: mustprogress nounwind sanitize_cilk uwtable
+define linkonce_odr dso_local void @_Z10sum_reduceIdEvPvS0_(ptr noundef %v, ptr noundef %v2) #2 comdat {
+entry:
+  %0 = load double, ptr %v2, align 8, !tbaa !5
+  %1 = load double, ptr %v, align 8, !tbaa !5
+  %add = fadd double %0, %1
+  store double %add, ptr %v, align 8, !tbaa !5
+  ret void
+}
+
+; Function Attrs: mustprogress nounwind reducer_register willreturn memory(inaccessiblemem: readwrite)
+declare void @llvm.reducer.register.i64(ptr, i64, ptr, ptr) #3
+
+declare i32 @__gxx_personality_v0(...)
+
+; Function Attrs: mustprogress nounwind reducer_unregister willreturn memory(inaccessiblemem: readwrite)
+declare void @llvm.reducer.unregister(ptr) #4
+
+; Function Attrs: mustprogress nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg, ptr nocapture) #1
+
+declare void @_Z1hd(double noundef) local_unnamed_addr #5
+
+; Function Attrs: hyper_view injective mustprogress nofree nounwind strand_pure willreturn memory(inaccessiblemem: read)
+declare ptr @llvm.hyper.lookup.i64(ptr, i64, ptr, ptr) #6
+
+attributes #0 = { mustprogress sanitize_cilk uwtable "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #1 = { mustprogress nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { mustprogress nounwind sanitize_cilk uwtable "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #3 = { mustprogress nounwind reducer_register willreturn memory(inaccessiblemem: readwrite) }
+attributes #4 = { mustprogress nounwind reducer_unregister willreturn memory(inaccessiblemem: readwrite) }
+attributes #5 = { "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #6 = { hyper_view injective mustprogress nofree nounwind strand_pure willreturn memory(inaccessiblemem: read) }
+attributes #7 = { nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 8, !"PIC Level", i32 2}
+!2 = !{i32 7, !"PIE Level", i32 2}
+!3 = !{i32 7, !"uwtable", i32 2}
+!4 = !{!"clang version 18.1.8 (git@github.com:neboat/opencilk-project.git c3cd84365e099ab6dfa4b484475ef66f33f16eab)"}
+!5 = !{!6, !6, i64 0}
+!6 = !{!"double", !7, i64 0}
+!7 = !{!"omnipotent char", !8, i64 0}
+!8 = !{!"Simple C++ TBAA"}

--- a/llvm/test/Transforms/Tapir/CilkSanitizer/synthesize-alloc-hook.ll
+++ b/llvm/test/Transforms/Tapir/CilkSanitizer/synthesize-alloc-hook.ll
@@ -1,0 +1,40 @@
+; Check synthesis of alloc function hooks.
+;
+; RUN: opt < %s -passes="cilksan" -cilksan-bc-path=%S/null-bitcode.bc -S | FileCheck %s
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+@.str = private unnamed_addr constant [2 x i8] c"a\00", align 1
+
+; Function Attrs: mustprogress nofree nounwind sanitize_cilk willreturn memory(inaccessiblemem: readwrite) uwtable
+define dso_local noalias noundef ptr @_Z8strdup_av() local_unnamed_addr #0 {
+entry:
+  %call = tail call noalias dereferenceable_or_null(2) ptr @strdup(ptr noundef nonnull @.str) #2
+  ret ptr %call
+}
+
+; CHECK-LABEL: define dso_local noalias noundef ptr @_Z8strdup_av()
+; CHECK: %[[CALL:.+]] = tail call noalias dereferenceable_or_null(2) ptr @strdup(ptr noundef nonnull @.str)
+; CHECK-NEXT: call void @__csan_alloc_strdup(i64 %{{.*}}, i64 %{{.*}}, i8 0, i64 {{.*}}, ptr %[[CALL]], ptr @.str)
+; CHECK: ret ptr %[[CALL]]
+
+; CHECK-LABEL: define void @__csan_alloc_strdup(i64 %0, i64 %1, i8 %2, i64 %3, ptr %4, ptr %5)
+; CHECK-NEXT: entry:
+; CHECK-NEXT: call void @__csan_default_libhook(i64 %0, i64 %1, i8 %2)
+; CHECK-NEXT: ret void
+
+; Function Attrs: mustprogress nofree nounwind willreturn memory(argmem: readwrite, inaccessiblemem: readwrite)
+declare noalias ptr @strdup(ptr nocapture noundef readonly) local_unnamed_addr #1
+
+attributes #0 = { mustprogress nofree nounwind sanitize_cilk willreturn memory(inaccessiblemem: readwrite) uwtable "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #1 = { mustprogress nofree nounwind willreturn memory(argmem: readwrite, inaccessiblemem: readwrite) "alloc-family"="malloc" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #2 = { nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 8, !"PIC Level", i32 2}
+!2 = !{i32 7, !"PIE Level", i32 2}
+!3 = !{i32 7, !"uwtable", i32 2}
+!4 = !{!"clang version 18.1.8 (git@github.com:neboat/opencilk-project.git c3cd84365e099ab6dfa4b484475ef66f33f16eab)"}

--- a/llvm/test/Transforms/Tapir/CilkSanitizer/task-hook-debuginfo.ll
+++ b/llvm/test/Transforms/Tapir/CilkSanitizer/task-hook-debuginfo.ll
@@ -1,0 +1,199 @@
+; RUN: opt %s -aa-pipeline=default -passes='cilksan' -cilksan-bc-path=%S/null-bitcode.bc -enable-static-race-detection=false -S | FileCheck %s
+
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+@.str = private unnamed_addr constant [12 x i8] c"fib(%d)=%d\0A\00", align 1
+
+; Function Attrs: nounwind readnone sanitize_cilk uwtable
+define i32 @fib(i32 %n) local_unnamed_addr #0 !dbg !13 {
+entry:
+  %x = alloca i32, align 4
+  %syncreg = tail call token @llvm.syncregion.start()
+  call void @llvm.dbg.value(metadata i32 %n, metadata !17, metadata !DIExpression()), !dbg !20
+  %cmp = icmp slt i32 %n, 2, !dbg !21
+  br i1 %cmp, label %return, label %if.end, !dbg !23
+
+if.end:                                           ; preds = %entry
+  %x.0.x.0..sroa_cast = bitcast i32* %x to i8*, !dbg !24
+  call void @llvm.lifetime.start.p0i8(i64 4, i8* nonnull %x.0.x.0..sroa_cast), !dbg !24
+  detach within %syncreg, label %det.achd, label %det.cont, !dbg !25
+
+det.achd:                                         ; preds = %if.end
+  %dummy = alloca i32
+  %sub = add nsw i32 %n, -1, !dbg !26
+  %call = tail call i32 @fib(i32 %sub), !dbg !25
+  call void @llvm.dbg.value(metadata i32 %call, metadata !18, metadata !DIExpression()), !dbg !27
+  store i32 %call, i32* %x, align 4, !dbg !28
+  reattach within %syncreg, label %det.cont, !dbg !28
+; CHECK-LABEL: det.achd:
+; CHECK: call void @__csan_task({{.*}}), !dbg ![[DBG:[0-9]+]]
+; CHECK: %dummy = alloca i32
+; CHECK-NOT: !dbg
+; CHECK-NEXT: load
+; CHECK: call void @__csi_after_alloca({{.*}}), !dbg ![[DBG]]
+; CHECK: %sub = add nsw i32 %n, -1, !dbg ![[DBG]]
+
+det.cont:                                         ; preds = %det.achd, %if.end
+  %dummy2 = alloca i32
+  %sub1 = add nsw i32 %n, -2, !dbg !29
+  %call2 = tail call i32 @fib(i32 %sub1), !dbg !30
+  call void @llvm.dbg.value(metadata i32 %call2, metadata !19, metadata !DIExpression()), !dbg !31
+  sync within %syncreg, label %sync.continue, !dbg !32
+; CHECK-LABEL: det.cont:
+; CHECK: call void @__csan_detach_continue({{.*}}), !dbg ![[DBG:[0-9]+]]
+; CHECK: %dummy2 = alloca i32
+; CHECK-NOT: !dbg
+; CHECK-NEXT: call void @__csi_after_alloca({{.*}}), !dbg ![[DBG]]
+; CHECK: %sub1 = add nsw i32 %n, -2, !dbg ![[DBG]]
+
+sync.continue:                                    ; preds = %det.cont
+  %x.0.load9 = load i32, i32* %x, align 4, !dbg !33
+  call void @llvm.dbg.value(metadata i32 %x.0.load9, metadata !18, metadata !DIExpression()), !dbg !27
+  %add = add nsw i32 %x.0.load9, %call2, !dbg !34
+  call void @llvm.lifetime.end.p0i8(i64 4, i8* nonnull %x.0.x.0..sroa_cast), !dbg !35
+  br label %return
+
+return:                                           ; preds = %entry, %sync.continue
+  %retval.0 = phi i32 [ %add, %sync.continue ], [ %n, %entry ]
+  ret i32 %retval.0, !dbg !35
+}
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
+
+; Function Attrs: argmemonly nounwind
+declare token @llvm.syncregion.start() #1
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+
+; Function Attrs: nounwind sanitize_cilk uwtable
+define i32 @main(i32 %argc, i8** nocapture readonly %argv) local_unnamed_addr #2 !dbg !36 {
+entry:
+  call void @llvm.dbg.value(metadata i32 %argc, metadata !40, metadata !DIExpression()), !dbg !44
+  call void @llvm.dbg.value(metadata i8** %argv, metadata !41, metadata !DIExpression()), !dbg !45
+  call void @llvm.dbg.value(metadata i32 10, metadata !42, metadata !DIExpression()), !dbg !46
+  %cmp = icmp sgt i32 %argc, 1, !dbg !47
+  br i1 %cmp, label %if.then, label %if.end, !dbg !49
+
+if.then:                                          ; preds = %entry
+  %arrayidx = getelementptr inbounds i8*, i8** %argv, i64 1, !dbg !50
+  %0 = load i8*, i8** %arrayidx, align 8, !dbg !50, !tbaa !51
+  %call = tail call i32 @atoi(i8* %0) #6, !dbg !55
+  call void @llvm.dbg.value(metadata i32 %call, metadata !42, metadata !DIExpression()), !dbg !46
+  br label %if.end, !dbg !56
+
+if.end:                                           ; preds = %if.then, %entry
+  %n.0 = phi i32 [ %call, %if.then ], [ 10, %entry ]
+  call void @llvm.dbg.value(metadata i32 %n.0, metadata !42, metadata !DIExpression()), !dbg !46
+  %call1 = tail call i32 @fib(i32 %n.0), !dbg !57
+  call void @llvm.dbg.value(metadata i32 %call1, metadata !43, metadata !DIExpression()), !dbg !58
+  %call2 = tail call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([12 x i8], [12 x i8]* @.str, i64 0, i64 0), i32 %n.0, i32 %call1), !dbg !59
+  ret i32 0, !dbg !60
+}
+
+; Function Attrs: inlinehint nounwind readonly uwtable
+define available_externally i32 @atoi(i8* nonnull %__nptr) local_unnamed_addr #3 !dbg !61 {
+entry:
+  call void @llvm.dbg.value(metadata i8* %__nptr, metadata !68, metadata !DIExpression()), !dbg !69
+  %call = tail call i64 @strtol(i8* nocapture nonnull %__nptr, i8** null, i32 10) #7, !dbg !70
+  %conv = trunc i64 %call to i32, !dbg !71
+  ret i32 %conv, !dbg !72
+}
+
+; Function Attrs: nounwind
+declare i32 @printf(i8* nocapture readonly, ...) local_unnamed_addr #4
+
+; Function Attrs: nounwind
+declare i64 @strtol(i8* readonly, i8** nocapture, i32) local_unnamed_addr #4
+
+; Function Attrs: nounwind readnone speculatable
+declare void @llvm.dbg.value(metadata, metadata, metadata) #5
+
+attributes #0 = { nounwind readnone sanitize_cilk uwtable "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { argmemonly nounwind }
+attributes #2 = { nounwind sanitize_cilk uwtable "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #3 = { inlinehint nounwind readonly uwtable "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #4 = { nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #5 = { nounwind readnone speculatable }
+attributes #6 = { nounwind readonly }
+attributes #7 = { nounwind }
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!9, !10, !11}
+!llvm.ident = !{!12}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 6.0.0 (git@github.com:wsmoses/Tapir-Clang.git 051bd478f93bf64db3934d14f97a36137bffef5e) (git@github.mit.edu:SuperTech/Tapir-CSI-llvm.git 9de43afffece94ca0534b391544bbfd246fc7b91)", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, retainedTypes: !3)
+!1 = !DIFile(filename: "fib.c", directory: "/data/compilers/tests/cilksan")
+!2 = !{}
+!3 = !{!4, !5, !8}
+!4 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!5 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !6, size: 64)
+!6 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !7, size: 64)
+!7 = !DIBasicType(name: "char", size: 8, encoding: DW_ATE_signed_char)
+!8 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: null, size: 64)
+!9 = !{i32 2, !"Dwarf Version", i32 4}
+!10 = !{i32 2, !"Debug Info Version", i32 3}
+!11 = !{i32 1, !"wchar_size", i32 4}
+!12 = !{!"clang version 6.0.0 (git@github.com:wsmoses/Tapir-Clang.git 051bd478f93bf64db3934d14f97a36137bffef5e) (git@github.mit.edu:SuperTech/Tapir-CSI-llvm.git 9de43afffece94ca0534b391544bbfd246fc7b91)"}
+!13 = distinct !DISubprogram(name: "fib", scope: !1, file: !1, line: 5, type: !14, isLocal: false, isDefinition: true, scopeLine: 5, flags: DIFlagPrototyped, isOptimized: true, unit: !0, retainedNodes: !16)
+!14 = !DISubroutineType(types: !15)
+!15 = !{!4, !4}
+!16 = !{!17, !18, !19}
+!17 = !DILocalVariable(name: "n", arg: 1, scope: !13, file: !1, line: 5, type: !4)
+!18 = !DILocalVariable(name: "x", scope: !13, file: !1, line: 7, type: !4)
+!19 = !DILocalVariable(name: "y", scope: !13, file: !1, line: 7, type: !4)
+!20 = !DILocation(line: 5, column: 13, scope: !13)
+!21 = !DILocation(line: 6, column: 9, scope: !22)
+!22 = distinct !DILexicalBlock(scope: !13, file: !1, line: 6, column: 7)
+!23 = !DILocation(line: 6, column: 7, scope: !13)
+!24 = !DILocation(line: 7, column: 3, scope: !13)
+!25 = !DILocation(line: 8, column: 18, scope: !13)
+!26 = !DILocation(line: 8, column: 23, scope: !13)
+!27 = !DILocation(line: 7, column: 7, scope: !13)
+!28 = !DILocation(line: 8, column: 5, scope: !13)
+!29 = !DILocation(line: 9, column: 12, scope: !13)
+!30 = !DILocation(line: 9, column: 7, scope: !13)
+!31 = !DILocation(line: 7, column: 10, scope: !13)
+!32 = !DILocation(line: 10, column: 3, scope: !13)
+!33 = !DILocation(line: 11, column: 10, scope: !13)
+!34 = !DILocation(line: 11, column: 11, scope: !13)
+!35 = !DILocation(line: 12, column: 1, scope: !13)
+!36 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 14, type: !37, isLocal: false, isDefinition: true, scopeLine: 14, flags: DIFlagPrototyped, isOptimized: true, unit: !0, retainedNodes: !39)
+!37 = !DISubroutineType(types: !38)
+!38 = !{!4, !4, !5}
+!39 = !{!40, !41, !42, !43}
+!40 = !DILocalVariable(name: "argc", arg: 1, scope: !36, file: !1, line: 14, type: !4)
+!41 = !DILocalVariable(name: "argv", arg: 2, scope: !36, file: !1, line: 14, type: !5)
+!42 = !DILocalVariable(name: "n", scope: !36, file: !1, line: 15, type: !4)
+!43 = !DILocalVariable(name: "result", scope: !36, file: !1, line: 19, type: !4)
+!44 = !DILocation(line: 14, column: 14, scope: !36)
+!45 = !DILocation(line: 14, column: 26, scope: !36)
+!46 = !DILocation(line: 15, column: 7, scope: !36)
+!47 = !DILocation(line: 16, column: 12, scope: !48)
+!48 = distinct !DILexicalBlock(scope: !36, file: !1, line: 16, column: 7)
+!49 = !DILocation(line: 16, column: 7, scope: !36)
+!50 = !DILocation(line: 17, column: 14, scope: !48)
+!51 = !{!52, !52, i64 0}
+!52 = !{!"any pointer", !53, i64 0}
+!53 = !{!"omnipotent char", !54, i64 0}
+!54 = !{!"Simple C/C++ TBAA"}
+!55 = !DILocation(line: 17, column: 9, scope: !48)
+!56 = !DILocation(line: 17, column: 5, scope: !48)
+!57 = !DILocation(line: 19, column: 16, scope: !36)
+!58 = !DILocation(line: 19, column: 7, scope: !36)
+!59 = !DILocation(line: 20, column: 3, scope: !36)
+!60 = !DILocation(line: 21, column: 3, scope: !36)
+!61 = distinct !DISubprogram(name: "atoi", scope: !62, file: !62, line: 361, type: !63, isLocal: false, isDefinition: true, scopeLine: 362, flags: DIFlagPrototyped, isOptimized: true, unit: !0, retainedNodes: !67)
+!62 = !DIFile(filename: "/usr/include/stdlib.h", directory: "/data/compilers/tests/cilksan")
+!63 = !DISubroutineType(types: !64)
+!64 = !{!4, !65}
+!65 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !66, size: 64)
+!66 = !DIDerivedType(tag: DW_TAG_const_type, baseType: !7)
+!67 = !{!68}
+!68 = !DILocalVariable(name: "__nptr", arg: 1, scope: !61, file: !62, line: 361, type: !65)
+!69 = !DILocation(line: 361, column: 1, scope: !61)
+!70 = !DILocation(line: 363, column: 16, scope: !61)
+!71 = !DILocation(line: 363, column: 10, scope: !61)
+!72 = !DILocation(line: 363, column: 3, scope: !61)


### PR DESCRIPTION
This PR fixes some issues with Cilksan's instrumentation pass.

- When synthesizing default instrumentation hooks, make sure the synthesized hook has a `ret` instruction that returns an appropriate value if the synthesized hook does not return void.
- If a hook has been synthesized previously, go ahead and return that hook.  This way, synthesized hooks don't end up with lots of unnecessary dead basic blocks.
- Search for debug information to attach to `__csan_task` and `__csan_detach_continue` hooks, in case such debug information isn't available exactly at the hook-insertion point.

These changes fix various compiler crashes with Cilksan, including those in OpenCilk/opencilk-project#291.