### PR TITLE
[IPO] Remove dependence on TapirOpts from IPO library.

### DIFF
--- a/llvm/lib/Transforms/IPO/CMakeLists.txt
+++ b/llvm/lib/Transforms/IPO/CMakeLists.txt
@@ -70,7 +70,6 @@ add_llvm_component_library(LLVMipo
   ProfileData
   Scalar
   Support
-  TapirOpts
   TargetParser
   TransformUtils
   Vectorize

--- a/llvm/lib/Transforms/Tapir/CMakeLists.txt
+++ b/llvm/lib/Transforms/Tapir/CMakeLists.txt
@@ -37,6 +37,7 @@ add_llvm_component_library(LLVMTapirOpts
   MC
   Scalar
   Support
+  TargetParser
   TransformUtils
   Vectorize
   )


### PR DESCRIPTION
A simpler fix for #331.