### PR TITLE
Add new keyword spellings with cilk_ instead of _Cilk_

### DIFF
--- a/clang/include/clang/Basic/TokenKinds.def
+++ b/clang/include/clang/Basic/TokenKinds.def
@@ -339,6 +339,7 @@ KEYWORD(_Bool                       , KEYNOCXX)
 KEYWORD(_Complex                    , KEYALL)
 KEYWORD(_Generic                    , KEYALL)
 KEYWORD(_Hyperobject                , KEYALL)
+KEYWORD(cilk_reducer                , KEYOPENCILK)
 // Note, C2y removed support for _Imaginary; we retain it as a keyword because
 // 1) it's a reserved identifier, so we're allowed to steal it, 2) there's no
 // good way to specify a keyword in earlier but not later language modes within
@@ -494,6 +495,10 @@ KEYWORD(_Cilk_spawn                 , KEYALL)
 KEYWORD(_Cilk_sync                  , KEYALL)
 KEYWORD(_Cilk_for                   , KEYALL)
 KEYWORD(_Cilk_scope                 , KEYALL)
+KEYWORD(cilk_spawn                  , KEYOPENCILK)
+KEYWORD(cilk_sync                   , KEYOPENCILK)
+KEYWORD(cilk_for                    , KEYOPENCILK)
+KEYWORD(cilk_scope                  , KEYOPENCILK)
 
 // MSVC12.0 / VS2013 Type Traits
 TYPE_TRAIT_1(__is_destructible, IsDestructible, KEYALL)

