### PR TITLE
Fix Cilkscale with LLD

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -98,7 +98,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: Setup Python env
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
           cache: 'pip'

--- a/.github/workflows/llvm-project-tests.yml
+++ b/.github/workflows/llvm-project-tests.yml
@@ -77,7 +77,7 @@ jobs:
       # lldb.  Using this setup-python action to make 3.10 the default
       # python fixes this.
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ inputs.python_version }}
       - name: Install Ninja

--- a/.github/workflows/llvm-project-tests.yml
+++ b/.github/workflows/llvm-project-tests.yml
@@ -14,7 +14,7 @@ on:
         required: false
       os_list:
         required: false
-        default: '["ubuntu-latest", "windows-2019", "macOS-13"]'
+        default: '["ubuntu-22.04", "windows-2019", "macOS-13"]'
       python_version:
         required: false
         type: string
@@ -39,7 +39,7 @@ on:
         type: string
         # Use windows-2019 due to:
         # https://developercommunity.visualstudio.com/t/Prev-Issue---with-__assume-isnan-/1597317
-        default: '["ubuntu-latest", "macOS-13"]'
+        default: '["ubuntu-22.04", "macOS-13"]'
 
       python_version:
         required: false

--- a/.github/workflows/pr-code-format.yml
+++ b/.github/workflows/pr-code-format.yml
@@ -56,7 +56,7 @@ jobs:
           clangformat: 17.0.1
 
       - name: Setup Python env
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
           cache: 'pip'

--- a/.github/workflows/release-documentation.yml
+++ b/.github/workflows/release-documentation.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Setup Python env
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           cache: 'pip'
           cache-dependency-path: './llvm/docs/requirements.txt'

--- a/.github/workflows/release-doxygen.yml
+++ b/.github/workflows/release-doxygen.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Setup Python env
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           cache: 'pip'
           cache-dependency-path: './llvm/docs/requirements.txt'

--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -1078,7 +1078,7 @@ void EmitAssemblyHelper::RunOptimizationPipeline(
             });
         break;
       case LangOptions::CilktoolKind::Cilktool_Cilkscale_Benchmark:
