### PR TITLE
Sync before exiting a cilk_scope with a non-compound statement body

### DIFF
--- a/clang/lib/CodeGen/CGCilk.cpp
+++ b/clang/lib/CodeGen/CGCilk.cpp
@@ -456,7 +456,7 @@ void CodeGenFunction::EmitCilkSyncStmt(const CilkSyncStmt &S) {
 void CodeGenFunction::EmitCilkScopeStmt(const CilkScopeStmt &S) {
   LexicalScope CilkScope(*this, S.getSourceRange());
 
-  // If this _Cilk_scope is outermost in the function, emit
+  // If this cilk_scope is outermost in the function, emit
   // tapir_runtime_{start,end} intrinsics around the scope.
   bool ThisScopeIsOutermost = false;
   if (!WithinCilkScope) {
@@ -465,13 +465,14 @@ void CodeGenFunction::EmitCilkScopeStmt(const CilkScopeStmt &S) {
   }
 
   {
+    ScopeIsSynced = true;
     // Add a taskframe around this scope in case there are other spawns outside
     // of this scope, which would need to be synced separately.
     TaskFrameScope TFScope(*this);
     if (ThisScopeIsOutermost && !CurSyncRegion) {
       llvm::Instruction *TapirRTStart = Builder.CreateCall(
           CGM.getIntrinsic(llvm::Intrinsic::tapir_runtime_start));
-      // Mark the end of the _Cilk_scope with tapir_runtime_end.
+      // Mark the end of the cilk_scope with tapir_runtime_end.
       EHStack.pushCleanup<TapirRuntimeEndCleanup>(NormalAndEHCleanup,
                                                   TapirRTStart);
     }
@@ -485,8 +486,8 @@ void CodeGenFunction::EmitCilkScopeStmt(const CilkScopeStmt &S) {
     EmitStmt(S.getBody());
   }
 
-  // If this _Cilk_scope is outermost in the function, mark that CodeGen is no
-  // longer emitting within a _Cilk_scope.
+  // If this cilk_scope is outermost in the function, mark that CodeGen is no
+  // longer emitting within a cilk_scope.
   if (ThisScopeIsOutermost)
     WithinCilkScope = false;
 }

--- a/clang/test/Cilk/double-scope.c
+++ b/clang/test/Cilk/double-scope.c
@@ -1,0 +1,9 @@
+// RUN: %clang_cc1 -emit-llvm -fopencilk -mllvm -use-opencilk-runtime-bc=false -mllvm -debug-abi-calls -O0 -x c %s -o /dev/null
+// RUN: %clang_cc1 -emit-llvm -fopencilk -mllvm -use-opencilk-runtime-bc=false -mllvm -debug-abi-calls -O1 -x c %s -o /dev/null
+// If the compiler doesn't crash the bug is fixed.
+
+void ccc()
+{
+  extern void ddd(void);
+  cilk_scope { cilk_scope cilk_spawn { ddd(); } }
+}

--- a/clang/test/Cilk/scope.c
+++ b/clang/test/Cilk/scope.c
@@ -1,0 +1,19 @@
+// RUN: %clang_cc1 -emit-llvm -fopencilk -disable-llvm-passes -O1 -x c %s -o - | FileCheck %s
+
+extern void bbb(void);
+
+// CHECK-LABEL: @aaa
+int aaa(int argc, char *argv[])
+{
+// CHECK: call token @llvm.tapir.runtime.start()
+  cilk_scope
+    for (int i = 0; i < argc; ++i)
+// CHECK: detach within
+// CHECK: call void @bbb
+// CHECK-NEXT: reattach within
+// sync must precede runtime end
+// CHECK: sync within
+// CHECK: call void @llvm.tapir.runtime.end
+      cilk_spawn { bbb(); }
+  return 0;
+}


### PR DESCRIPTION
Fixes #319.