### PR TITLE
[ci] Enable testing builds on Fedora infrastructure

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -1,0 +1,17 @@
+# https://packit.dev/docs/configuration/
+
+specfile_path: packaging/fedora/opencilk.spec
+
+notifications:
+  pull_request:
+    successful_build: true
+
+jobs:
+- job: copr_build
+  trigger: pull_request
+  targets:
+  - fedora-rawhide-aarch64
+  - fedora-rawhide-i386
+  - fedora-rawhide-ppc64le
+  - fedora-rawhide-s390x
+  - fedora-rawhide-x86_64

--- a/packaging/fedora/linux-termios.patch
+++ b/packaging/fedora/linux-termios.patch
@@ -1,0 +1,45 @@
+diff -ruN opencilk-project-opencilk-v3.0/compiler-rt/lib/sanitizer_common/sanitizer_common_interceptors_ioctl.inc opencilk-project-opencilk-v3.0-mod/compiler-rt/lib/sanitizer_common/sanitizer_common_interceptors_ioctl.inc
+--- opencilk-project-opencilk-v3.0/compiler-rt/lib/sanitizer_common/sanitizer_common_interceptors_ioctl.inc	2025-05-08 13:32:27.000000000 +0300
++++ opencilk-project-opencilk-v3.0-mod/compiler-rt/lib/sanitizer_common/sanitizer_common_interceptors_ioctl.inc	2025-06-12 07:22:52.251346829 +0300
+@@ -338,17 +338,9 @@
+   _(SOUND_PCM_WRITE_CHANNELS, WRITE, sizeof(int));
+   _(SOUND_PCM_WRITE_FILTER, WRITE, sizeof(int));
+   _(TCFLSH, NONE, 0);
+-#if SANITIZER_GLIBC
+-  _(TCGETA, WRITE, struct_termio_sz);
+-#endif
+   _(TCGETS, WRITE, struct_termios_sz);
+   _(TCSBRK, NONE, 0);
+   _(TCSBRKP, NONE, 0);
+-#if SANITIZER_GLIBC
+-  _(TCSETA, READ, struct_termio_sz);
+-  _(TCSETAF, READ, struct_termio_sz);
+-  _(TCSETAW, READ, struct_termio_sz);
+-#endif
+   _(TCSETS, READ, struct_termios_sz);
+   _(TCSETSF, READ, struct_termios_sz);
+   _(TCSETSW, READ, struct_termios_sz);
+diff -ruN opencilk-project-opencilk-v3.0/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp opencilk-project-opencilk-v3.0-mod/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp
+--- opencilk-project-opencilk-v3.0/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp	2025-05-08 13:32:27.000000000 +0300
++++ opencilk-project-opencilk-v3.0-mod/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp	2025-06-12 07:19:02.145949709 +0300
+@@ -479,9 +479,6 @@
+   unsigned struct_input_id_sz = sizeof(struct input_id);
+   unsigned struct_mtpos_sz = sizeof(struct mtpos);
+   unsigned struct_rtentry_sz = sizeof(struct rtentry);
+-#if SANITIZER_GLIBC || SANITIZER_ANDROID
+-  unsigned struct_termio_sz = sizeof(struct termio);
+-#endif
+   unsigned struct_vt_consize_sz = sizeof(struct vt_consize);
+   unsigned struct_vt_sizes_sz = sizeof(struct vt_sizes);
+   unsigned struct_vt_stat_sz = sizeof(struct vt_stat);
+diff -ruN opencilk-project-opencilk-v3.0/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.h opencilk-project-opencilk-v3.0-mod/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.h
+--- opencilk-project-opencilk-v3.0/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.h	2025-05-08 13:32:27.000000000 +0300
++++ opencilk-project-opencilk-v3.0-mod/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.h	2025-06-12 12:16:57.076203680 +0300
+@@ -1013,7 +1013,6 @@
+ extern unsigned struct_input_absinfo_sz;
+ extern unsigned struct_input_id_sz;
+ extern unsigned struct_mtpos_sz;
+-extern unsigned struct_termio_sz;
+ extern unsigned struct_vt_consize_sz;
+ extern unsigned struct_vt_sizes_sz;
+ extern unsigned struct_vt_stat_sz;

