### PR TITLE
Tests for cilk_for

### DIFF
--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -4002,7 +4002,7 @@ StmtResult Sema::BuildCilkForRangeStmt(CXXForRangeStmt *ForRange) {
   }
   ExprResult LimitExpr = ActOnBinOp(S, ForRange->getColonLoc(), tok::minus,
                                     EndRef.get(), BeginRef.get());
-  if (LimitExpr.isInvalid()) {
+  if (LimitExpr.isInvalid() || !LimitExpr.get()->getType()->isIntegerType()) {
     // CilkForRange currently only supports random access iterators.
     Diag(ForRange->getForLoc(), diag::err_cilk_for_range_end_minus_begin);
     return StmtError();

--- a/clang/test/Cilk/cilkfor-init.cpp
+++ b/clang/test/Cilk/cilkfor-init.cpp
@@ -1,0 +1,26 @@
+// RUN: %clang_cc1 %s -std=c++20 -triple x86_64-unknown-linux-gnu -fopencilk -disable-llvm-passes -verify -emit-llvm -o - | FileCheck %s
+// Make sure the C++20 init-statement works with cilk_for.
+
+extern bool *getarray(unsigned long size);
+
+extern unsigned int global[1000];
+
+// CHECK-LABEL: _Z4scanv
+void scan() {
+
+  // This syntax is new in C++20.
+  _Cilk_for (bool *array = getarray(666); unsigned int i : global) {
+    // expected-warning@-1{{experimental}}
+    // CHECK: %[[ARRAY:.+]] = call noundef ptr @_Z8getarraym(i64 noundef 666)
+    // CHECK-NEXT: store ptr %[[ARRAY]], ptr %array, align 8
+    // CHECK: pfor.body:
+    // CHECK: %[[ARRAY2:.+]] = load ptr, ptr %array
+    // CHECK: %[[ELEMENT:.+]] = getelementptr inbounds i8, ptr %[[ARRAY2]]
+    // CHECK: store i8 1, ptr %[[ELEMENT]]
+    // CHECK-NEXT: br label
+    array[i] = true;
+  }
+
+  // CHECK: ret void
+
+}

--- a/clang/test/Cilk/cilkfor-range-error.cpp
+++ b/clang/test/Cilk/cilkfor-range-error.cpp
@@ -1,0 +1,36 @@
+// RUN: %clang_cc1 %s -std=c++20 -triple x86_64-unknown-linux-gnu -fopencilk -fsyntax-only -verify
+
+template<class Datum>
+struct Iterator {
+  void *data;
+  Iterator operator+(long);
+  bool operator!=(const Iterator &) const;
+  Iterator &operator++();
+  Datum &operator*();
+  Datum *operator->();
+};
+
+struct S {
+  int data;
+  struct I : public Iterator<S> {
+    float operator-(const I &) const;
+  };
+  I begin(), end();
+};
+
+struct T {
+  int data;
+  struct I : public Iterator<T> {
+    long operator-(const I &) const;
+  };
+  I begin(), end();
+};
+
+void sum(S &s, T &t) {
+  _Cilk_for (auto i : s) { // expected-warning{{experimental}}
+    // expected-error@-1{{cannot determine length}}
+  }
+  _Cilk_for (auto i : _Cilk_spawn t) { // expected-warning{{experimental}}
+    // expected-error@-1{{'cilk_spawn' not allowed in this scope}}
+  }
+}


### PR DESCRIPTION
Give a better error if an iterator type's `operator-` returns a non-integral type.

Test that the C++20 init-statement of a range for works with `cilk_for`.

Test behavior of `spawn` within the control structure of `cilk_for`.