-          PB.registerTapirLoopEndEPCallback(
+          PB.registerTapirLateEPCallback(
             [&PB](ModulePassManager &MPM, OptimizationLevel Level) {
               MPM.addPass(CSISetupPass(getCSIOptionsForCilkscaleBenchmark()));
               MPM.addPass(ComprehensiveStaticInstrumentationPass(

--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
@@ -1639,15 +1639,6 @@ bool tools::addSanitizerRuntimes(const ToolChain &TC, const ArgList &Args,
       CmdArgs.push_back("--android-memtag-stack");
   }
 
-  if (SanArgs.needsCilksanRt()) {
-    // Interpose the __cilkrts_internal_merge_two_rmaps, __cilkrts_hyper_alloc,
-    // and __cilkrts_hyper_dealloc functions in the OpenCilk runtime, to properly
-    // suppress races involving reducer hyperobjects.
-    CmdArgs.push_back("--wrap=__cilkrts_internal_merge_two_rmaps");
-    CmdArgs.push_back("--wrap=__cilkrts_hyper_alloc");
-    CmdArgs.push_back("--wrap=__cilkrts_hyper_dealloc");
-  }
-
   return !StaticRuntimes.empty() || !NonWholeStaticRuntimes.empty();
 }
 

--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
@@ -301,6 +301,10 @@ static void renderTapirLoweringOptions(const ArgList &Args,
     } else if (Args.hasArg(options::OPT_fcilkplus))
       CmdArgs.push_back("--plugin-opt=tapir-target=cilkplus");
   }
+
+  if (const Arg *A = Args.getLastArg(options::OPT_fcilktool_EQ))
+    CmdArgs.push_back(Args.MakeArgString(
+        Twine("--plugin-opt=cilktool=") + A->getValue()));
 }
 
 void tools::addPathIfExists(const Driver &D, const Twine &Path,

--- a/clang/lib/Driver/ToolChains/Darwin.cpp
+++ b/clang/lib/Driver/ToolChains/Darwin.cpp
@@ -576,6 +576,10 @@ static void renderTapirLoweringOptions(const ArgList &Args,
     } else if (Args.hasArg(options::OPT_fcilkplus))
       CmdArgs.push_back("--tapir-target=cilkplus");
   }
+
+  if (const Arg *A = Args.getLastArg(options::OPT_fcilktool_EQ))
+    CmdArgs.push_back(
+        Args.MakeArgString(Twine("--plugin-opt=cilktool=") + A->getValue()));
 }
 
 static void AppendPlatformPrefix(SmallString<128> &Path, const llvm::Triple &T);

--- a/lld/COFF/Config.h
+++ b/lld/COFF/Config.h
@@ -239,6 +239,9 @@ struct Configuration {
   llvm::StringRef opencilkABIBitcodeFile;
   llvm::TapirTargetID tapirTarget = llvm::TapirTargetID::None;
 
+  // Used for Cilk tool.
+  llvm::StringRef cilktool;
+
   // Used for /thinlto-index-only:
   llvm::StringRef thinLTOIndexOnlyArg;
 

--- a/lld/COFF/Driver.cpp
+++ b/lld/COFF/Driver.cpp
@@ -817,6 +817,7 @@ static std::string createResponseFile(const opt::InputArgList &args,
     case OPT_winsysroot:
       break;
     case OPT_call_graph_ordering_file:
+    case OPT_cilktool:
     case OPT_deffile:
     case OPT_manifestinput:
     case OPT_natvis:
@@ -2067,6 +2068,7 @@ void LinkerDriver::linkerMain(ArrayRef<const char *> argsArr) {
       args.getLastArgValue(OPT_opencilk_abi_bitcode);
   config->tapirTarget =
       args::parseTapirTarget(args.getLastArgValue(OPT_tapir_target));
+  config->cilktool = args.getLastArgValue(OPT_cilktool);
 
   if (config->incremental && args.hasArg(OPT_profile)) {
     warn("ignoring '/incremental' due to '/profile' specification");

--- a/lld/COFF/LTO.cpp
+++ b/lld/COFF/LTO.cpp
@@ -86,6 +86,7 @@ lto::Config BitcodeCompiler::createConfig() {
   if (args::validTapirTarget(ctx.config.tapirTarget))
     c.TapirTarget = ctx.config.tapirTarget;
   c.OpenCilkABIBitcodeFile = std::string(ctx.config.opencilkABIBitcodeFile);
+  c.Cilktool = std::string(ctx.config.cilktool);
   c.CSIRProfile = std::string(ctx.config.ltoCSProfileFile);
   c.RunCSIRInstr = ctx.config.ltoCSProfileGenerate;
   c.PGOWarnMismatch = ctx.config.ltoPGOWarnMismatch;

--- a/lld/COFF/Options.td
+++ b/lld/COFF/Options.td
@@ -225,6 +225,7 @@ def help_q : Flag<["/??", "-??", "/?", "-?"], "">, Alias<help>;
 // LLD extensions
 defm auto_import : B_priv<"auto-import">;
 defm runtime_pseudo_reloc : B_priv<"runtime-pseudo-reloc">;
+def cilktool : P<"cilktool", "Name of Cilk tool">;
 def end_lib : F<"end-lib">,
   HelpText<"End group of objects treated as if they were in a library">;
 def exclude_all_symbols : F<"exclude-all-symbols">;

--- a/lld/ELF/Config.h
+++ b/lld/ELF/Config.h
@@ -157,6 +157,7 @@ struct Config {
   llvm::StringMap<uint64_t> sectionStartMap;
   llvm::StringRef bfdname;
   llvm::StringRef chroot;
+  llvm::StringRef cilktool;
   llvm::StringRef dependencyFile;
   llvm::StringRef dwoDir;
   llvm::StringRef dynamicLinker;

--- a/lld/ELF/Driver.cpp
+++ b/lld/ELF/Driver.cpp
@@ -1224,6 +1224,7 @@ static void readConfigs(opt::InputArgList &args) {
   config->checkSections =
       args.hasFlag(OPT_check_sections, OPT_no_check_sections, true);
   config->chroot = args.getLastArgValue(OPT_chroot);
+  config->cilktool = args.getLastArgValue(OPT_cilktool);
   config->compressDebugSections = getCompressionType(
       args.getLastArgValue(OPT_compress_debug_sections, "none"),
       "--compress-debug-sections");

--- a/lld/ELF/DriverUtils.cpp
+++ b/lld/ELF/DriverUtils.cpp
@@ -186,6 +186,7 @@ std::string elf::createResponseFile(const opt::InputArgList &args) {
       os << arg->getSpelling() << quote(rewritePath(arg->getValue())) << "\n";
       break;
     case OPT_call_graph_ordering_file:
+    case OPT_cilktool:
     case OPT_dynamic_list:
     case OPT_export_dynamic_symbol_list:
     case OPT_just_symbols:

--- a/lld/ELF/LTO.cpp
+++ b/lld/ELF/LTO.cpp
@@ -131,6 +131,7 @@ static lto::Config createConfig() {
   if (args::validTapirTarget(config->tapirTarget))
     c.TapirTarget = config->tapirTarget;
   c.OpenCilkABIBitcodeFile = std::string(config->opencilkABIBitcodeFile);
+  c.Cilktool = std::string(config->cilktool);
 
   c.HasWholeProgramVisibility = config->ltoWholeProgramVisibility;
   c.ValidateAllVtablesHaveTypeInfos =

--- a/lld/ELF/Options.td
+++ b/lld/ELF/Options.td
@@ -618,6 +618,7 @@ defm lto_validate_all_vtables_have_type_infos: BB<"lto-validate-all-vtables-have
 defm lto_whole_program_visibility: BB<"lto-whole-program-visibility",
   "Asserts that the LTO link has whole program visibility",
   "Asserts that the LTO link does not have whole program visibility">;
+defm cilktool: Eq<"cilktool", "Name of Cilk tool">;
 def disable_verify: F<"disable-verify">;
 defm mllvm: Eq<"mllvm", "Additional arguments to forward to LLVM's option processing">;
 defm opencilk_abi_bitcode: EEq<"opencilk-abi-bitcode", "Path to OpenCilk ABI bitcode file">;
@@ -683,6 +684,9 @@ def: J<"plugin-opt=cs-profile-path=">,
 def: J<"plugin-opt=obj-path=">,
   Alias<lto_obj_path_eq>,
   HelpText<"Alias for --lto-obj-path=">;
+def: J<"plugin-opt=cilktool=">,
+  Alias<cilktool>,
+  HelpText<"Alias for --cilktool">;
 def: J<"plugin-opt=opencilk-abi-bitcode=">,
   Alias<opencilk_abi_bitcode>,
   HelpText<"Alias for --opencilk-abi-bitcode">;

--- a/lld/MachO/Config.h
+++ b/lld/MachO/Config.h
@@ -237,6 +237,7 @@ struct Configuration {
 
   llvm::TapirTargetID tapirTarget = llvm::TapirTargetID::None;
   llvm::StringRef opencilkABIBitcodeFile;
+  llvm::StringRef cilktool;
 
   llvm::MachO::Architecture arch() const { return platformInfo.target.Arch; }
 

--- a/lld/MachO/Driver.cpp
+++ b/lld/MachO/Driver.cpp
@@ -1682,6 +1682,7 @@ bool link(ArrayRef<const char *> argsArr, llvm::raw_ostream &stdoutOS,
       args::parseTapirTarget(args.getLastArgValue(OPT_tapir_target));
   config->opencilkABIBitcodeFile =
       args.getLastArgValue(OPT_opencilk_abi_bitcode);
+  config->cilktool = args.getLastArgValue(OPT_cilktool);
 
   for (const Arg *arg : args.filtered(OPT_alias)) {
     config->aliasedSymbols.push_back(

--- a/lld/MachO/LTO.cpp
+++ b/lld/MachO/LTO.cpp
@@ -65,6 +65,7 @@ static lto::Config createConfig() {
   if (args::validTapirTarget(config->tapirTarget))
     c.TapirTarget = config->tapirTarget;
   c.OpenCilkABIBitcodeFile = std::string(config->opencilkABIBitcodeFile);
+  c.Cilktool = std::string(config->cilktool);
   if (config->saveTemps)
     checkError(c.addSaveTemps(config->outputFile.str() + ".",
                               /*UseInputModulePath=*/true));

--- a/lld/MachO/Options.td
+++ b/lld/MachO/Options.td
@@ -144,6 +144,9 @@ def tapir_target: Joined<["--"], "tapir-target=">,
 def opencilk_abi_bitcode: Joined<["--"], "opencilk-abi-bitcode=">,
     HelpText<"Path to the OpenCilk ABI bitcode file">,
     Group<grp_lld>;
+def cilktool: Joined<["--"], "cilktool=">,
+    HelpText<"Name of Cilk tool">,
+    Group<grp_lld>;
 
 // This is a complete Options.td compiled from Apple's ld(1) manpage
 // dated 2018-03-07 and cross checked with ld64 source code in repo

--- a/llvm/include/llvm/LTO/Config.h
+++ b/llvm/include/llvm/LTO/Config.h
@@ -104,6 +104,9 @@ struct Config {
   // Path to OpenCilk runtime bitcode file.
   std::string OpenCilkABIBitcodeFile;
 
+  // Name of Cilk tool.
+  std::string Cilktool;
+
   /// If this field is set, the set of passes run in the middle-end optimizer
   /// will be the one specified by the string. Only works with the new pass
   /// manager as the old one doesn't have this ability.

--- a/llvm/lib/LTO/LTOBackend.cpp
+++ b/llvm/lib/LTO/LTOBackend.cpp
@@ -42,6 +42,7 @@
 #include "llvm/Target/TargetMachine.h"
 #include "llvm/TargetParser/SubtargetFeature.h"
 #include "llvm/Transforms/IPO/WholeProgramDevirt.h"
+#include "llvm/Transforms/Instrumentation/ComprehensiveStaticInstrumentation.h"
 #include "llvm/Transforms/Scalar/LoopPassManager.h"
 #include "llvm/Transforms/Utils/FunctionImportUtils.h"
 #include "llvm/Transforms/Utils/SplitModule.h"
@@ -239,6 +240,29 @@ static bool hasTapirTarget(const Config &Conf) {
          (Conf.TapirTarget != TapirTargetID::None);
 }
 
+enum class CilktoolID { Cilkscale, CilkscaleInstructions, Unknown };
+
+static CilktoolID parseCilktool(StringRef ToolName) {
+  return llvm::StringSwitch<CilktoolID>(ToolName)
+      .Case("cilkscale", CilktoolID::Cilkscale)
+      .Case("cilkscale-instructions", CilktoolID::CilkscaleInstructions)
+      .Default(CilktoolID::Unknown);
+}
+
+static CSIOptions getCSIOptionsForCilkscale(bool InstrumentBasicBlocks) {
+  CSIOptions Options;
+  // Disable CSI hooks that Cilkscale doesn't need.
+  Options.InstrumentBasicBlocks = InstrumentBasicBlocks;
+  Options.InstrumentLoops = false;
+  Options.InstrumentMemoryAccesses = false;
+  Options.InstrumentCalls = false;
+  Options.InstrumentAtomics = false;
+  Options.InstrumentMemIntrinsics = false;
+  Options.InstrumentAllocas = false;
+  Options.InstrumentAllocFns = false;
+  return Options;
+}
+
 static void runNewPMPasses(const Config &Conf, Module &Mod, TargetMachine *TM,
                            unsigned OptLevel, bool IsThinLTO,
                            ModuleSummaryIndex *ExportSummary,
@@ -326,6 +350,32 @@ static void runNewPMPasses(const Config &Conf, Module &Mod, TargetMachine *TM,
     break;
   case 3:
     OL = OptimizationLevel::O3;
+    break;
+  }
+
+  // Handle tools with late CSI instrumentation passes.
+  switch (parseCilktool(Conf.Cilktool)) {
+  case CilktoolID::Cilkscale: {
+    PB.registerTapirLoopEndEPCallback(
+        [&PB](ModulePassManager &MPM, OptimizationLevel Level) {
+          MPM.addPass(CSISetupPass(getCSIOptionsForCilkscale(false)));
+          MPM.addPass(ComprehensiveStaticInstrumentationPass(
+              getCSIOptionsForCilkscale(false)));
+          MPM.addPass(PB.buildPostCilkInstrumentationPipeline(Level));
+        });
+    break;
+  }
+  case CilktoolID::CilkscaleInstructions: {
+    PB.registerTapirLoopEndEPCallback(
+        [&PB](ModulePassManager &MPM, OptimizationLevel Level) {
+          MPM.addPass(CSISetupPass(getCSIOptionsForCilkscale(true)));
+          MPM.addPass(ComprehensiveStaticInstrumentationPass(
+              getCSIOptionsForCilkscale(true)));
+          MPM.addPass(PB.buildPostCilkInstrumentationPipeline(Level));
+        });
+    break;
+  }
+  case CilktoolID::Unknown:
     break;
   }
 

--- a/llvm/lib/Passes/PassBuilderPipelines.cpp
+++ b/llvm/lib/Passes/PassBuilderPipelines.cpp
@@ -1777,7 +1777,7 @@ PassBuilder::buildPerModuleDefaultPipeline(OptimizationLevel Level,
     MPM.addPass(buildTapirLoweringPipeline(
         Level, LTOPreLink ? ThinOrFullLTOPhase::FullLTOPreLink
                           : ThinOrFullLTOPhase::None));
-  else
+  else if (!LTOPreLink)
     invokeTapirLoopEndEPCallbacks(MPM, Level);
 
   return MPM;
@@ -2359,7 +2359,7 @@ ModulePassManager PassBuilder::buildO0DefaultPipeline(OptimizationLevel Level,
     MPM.addPass(buildTapirLoweringPipeline(
         Level, LTOPreLink ? ThinOrFullLTOPhase::FullLTOPreLink
                           : ThinOrFullLTOPhase::None));
-  else
+  else if (!LTOPreLink)
     invokeTapirLoopEndEPCallbacks(MPM, Level);
 
   invokeOptimizerLastEPCallbacks(MPM, Level);

--- a/llvm/lib/Transforms/Instrumentation/CilkSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/CilkSanitizer.cpp
@@ -386,33 +386,6 @@ struct CilkSanitizerImpl : public CSIImpl {
                    LoopInfo *LI = nullptr);
   bool setupFunction(Function &F, bool NeedToSetupCalls);
 
-  FunctionCallee getHookFunction(StringRef Name, FunctionType *FnTy,
-                                 AttributeList AL) {
-    FunctionCallee Callee = M.getOrInsertFunction(Name, FnTy, AL);
-    if (Function *Fn = dyn_cast<Function>(Callee.getCallee())) {
-      Fn->setOnlyAccessesInaccessibleMemOrArgMem();
-      Fn->setDoesNotThrow();
-    }
-    return Callee;
-  }
-  template <typename... ArgsTy>
-  FunctionCallee getHookFunction(StringRef Name, AttributeList AL, Type *RetTy,
-                                 ArgsTy... Args) {
-    FunctionCallee Callee = M.getOrInsertFunction(Name, AL, RetTy, Args...);
-    if (Function *Fn = dyn_cast<Function>(Callee.getCallee())) {
-      MemoryEffects ME = MemoryEffects::argMemOnly(ModRefInfo::Ref) |
-                         MemoryEffects::inaccessibleMemOnly(ModRefInfo::ModRef);
-      Fn->setMemoryEffects(ME);
-      Fn->setDoesNotThrow();
-    }
-    return Callee;
-  }
-  template <typename... ArgsTy>
-  FunctionCallee getHookFunction(StringRef Name, Type *RetTy,
-                                 ArgsTy... Args) {
-    return getHookFunction(Name, AttributeList{}, RetTy, Args...);
-  }
-
   // Methods for handling FED tables
   void initializeFEDTables() {}
   void collectUnitFEDTables() {}

--- a/llvm/tools/gold/gold-plugin.cpp
+++ b/llvm/tools/gold/gold-plugin.cpp
@@ -224,6 +224,7 @@ namespace options {
   // Tapir lowering options.
   static TapirTargetID tapir_target = TapirTargetID::Last_TapirTargetID;
   static std::string opencilk_abi_bitcode_file;
+  static std::string cilktool;
 
   static TapirTargetID parseTapirTarget(StringRef tapirTarget) {
     return llvm::StringSwitch<TapirTargetID>(tapirTarget)
@@ -330,6 +331,8 @@ namespace options {
       tapir_target = parseTapirTarget(std::string(opt));
     } else if (opt.consume_front("opencilk-abi-bitcode=")) {
       opencilk_abi_bitcode_file = std::string(opt);
+    } else if (opt.consume_front("cilktool=")) {
+      cilktool = std::string(opt);
     } else {
       // Save this option to pass to the code generator.
       // ParseCommandLineOptions() expects argv[0] to be program name. Lazily
@@ -978,6 +981,8 @@ static std::unique_ptr<LTO> createLTO(IndexWriteCallback OnIndexWrite,
     Conf.TapirTarget = options::tapir_target;
     Conf.OpenCilkABIBitcodeFile = options::opencilk_abi_bitcode_file;
   }
+
+  Conf.Cilktool = options::cilktool;
 
   return std::make_unique<LTO>(std::move(Conf), Backend,
                                 options::ParallelCodeGenParallelismLevel);


### PR DESCRIPTION
This PR fixes the `-fcilktool=cilkscale` functionality when used with the LLD linker when using LTO.  These changes ensure that Cilkscale's instrumentation during the post-link phase of LTO, around when Tapir instructions in the IR are lowered to a parallel runtime ABI.

This PR also fixes some minor issues with Cilkscale's instrumentation, removes some now-unused linker flags, and updates the `python-setup` GitHub action to resolve recent CI failures.