--- a/packaging/fedora/opencilk.spec
+++ b/packaging/fedora/opencilk.spec
@@ -1,0 +1,93 @@
+Name:       opencilk
+Version:    3.0
+Release:    %{autorelease}
+Summary:    Shared memory task parallelization tool
+
+License:    Apache-2.0-WITH-LLVM-Exceptions AND MIT-WITH-OpenCilk-Addendum
+URL:        htttps://www.opencilk.org
+Source0:    https://github.com/OpenCilk/opencilk-project/archive/opencilk/v%{version}/opencilk-project-%{version}.tar.gz
+Source1:    https://github.com/OpenCilk/cheetah/archive/opencilk/v%{version}/cheetah-%{version}.tar.gz
+Source2:    https://github.com/OpenCilk/productivity-tools/archive/opencilk/v%{version}/productivity-tools-%{version}.tar.gz
+Patch:      linux-termios.patch
+
+BuildRequires:  cmake
+BuildRequires:  gcc
+BuildRequires:  gcc-c++
+BuildRequires:  ninja-build
+BuildRequires:  git
+
+%description
+OpenCilk is a state-of-the-art open-source implementation of the Cilk
+task-parallel programming platform. OpenCilk supports writing fast parallel
+programs using the Cilk task-parallel language extensions to C/C++. In
+addition, OpenCilk provides a platform to develop compilers, runtime systems,
+and program-analysis tools for task-parallel code.
+
+%prep
+%autosetup -p1 -n opencilk-project-opencilk-v%{version}
+tar -xf %{SOURCE1}
+mv cheetah-opencilk-v%{version} cheetah
+tar -xf %{SOURCE2}
+mv productivity-tools-opencilk-v%{version} cilktools
+
+%build
+%cmake -DLLVM_ENABLE_PROJECTS="clang;compiler-rt" \
+       -DLLVM_ENABLE_RUNTIMES="cheetah;cilktools" \
+       -DLLVM_ENABLE_ASSERTIONS="ON" \
+       -DLLVM_TARGETS_TO_BUILD="host" \
+       -DLLVM_OPTIMIZED_TABLEGEN=On \
+       -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+       -G Ninja \
+       -S llvm \
+       -B  %_vpath_builddir
+%cmake_build
+
+
+%install
+%cmake_install
+
+
+%files
+%license LICENSE.txt
+%license MIT_LICENSE.txt
+%doc README.md
+%doc README_LLVM.md
+%{_includedir}/clang/
+%{_includedir}/clang-c/
+%{_includedir}/llvm/
+%{_includedir}/llvm-c/
+%{_libdir}/libclang*
+%{_libdir}/libLLVM*
+%{_libdir}/clang/
+%{_libdir}/cmake/clang/
+%{_libdir}/cmake/llvm
+%{_libdir}/libear/
+%{_libdir}/libscanbuild/
+%{_libdir}/libLTO.so
+%{_libdir}/libLTO.so.16
+%{_libdir}/libRemarks.so
+%{_libdir}/libRemarks.so.16
+%{_bindir}/amdgpu-arch
+%{_bindir}/analyze-build
+%{_bindir}/bugpoint
+%{_bindir}/c-index-test
+%{_bindir}/clang*
+%{_bindir}/diagtool
+%{_bindir}/dsymutil
+%{_bindir}/git-clang-format
+%{_bindir}/hmaptool
+%{_bindir}/intercept-build
+%{_bindir}/llc
+%{_bindir}/lli
+%{_bindir}/llvm*
+%{_bindir}/nvptx-arch
+%{_bindir}/opt
+%{_bindir}/sancov
+%{_bindir}/sanstats
+%{_bindir}/scan-build
+%{_bindir}/scan-build-py
+%{_bindir}/scan-view
+%{_bindir}/verify-uselistorder
+
+%changelog
+%autochangelog


### PR DESCRIPTION
Additional tests that will make distributing RPMs easier.

To get it to work, someone with commit access will need to agree to make a Fedora account at:
https://accounts.fedoraproject.org/

and agree to Fedora Code of Conduct, then follow the steps at:

http://packit.dev/docs/guide#1-set-up-packit-integration

The patch has changes in https://github.com/OpenCilk/opencilk-project/pull/343

It is possible to use specific commits for [cheetah](https://github.com/OpenCilk/cheetah/)
and [productivity-tools](https://github.com/OpenCilk/productivity-tools)