--- a/clang/lib/Basic/IdentifierTable.cpp
+++ b/clang/lib/Basic/IdentifierTable.cpp
@@ -109,7 +109,8 @@ namespace {
     KEYCUDA       = 0x1000000,
     KEYHLSL       = 0x2000000,
     KEYFIXEDPOINT = 0x4000000,
-    KEYMAX        = KEYFIXEDPOINT, // The maximum key
+    KEYOPENCILK   = 0x8000000,
+    KEYMAX        = KEYOPENCILK, // The maximum key
     KEYALLCXX = KEYCXX | KEYCXX11 | KEYCXX20,
     KEYALL = (KEYMAX | (KEYMAX-1)) & ~KEYNOMS18 &
              ~KEYNOOPENCL // KEYNOMS18 and KEYNOOPENCL are used to exclude.
@@ -213,6 +214,9 @@ static KeywordStatus getKeywordStatusHelper(const LangOptions &LangOpts,
     return KS_Unknown;
   case KEYFIXEDPOINT:
     return LangOpts.FixedPoint ? KS_Enabled : KS_Disabled;
+  case KEYOPENCILK:
+    return LangOpts.getCilk() == LangOptions::Cilk_opencilk ?
+      KS_Enabled : KS_Disabled;
   default:
     llvm_unreachable("Unknown KeywordStatus flag");
   }

--- a/clang/lib/Parse/ParseCilk.cpp
+++ b/clang/lib/Parse/ParseCilk.cpp
@@ -19,7 +19,8 @@ using namespace clang;
 ///       cilk_sync-statement:
 ///         '_Cilk_sync' ';'
 StmtResult Parser::ParseCilkSyncStatement() {
-  assert(Tok.is(tok::kw__Cilk_sync) && "Not a _Cilk_sync stmt!");
+  assert(Tok.isOneOf(tok::kw__Cilk_sync, tok::kw_cilk_sync) &&
+         "Not a cilk_sync stmt!");
   return Actions.ActOnCilkSyncStmt(ConsumeToken());
 }
 
@@ -27,7 +28,8 @@ StmtResult Parser::ParseCilkSyncStatement() {
 ///       cilk_spawn-statement:
 ///         '_Cilk_spawn' statement
 StmtResult Parser::ParseCilkSpawnStatement() {
-  assert(Tok.is(tok::kw__Cilk_spawn) && "Not a _Cilk_spawn stmt!");
+  assert(Tok.isOneOf(tok::kw__Cilk_spawn, tok::kw_cilk_spawn) &&
+         "Not a cilk_spawn stmt!");
   SourceLocation SpawnLoc = ConsumeToken();  // eat the '_Cilk_spawn'.
 
   unsigned ScopeFlags = Scope::BlockScope | Scope::FnScope | Scope::DeclScope;
@@ -149,9 +151,9 @@ struct MisleadingIndentationChecker {
 
 /// ParseCilkForStatement
 ///       cilk_for-statement:
-///         '_Cilk_for' '(' expr ';' expr ';' expr ')' statement
-///         '_Cilk_for' '(' declaration expr ';' expr ';' expr ')' statement
-/// [C++0x] '_Cilk_for'
+///         'cilk_for' '(' expr ';' expr ';' expr ')' statement
+///         'cilk_for' '(' declaration expr ';' expr ';' expr ')' statement
+/// [C++0x] 'cilk_for'
 ///             '(' for-range-declaration ':' for-range-initializer ')'
 ///             statement
 ///
@@ -161,15 +163,17 @@ struct MisleadingIndentationChecker {
 /// [C++0x]   expression
 /// [C++0x]   braced-init-list
 StmtResult Parser::ParseCilkForStatement(SourceLocation *TrailingElseLoc) {
-  assert(Tok.is(tok::kw__Cilk_for) && "Not a _Cilk_for stmt!");
-  SourceLocation ForLoc = ConsumeToken();  // eat the '_Cilk_for'.
+  StringRef Spelling = Tok.getName();
+  assert(Tok.isOneOf(tok::kw__Cilk_for, tok::kw_cilk_for) && 
+         "Not a cilk_for stmt!");
+  SourceLocation ForLoc = ConsumeToken();  // eat the 'cilk_for'.
 
   // SourceLocation CoawaitLoc;
   // if (Tok.is(tok::kw_co_await))
   //   CoawaitLoc = ConsumeToken();
 
   if (Tok.isNot(tok::l_paren)) {
-    Diag(Tok, diag::err_expected_lparen_after) << "_Cilk_for";
+    Diag(Tok, diag::err_expected_lparen_after) << Spelling;
     SkipUntil(tok::semi);
     return StmtError();
   }
@@ -523,7 +527,8 @@ StmtResult Parser::ParseCilkForStatement(SourceLocation *TrailingElseLoc) {
 ///       cilk_scope-statement:
 ///         '_Cilk_scope' statement
 StmtResult Parser::ParseCilkScopeStatement() {
-  assert(Tok.is(tok::kw__Cilk_scope) && "Not a _Cilk_scope stmt!");
+  assert(Tok.isOneOf(tok::kw__Cilk_scope, tok::kw_cilk_scope) &&
+         "Not a cilk_scope stmt!");
   SourceLocation ScopeLoc = ConsumeToken();  // eat the '_Cilk_scope'.
 
   // TODO: Decide whether to allow break statements in _Cilk_scopes.

--- a/clang/lib/Parse/ParseDecl.cpp
+++ b/clang/lib/Parse/ParseDecl.cpp
@@ -5776,6 +5776,7 @@ bool Parser::isKnownToBeTypeSpecifier(const Token &Tok) const {
   case tok::kw_signed:
   case tok::kw_unsigned:
   case tok::kw__Hyperobject:
+  case tok::kw_cilk_reducer:
   case tok::kw__Complex:
   case tok::kw__Imaginary:
   case tok::kw_void:
@@ -5861,6 +5862,7 @@ bool Parser::isTypeSpecifierQualifier() {
   case tok::kw_signed:
   case tok::kw_unsigned:
   case tok::kw__Hyperobject:
+  case tok::kw_cilk_reducer:
   case tok::kw__Complex:
   case tok::kw__Imaginary:
   case tok::kw_void:
@@ -6083,6 +6085,7 @@ bool Parser::isDeclarationSpecifier(
   case tok::kw_signed:
   case tok::kw_unsigned:
   case tok::kw__Hyperobject:
+  case tok::kw_cilk_reducer:
   case tok::kw__Complex:
   case tok::kw__Imaginary:
   case tok::kw_void:
@@ -6586,7 +6589,7 @@ static bool isPtrOperatorToken(tok::TokenKind Kind, const LangOptions &Lang,
       Lang.getOpenCLCompatibleVersion() >= 200)
     return true;
 
-  if (Kind == tok::kw__Hyperobject)
+  if (Kind == tok::kw__Hyperobject || Kind == tok::kw_cilk_reducer)
     return true;
 
   if (!Lang.CPlusPlus)
@@ -6725,7 +6728,7 @@ void Parser::ParseDeclaratorInternal(Declarator &D,
   SourceLocation Loc = ConsumeToken();  // Eat the *, ^, & or &&.
   D.SetRangeEnd(Loc);
 
-  if (Kind == tok::kw__Hyperobject) {
+  if (Kind == tok::kw__Hyperobject || Kind == tok::kw_cilk_reducer) {
     // Is a hyperobject.
     DeclSpec DS(AttrFactory);
 

--- a/clang/lib/Parse/ParseExpr.cpp
+++ b/clang/lib/Parse/ParseExpr.cpp
@@ -1840,7 +1840,8 @@ ExprResult Parser::ParseCastExpression(CastParseKind ParseKind,
 
   // postfix-expression: [CP]
   //   _Cilk_spawn[opt] postfix-expression '(' argument-expression-list[opt] ')'
-  case tok::kw__Cilk_spawn: {
+  case tok::kw__Cilk_spawn:
+  case tok::kw_cilk_spawn: {
     SourceLocation SpawnLoc = ConsumeToken();
     // if (!getLangOpts().Cilk) {
     //   Diag(SpawnLoc, diag::err_cilkplus_disable);

--- a/clang/lib/Parse/ParseObjc.cpp
+++ b/clang/lib/Parse/ParseObjc.cpp
@@ -1162,6 +1162,7 @@ IdentifierInfo *Parser::ParseObjCSelectorPiece(SourceLocation &SelectorLoc) {
   case tok::kw___alignof:
   case tok::kw___auto_type:
   case tok::kw__Hyperobject:
+  case tok::kw_cilk_reducer:
     IdentifierInfo *II = Tok.getIdentifierInfo();
     SelectorLoc = ConsumeToken();
     return II;

--- a/clang/lib/Parse/ParseStmt.cpp
+++ b/clang/lib/Parse/ParseStmt.cpp
@@ -488,7 +488,8 @@ Retry:
     ProhibitAttributes(GNUAttrs);
     return HandlePragmaCaptured();
 
-  case tok::kw__Cilk_spawn:              // [CP] _Cilk_spawn statement
+  case tok::kw__Cilk_spawn:              // [CP] cilk_spawn statement
+  case tok::kw_cilk_spawn:
     // if (!getLangOpts().Cilk) {
     //   Diag(Tok, diag::err_cilkplus_disable);
     //   SkipUntil(tok::semi);
@@ -497,16 +498,18 @@ Retry:
     return ParseCilkSpawnStatement();
 
   case tok::kw__Cilk_sync:               // [CP] _Cilk_sync statement
+  case tok::kw_cilk_sync:
     // if (!getLangOpts().Cilk) {
     //   Diag(Tok, diag::err_cilkplus_disable);
     //   SkipUntil(tok::semi);
     //   return StmtError();
     // }
     Res = ParseCilkSyncStatement();
-    SemiError = "_Cilk_sync";
+    SemiError = "cilk_sync";
     break;
 
   case tok::kw__Cilk_for:
+  case tok::kw_cilk_for:
     // if (!getLangOpts().Cilk) {
     //   Diag(Tok, diag::err_cilkplus_disable);
     //   SkipUntil(tok::semi);
@@ -515,6 +518,7 @@ Retry:
     return ParseCilkForStatement(TrailingElseLoc);
 
   case tok::kw__Cilk_scope:              // [CP] _Cilk_scope statement
+  case tok::kw_cilk_scope:
     // if (!getLangOpts().Cilk) {
     //   Diag(Tok, diag::err_cilkplus_disable);
     //   SkipUntil(tok::semi);

--- a/clang/lib/Parse/ParseTentative.cpp
+++ b/clang/lib/Parse/ParseTentative.cpp
@@ -1557,6 +1557,7 @@ Parser::isCXXDeclarationSpecifier(ImplicitTypenameContext AllowImplicitTypename,
 
     // Cilk
   case tok::kw__Hyperobject:
+  case tok::kw_cilk_reducer:
 
     // GNU
   case tok::kw_restrict:

--- a/clang/test/Cilk/cilk-exceptions.cpp
+++ b/clang/test/Cilk/cilk-exceptions.cpp
@@ -65,7 +65,7 @@ void serial_tryblock(int n) {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// _Cilk_for code snippets
+/// cilk_for code snippets
 ////////////////////////////////////////////////////////////////////////////////
 
 // CHECK-LABEL: @_Z20parallelfor_noexcepti(
@@ -73,7 +73,7 @@ void serial_tryblock(int n) {
 // CHECK-NOT: landingpad
 // CHECK-NOT: resume
 void parallelfor_noexcept(int n) {
-  _Cilk_for (int i = 0; i < n; ++i)
+  cilk_for (int i = 0; i < n; ++i)
     quuz(i);
 }
 
@@ -99,7 +99,7 @@ void parallelfor_noexcept(int n) {
 // CHECK: [[DRUNREACH]]:
 // CHECK-NEXT: unreachable
 void parallelfor_except(int n) {
-  _Cilk_for (int i = 0; i < n; ++i)
+  cilk_for (int i = 0; i < n; ++i)
     bar(new Foo());
 }
 
@@ -110,7 +110,7 @@ void parallelfor_tryblock(int n) {
   try
     {
       // CHECK-NOT: detach within %[[SYNCREG1]], label %{{.+}}, label %{{.+}} unwind
-      _Cilk_for (int i = 0; i < n; ++i)
+      cilk_for (int i = 0; i < n; ++i)
         quuz(i);
       // CHECK: invoke void @llvm.sync.unwind(token %[[SYNCREG1]])
       // CHECK-NEXT: to label %{{.+}} unwind label %[[CATCH:.+]]
@@ -145,7 +145,7 @@ void parallelfor_tryblock(int n) {
       // CHECK: invoke void @llvm.detached.rethrow
       // CHECK: (token %[[SYNCREG2]], [[LPADTYPE]] {{.+}})
       // CHECK-NEXT: to label {{.+}} unwind label %[[CATCH]]
-      _Cilk_for (int i = 0; i < n; ++i)
+      cilk_for (int i = 0; i < n; ++i)
         bar(new Foo());
     }
   catch (int e)
@@ -182,7 +182,7 @@ void parallelfor_tryblock_inline(int n) {
       // CHECK: landingpad [[LPADTYPE]]
       // CHECK-NEXT: catch ptr @_ZTIi
       // CHECK-NEXT: catch ptr null
-      _Cilk_for (int i = 0; i < n; ++i)
+      cilk_for (int i = 0; i < n; ++i)
         foo(new Foo());
     }
   catch (int e)
@@ -196,14 +196,14 @@ void parallelfor_tryblock_inline(int n) {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// _Cilk_spawn code snippets
+/// cilk_spawn code snippets
 ////////////////////////////////////////////////////////////////////////////////
 
 // CHECK-LABEL: @_Z14spawn_noexcepti(
 // CHECK-NOT: landingpad
 // CHECK-NOT: detached.rethrow
 void spawn_noexcept(int n) {
-  _Cilk_spawn quuz(n);
+  cilk_spawn quuz(n);
   quuz(n);
 }
 
@@ -237,7 +237,7 @@ void spawn_tf_except(int n) {
   // CHECK-NOT: load ptr, ptr %[[EXN]],
   // CHECK-NOT: load i32, ptr %[[EHSELECTOR]],
   // CHECK: resume [[LPADTYPE]]
-  _Cilk_spawn bar(new Foo());
+  cilk_spawn bar(new Foo());
   quuz(n);
 }
 
@@ -292,7 +292,7 @@ void spawn_stmt_destructor(int n) {
   // CHECK-NOT: load ptr, ptr %[[EXNTF]],
   // CHECK-NOT: load i32, ptr %[[EHSELECTORTF]],
   // CHECK: resume [[LPADTYPE]]
-  _Cilk_spawn baz(Foo());
+  cilk_spawn baz(Foo());
   quuz(n);
 }
 
@@ -348,7 +348,7 @@ void spawn_decl_destructor(int n) {
   // CHECK-NOT: load ptr, ptr %[[EXNTF]],
   // CHECK-NOT: load i32, ptr %[[EHSELECTORTF]],
   // CHECK: resume [[LPADTYPE]]
-  int result = _Cilk_spawn baz(Foo());
+  int result = cilk_spawn baz(Foo());
   quuz(n);
 }
 
@@ -414,7 +414,7 @@ void spawn_block_destructor(int n) {
   // CHECK: resume [[LPADTYPE]]
   {
     auto f = Foo();
-    int result = _Cilk_spawn baz(f);
+    int result = cilk_spawn baz(f);
     quuz(n);
   }
 }
@@ -444,7 +444,7 @@ void spawn_throw_inline(int n) {
   // CHECK: invoke void @llvm.taskframe.resume
   // CHECK: (token %[[TASKFRAME]], [[LPADTYPE]] {{.+}})
   // CHECK-NEXT: to label {{.+}} unwind label {{.+}}
-  _Cilk_spawn foo(new Foo());
+  cilk_spawn foo(new Foo());
   quuz(n);
 }
 
@@ -460,7 +460,7 @@ void spawn_tryblock(int n) {
       // CHECK-NEXT: call void @llvm.taskframe.use(token %[[TASKFRAME]])
       // CHECK-NEXT: call {{.*}}i32 @_Z4quuzi(
       // CHECK-NEXT: reattach within %[[SYNCREG]], label %[[CONTINUE1]]
-      _Cilk_spawn quuz(n);
+      cilk_spawn quuz(n);
       // CHECK: %[[TASKFRAME2:.+]] = call token @llvm.taskframe.create()
       // CHECK: detach within %[[SYNCREG]], label %[[DETACHED2:.+]], label %[[CONTINUE2:.+]] unwind label %[[DUNWIND:.+]]
       // CHECK: [[DETACHED2]]:
@@ -469,21 +469,21 @@ void spawn_tryblock(int n) {
       // CHECK-NEXT: to label %[[INVOKECONT1:.+]] unwind label %[[TASKLPAD:.+]]
       // CHECK: [[INVOKECONT1]]:
       // CHECK-NEXT: reattach within %[[SYNCREG]], label %[[CONTINUE2]]
-      _Cilk_spawn bar(new Foo());
+      cilk_spawn bar(new Foo());
       // CHECK: %[[TASKFRAME3:.+]] = call token @llvm.taskframe.create()
       // CHECK: detach within %[[SYNCREG]], label %[[DETACHED3:.+]], label %[[CONTINUE3:.+]]
       // CHECK: [[DETACHED3]]:
       // CHECK-NEXT: call void @llvm.taskframe.use(token %[[TASKFRAME3]])
       // CHECK-NEXT: call {{.*}}i32 @_Z4quuzi(
       // CHECK-NEXT: reattach within %[[SYNCREG]], label %[[CONTINUE3]]
-      _Cilk_spawn quuz(n);
+      cilk_spawn quuz(n);
       // CHECK: [[CONTINUE3]]:
       // CHECK: invoke {{.*}}i32 @_Z3barP3Foo(
       // CHECK-NEXT: to label %[[INVOKECONT2:.+]] unwind label %[[CONT3UNWIND:.+]]
       bar(new Foo());
       // CHECK: [[INVOKECONT2]]:
       // CHECK-NEXT: sync within %[[SYNCREG]]
-      _Cilk_sync;
+      cilk_sync;
     }
   // CHECK: [[DUNWIND]]:
   // CHECK: landingpad [[LPADTYPE]]

--- a/clang/test/Cilk/hyper-address.c
+++ b/clang/test/Cilk/hyper-address.c
@@ -10,12 +10,12 @@
 void identity(void * value);
 void reduce(void* left, void* right);
 extern void consume_view(long *);
-extern void consume_hyper(long _Hyperobject *);
+extern void consume_hyper(long cilk_reducer *);
 // CHECK-LABEL: assorted_addresses
 void assorted_addresses()
 {
   // CHECK: call void @llvm.reducer.register
-  long _Hyperobject(identity, reduce) sum = 0;
+  long cilk_reducer(identity, reduce) sum = 0;
   // CHECK-NOT: llvm.hyper.lookup
   // CHECK: call void @[[FN1:.*consume_hyper]]
   consume_hyper(__builtin_addressof(sum));

--- a/clang/test/Cilk/hyper-assign.c
+++ b/clang/test/Cilk/hyper-assign.c
@@ -2,7 +2,7 @@
 // RUN: %clang_cc1 %s -x c++ -fopencilk -verify -emit-llvm -disable-llvm-passes -o - | FileCheck %s
 // expected-no-diagnostics
 
-extern long _Hyperobject x, _Hyperobject y;
+extern long _Hyperobject x, cilk_reducer y; // use both spellings of keyword
 
 long chain_assign()
 {

--- a/clang/test/Cilk/keywords.c
+++ b/clang/test/Cilk/keywords.c
@@ -1,0 +1,16 @@
+// RUN: %clang_cc1 %s -fopencilk -fsyntax-only -verify
+// RUN: %clang_cc1 %s -fsyntax-only -verify=nokeyword
+// nokeyword-no-diagnostics
+int cilk_spawn;
+// expected-error@-1{{expected identifier}}
+int cilk_sync = 1;
+// expected-error@-1{{expected identifier}}
+int cilk_scope = 2;
+// expected-error@-1{{expected identifier}}
+int cilk_for(int x)
+// expected-error@-1{{expected identifier}}
+{
+  return cilk_spawn + cilk_sync + cilk_scope;
+}
+int cilk_reducer = 3;
+// expected-error@-1{{expected identifier}}

--- a/clang/test/Cilk/looptest.cpp
+++ b/clang/test/Cilk/looptest.cpp
@@ -1,28 +1,28 @@
-// RUN: %clang_cc1 -std=c++1z -verify %s
+// RUN: %clang_cc1 -std=c++1z -fopencilk -verify %s
 
 int foo(int n);
 
 int Cilk_for_tests(int n) {
   /* int n = 10; */
-  /* _Cilk_for(int i = 0; i < n; i += 2); */
-  /* _Cilk_for(int j = 0, __begin = 0, __end = n/2; __begin < __end; j += 2, __begin++); */
-  _Cilk_for (int i = 0; i < n; ++i); // expected-warning {{'cilk_for' loop has empty body}}
-  _Cilk_for (int i = 0, __end = n; i < __end; ++i); // expected-warning {{'cilk_for' loop has empty body}}
+  /* cilk_for(int i = 0; i < n; i += 2); */
+  /* cilk_for(int j = 0, __begin = 0, __end = n/2; __begin < __end; j += 2, __begin++); */
+  cilk_for (int i = 0; i < n; ++i); // expected-warning {{'cilk_for' loop has empty body}}
+  cilk_for (int i = 0, __end = n; i < __end; ++i); // expected-warning {{'cilk_for' loop has empty body}}
   unsigned long long m = 10;
-  _Cilk_for (int i = 0; i < m; ++i); // expected-warning {{'cilk_for' loop has empty body}}
-  _Cilk_for (int i = 0, __end = m; i < __end; ++i); // expected-warning {{'cilk_for' loop has empty body}}
+  cilk_for (int i = 0; i < m; ++i); // expected-warning {{'cilk_for' loop has empty body}}
+  cilk_for (int i = 0, __end = m; i < __end; ++i); // expected-warning {{'cilk_for' loop has empty body}}
 
   // Check for return statements, which cannot appear anywhere in the body of a
-  // _Cilk_for loop.
-  _Cilk_for (int i = 0; i < n; ++i) return 7; // expected-error{{cannot return}}
-  _Cilk_for (int i = 0; i < n; ++i)
+  // cilk_for loop.
+  cilk_for (int i = 0; i < n; ++i) return 7; // expected-error{{cannot return}}
+  cilk_for (int i = 0; i < n; ++i)
     for (int j = 1; j < i; ++j)
       return 7; // expected-error{{cannot return}}
 
   // Check for illegal break statements, which cannot bind to the scope of a
-  // _Cilk_for loop, but can bind to loops nested within.
-  _Cilk_for (int i = 0; i < n; ++i) break; // expected-error{{cannot break}}
-  _Cilk_for (int i = 0; i < n; ++i)
+  // cilk_for loop, but can bind to loops nested within.
+  cilk_for (int i = 0; i < n; ++i) break; // expected-error{{cannot break}}
+  cilk_for (int i = 0; i < n; ++i)
     for (int j = 1; j < i; ++j)
       break;
   return 0;
@@ -30,20 +30,20 @@ int Cilk_for_tests(int n) {
 
 int pragma_tests(int n) {
 #pragma clang loop unroll_count(4)
-  _Cilk_for (int i = 0; i < n; ++i)
+  cilk_for (int i = 0; i < n; ++i)
     foo(i);
 
 #pragma cilk grainsize(4)
-  _Cilk_for (int i = 0; i < n; ++i)
+  cilk_for (int i = 0; i < n; ++i)
     foo(i);
 
 #pragma cilk grainsize 4
-  _Cilk_for (int i = 0; i < n; ++i)
+  cilk_for (int i = 0; i < n; ++i)
     foo(i);
 
 #pragma cilk grainsize = 4 \
 // expected-warning{{'#pragma cilk grainsize' no longer requires '='}}
-  _Cilk_for (int i = 0; i < n; ++i)
+  cilk_for (int i = 0; i < n; ++i)
     foo(i);
 
   return 0;
@@ -51,7 +51,7 @@ int pragma_tests(int n) {
 
 int scope_tests(int n) {
   int A[5];
-  _Cilk_for(int i = 0; i < n; ++i) {
+  cilk_for(int i = 0; i < n; ++i) {
     int A[5];
     A[i%5] = i;
   }


### PR DESCRIPTION
When `-fopencilk` is used `cilk_spawn`, `cilk_sync`, `cilk_for`, `cilk_reducer`, and `cilk_scope` become keywords.  The spellings prefixed with `_Cilk` are unaffected.  They remain keywords in all compilation modes.  They will not generate parallel code if Tapir is not enabled.