### PR TITLE
Fix off-by-one grainsize on inclusive cilk_for ranges

### DIFF
--- a/llvm/lib/Transforms/Tapir/LoopSpawningTI.cpp
+++ b/llvm/lib/Transforms/Tapir/LoopSpawningTI.cpp
@@ -745,7 +745,12 @@ void DACSpawning::implementDACIterSpawnOnHelper(
     if (PrimaryIVStart->getType() != End->getType())
       Start = Builder.CreateZExtOrTrunc(PrimaryIVStart, End->getType());
     IterCount = Builder.CreateSub(End, Start, "itercount");
-    Value *IterCountCmp = Builder.CreateICmpUGT(IterCount, Grainsize);
+    Value *IterCountCmp = nullptr;
+    if (TL.isInclusiveRange()) {
+      IterCountCmp = Builder.CreateICmpUGE(IterCount, Grainsize);
+    } else {
+      IterCountCmp = Builder.CreateICmpUGT(IterCount, Grainsize);
+    }
     Instruction *RecurTerm =
       SplitBlockAndInsertIfThen(IterCountCmp, PreheaderOrigFront,
                                 /*Unreachable=*/false,

--- a/llvm/test/Transforms/Tapir/looplimit.ll
+++ b/llvm/test/Transforms/Tapir/looplimit.ll
@@ -40,7 +40,7 @@ pfor.end.continue:                                ; preds = %pfor.cond.cleanup
 ; CHECK: {{^(; <label>:)?}}[[DACSTART:[a-zA-Z0-9._]+]]:
 ; CHECK: [[ITERSTART:%[a-zA-Z0-9._]+]] = phi [[TYPE]] [{{.*}}[[START]]{{.*}}]
 ; CHECK-NEXT: [[ITERCOUNT:%[a-zA-Z0-9._]+]] = sub [[TYPE]] [[END]], [[ITERSTART]]
-; CHECK-NEXT: [[CMP:%[0-9]+]] = icmp ugt [[TYPE]] [[ITERCOUNT]], [[GRAIN]]
+; CHECK-NEXT: [[CMP:%[0-9]+]] = icmp uge [[TYPE]] [[ITERCOUNT]], [[GRAIN]]
 ; CHECK-NEXT: br i1 [[CMP]], label %[[RECUR:[0-9]+]], label %[[BODY:[0-9]+]]
 
 ; CHECK: {{^(; <label>:)?}}[[RECUR]]:


### PR DESCRIPTION
If a cilk_for loop is over an inclusive range, the serial base case ended up being  <= grainsize+1 rather than <= grainsize.