### PR TITLE
Support for Android

### DIFF
--- a/.github/workflows/llvm-project-tests.yml
+++ b/.github/workflows/llvm-project-tests.yml
@@ -62,6 +62,7 @@ jobs:
       image: ${{(startsWith(matrix.os, 'ubuntu') && 'ghcr.io/llvm/ci-ubuntu-22.04:latest') || null}}
       volumes:
         - /mnt/:/mnt/
+      options: --user root
     strategy:
       fail-fast: false
       matrix:

--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -1830,7 +1830,10 @@ void ToolChain::AddTapirRuntimeLibArgs(const ArgList &Args,
     addOpenCilkRuntimeRunPath(*this, Args, CmdArgs, Triple);
     if (OnlyStaticOpenCilk) {
       CmdArgs.push_back("-Bdynamic");
-      CmdArgs.push_back("-lpthread");
+      if (!getTriple().isAndroid()) {
+        // There is no libpthread on Android
+        CmdArgs.push_back("-lpthread");
+      }
     }
     break;
   }


### PR DESCRIPTION
This PR adds a small bugfix for linking the static OpenCilk runtime on Android.