### PR TITLE
Increase __cilk to 301

### DIFF
--- a/clang/lib/Frontend/InitPreprocessor.cpp
+++ b/clang/lib/Frontend/InitPreprocessor.cpp
@@ -1469,7 +1469,7 @@ static void InitializePredefinedMacros(const TargetInfo &TI,
     Builder.defineMacro("__cilk", "200");
     break;
   case LangOptions::Cilk_opencilk:
-    Builder.defineMacro("__cilk", "300");
+    Builder.defineMacro("__cilk", "301");
     break;
   }
 


### PR DESCRIPTION
Relative to `__cilk=300` this new version indicates support for syntactic reducers and promotion of `cilk_spawn` et al. from macros to keywords.