### PR TITLE
Fix processing of `--opencilk-abi-bitcode` flag and flag to specify Cilktool to LLD

### DIFF
--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -1756,6 +1756,9 @@ void ToolChain::AddOpenCilkABIBitcode(const ArgList &Args,
     if (IsLTO)
       CmdArgs.push_back(
           Args.MakeArgString("--plugin-opt=opencilk-abi-bitcode=" + P));
+    else
+      CmdArgs.push_back(Args.MakeArgString("--opencilk-abi-bitcode=" + P));
+    return;
   }
 
   bool UseAsan = getSanitizerArgs(Args).needsAsanRt();

--- a/clang/lib/Driver/ToolChains/Darwin.cpp
+++ b/clang/lib/Driver/ToolChains/Darwin.cpp
@@ -3633,9 +3633,8 @@ void DarwinClang::AddOpenCilkABIBitcode(const ArgList &Args,
     if (!getVFS().exists(P))
       getDriver().Diag(diag::err_drv_opencilk_missing_abi_bitcode)
           << A->getAsString(Args);
-    if (IsLTO)
-      CmdArgs.push_back(
-          Args.MakeArgString("--opencilk-abi-bitcode=" + P));
+    CmdArgs.push_back(Args.MakeArgString("--opencilk-abi-bitcode=" + P));
+    return;
   }
 
   bool UseAsan = getSanitizerArgs(Args).needsAsanRt();

--- a/clang/lib/Driver/ToolChains/Darwin.cpp
+++ b/clang/lib/Driver/ToolChains/Darwin.cpp
@@ -579,7 +579,7 @@ static void renderTapirLoweringOptions(const ArgList &Args,
 
   if (const Arg *A = Args.getLastArg(options::OPT_fcilktool_EQ))
     CmdArgs.push_back(
-        Args.MakeArgString(Twine("--plugin-opt=cilktool=") + A->getValue()));
+        Args.MakeArgString(Twine("--cilktool=") + A->getValue()));
 }
 
 static void AppendPlatformPrefix(SmallString<128> &Path, const llvm::Triple &T);


### PR DESCRIPTION
This PR fixes a bug causing the `--opencilk-abi-bitcode` flag to not be processed outside of LTO.

This PR also fixes a bug where the wrong flag would be passed to LLD on macOS to specify the Cilktool to use.