### PR TITLE
CI fixes and LLVM inlining/SROA bug fixes

### DIFF
--- a/.ci/compute_projects.py
+++ b/.ci/compute_projects.py
@@ -91,6 +91,13 @@ DEPENDENT_RUNTIMES_TO_TEST_NEEDS_RECONFIG = {
 EXCLUDE_LINUX = {
     "cross-project-tests",  # TODO(issues/132796): Tests are failing.
     "openmp",  # https://github.com/google/llvm-premerge-checks/issues/410
+    # Tests to exclude for OpenCilk, to save CI resources.
+    "bolt",
+    "flang",
+    "libclc",
+    "lldb",
+    "mlir",
+    "polly",
 }
 
 EXCLUDE_WINDOWS = {
@@ -329,4 +336,4 @@ if __name__ == "__main__":
         current_platform = sys.argv[1]
     env_variables = get_env_variables(sys.stdin.readlines(), current_platform)
     for env_variable in env_variables:
-        print(f"{env_variable}='{env_variables[env_variable]}'")
+        print(f"{env_variable}={env_variables[env_variable]}")

--- a/.ci/generate_test_report_lib.py
+++ b/.ci/generate_test_report_lib.py
@@ -9,7 +9,7 @@ SEE_BUILD_FILE_STR = "Download the build's log file to see the details."
 UNRELATED_FAILURES_STR = (
     "If these failures are unrelated to your changes (for example "
     "tests are broken or flaky at HEAD), please open an issue at "
-    "https://github.com/llvm/llvm-project/issues and add the "
+    "https://github.com/OpenCilk/opencilk-project/issues and add the "
     "`infrastructure` label."
 )
 

--- a/.ci/generate_test_report_lib_test.py
+++ b/.ci/generate_test_report_lib_test.py
@@ -41,7 +41,7 @@ class TestReports(unittest.TestCase):
 
             Download the build's log file to see the details.
 
-            If these failures are unrelated to your changes (for example tests are broken or flaky at HEAD), please open an issue at https://github.com/llvm/llvm-project/issues and add the `infrastructure` label."""
+            If these failures are unrelated to your changes (for example tests are broken or flaky at HEAD), please open an issue at https://github.com/OpenCilk/opencilk-project/issues and add the `infrastructure` label."""
             ),
         )
 
@@ -71,7 +71,7 @@ class TestReports(unittest.TestCase):
 
                 Download the build's log file to see the details.
 
-                If these failures are unrelated to your changes (for example tests are broken or flaky at HEAD), please open an issue at https://github.com/llvm/llvm-project/issues and add the `infrastructure` label."""
+                If these failures are unrelated to your changes (for example tests are broken or flaky at HEAD), please open an issue at https://github.com/OpenCilk/opencilk-project/issues and add the `infrastructure` label."""
             ),
         )
 
@@ -134,7 +134,7 @@ class TestReports(unittest.TestCase):
 
               Download the build's log file to see the details.
               
-              If these failures are unrelated to your changes (for example tests are broken or flaky at HEAD), please open an issue at https://github.com/llvm/llvm-project/issues and add the `infrastructure` label."""
+              If these failures are unrelated to your changes (for example tests are broken or flaky at HEAD), please open an issue at https://github.com/OpenCilk/opencilk-project/issues and add the `infrastructure` label."""
                 )
             ),
         )
@@ -195,7 +195,7 @@ class TestReports(unittest.TestCase):
           ```
           </details>
           
-          If these failures are unrelated to your changes (for example tests are broken or flaky at HEAD), please open an issue at https://github.com/llvm/llvm-project/issues and add the `infrastructure` label."""
+          If these failures are unrelated to your changes (for example tests are broken or flaky at HEAD), please open an issue at https://github.com/OpenCilk/opencilk-project/issues and add the `infrastructure` label."""
                 )
             ),
         )
@@ -229,7 +229,7 @@ class TestReports(unittest.TestCase):
         ```
         </details>
         
-        If these failures are unrelated to your changes (for example tests are broken or flaky at HEAD), please open an issue at https://github.com/llvm/llvm-project/issues and add the `infrastructure` label."""
+        If these failures are unrelated to your changes (for example tests are broken or flaky at HEAD), please open an issue at https://github.com/OpenCilk/opencilk-project/issues and add the `infrastructure` label."""
     )
 
     def test_report_single_file_multiple_testsuites(self):
@@ -337,7 +337,7 @@ class TestReports(unittest.TestCase):
 
           Failed tests and their output was too large to report. Download the build's log file to see the details.
           
-          If these failures are unrelated to your changes (for example tests are broken or flaky at HEAD), please open an issue at https://github.com/llvm/llvm-project/issues and add the `infrastructure` label."""
+          If these failures are unrelated to your changes (for example tests are broken or flaky at HEAD), please open an issue at https://github.com/OpenCilk/opencilk-project/issues and add the `infrastructure` label."""
                 )
             ),
         )
@@ -373,7 +373,7 @@ class TestReports(unittest.TestCase):
 
           Failed tests and their output was too large to report. Download the build's log file to see the details.
           
-          If these failures are unrelated to your changes (for example tests are broken or flaky at HEAD), please open an issue at https://github.com/llvm/llvm-project/issues and add the `infrastructure` label."""
+          If these failures are unrelated to your changes (for example tests are broken or flaky at HEAD), please open an issue at https://github.com/OpenCilk/opencilk-project/issues and add the `infrastructure` label."""
                 )
             ),
         )
@@ -412,7 +412,7 @@ class TestReports(unittest.TestCase):
 
           Failed tests and their output was too large to report. Download the build's log file to see the details.
           
-          If these failures are unrelated to your changes (for example tests are broken or flaky at HEAD), please open an issue at https://github.com/llvm/llvm-project/issues and add the `infrastructure` label."""
+          If these failures are unrelated to your changes (for example tests are broken or flaky at HEAD), please open an issue at https://github.com/OpenCilk/opencilk-project/issues and add the `infrastructure` label."""
                 )
             ),
         )

--- a/.ci/monolithic-linux.sh
+++ b/.ci/monolithic-linux.sh
@@ -38,7 +38,7 @@ function at-exit {
   # If building fails there will be no results files.
   shopt -s nullglob
   
-  python3 "${MONOREPO_ROOT}"/.ci/generate_test_report_github.py ":penguin: Linux x64 Test Results" \
+  python3 "${MONOREPO_ROOT}"/.ci/generate_test_report_github.py ":penguin: Linux Test Results" \
     $retcode "${BUILD_DIR}"/test-results.*.xml >> $GITHUB_STEP_SUMMARY
 }
 trap at-exit EXIT
@@ -74,6 +74,7 @@ cmake -S "${MONOREPO_ROOT}"/llvm -B "${BUILD_DIR}" \
       -D COMPILER_RT_BUILD_LIBFUZZER=OFF \
       -D LLVM_LIT_ARGS="${lit_args}" \
       -D LLVM_ENABLE_LLD=ON \
+      -D LLVM_TARGETS_TO_BUILD=host \
       -D CMAKE_CXX_FLAGS=-gmlt \
       -D CMAKE_C_COMPILER_LAUNCHER=sccache \
       -D CMAKE_CXX_COMPILER_LAUNCHER=sccache \

--- a/.github/workflows/libcxx-build-and-test.yaml
+++ b/.github/workflows/libcxx-build-and-test.yaml
@@ -22,9 +22,9 @@ on:
       - 'runtimes/**'
       - 'cmake/**'
       - '.github/workflows/libcxx-build-and-test.yaml'
-  schedule:
-    # Run nightly at 08:00 UTC (aka 00:00 Pacific, aka 03:00 Eastern)
-    - cron: '0 8 * * *'
+  # schedule:
+  #   # Run nightly at 08:00 UTC (aka 00:00 Pacific, aka 03:00 Eastern)
+  #   - cron: '0 8 * * *'
 
 permissions:
   contents: read # Default everything to read-only

--- a/.github/workflows/premerge.yaml
+++ b/.github/workflows/premerge.yaml
@@ -17,6 +17,7 @@ on:
   push:
     branches:
       - 'release/**'
+      - 'dev/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
@@ -26,59 +27,98 @@ jobs:
   premerge-checks-linux:
     name: Build and Test Linux
     if: >-
-        github.repository_owner == 'llvm' &&
         (github.event_name != 'pull_request' || github.event.action != 'closed')
-    runs-on: llvm-premerge-linux-runners
+    strategy:
+      fail-fast: false
+      matrix:
+        runs-on:
+          # The Linux x64 runners on GitHub don't have enough disk space to build LLVM and its tests.
+          # We need another runner to automate these tests.
+          # This may be an issue with the arm and macos runners in the future.
+          # - ubuntu-24.04
+          - ubuntu-24.04-arm
+    runs-on: ${{ matrix.runs-on }}
     steps:
       - name: Checkout LLVM
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 2
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.9
+      - name: Compute projects to build
+        run: |
+          git config --global --add safe.directory '*'
+          git diff --name-only HEAD~1...HEAD | python3 .ci/compute_projects.py >> $GITHUB_ENV
       - name: Build and Test
+        env:
+          SCCACHE_GHA_ENABLED: "true"
         # Mark the job as a success even if the step fails so that people do
         # not get notified while the new premerge pipeline is in an
         # experimental state.
         run: |
           git config --global --add safe.directory '*'
 
-          source <(git diff --name-only HEAD~1...HEAD | python3 .ci/compute_projects.py)
+          # source <(git diff --name-only HEAD~1...HEAD | python3 .ci/compute_projects.py)
 
           if [[ "${projects_to_build}" == "" ]]; then
             echo "No projects to build"
             exit 0
           fi
 
+          df -h
+
           echo "Building projects: ${projects_to_build}"
           echo "Running project checks targets: ${project_check_targets}"
-          echo "Building runtimes: ${runtimes_to_build}"
-          echo "Running runtimes checks targets: ${runtimes_check_targets}"
-          echo "Running runtimes checks requiring reconfiguring targets: ${runtimes_check_targets_needs_reconfig}"
+          # echo "Building runtimes: ${runtimes_to_build}"
+          # echo "Running runtimes checks targets: ${runtimes_check_targets}"
+          # echo "Running runtimes checks requiring reconfiguring targets: ${runtimes_check_targets_needs_reconfig}"
 
-          export CC=/opt/llvm/bin/clang
-          export CXX=/opt/llvm/bin/clang++
+          export CC=clang
+          export CXX=clang++
 
-          # This environment variable is passes into the container through the
-          # runner pod definition. This differs between our two clusters which
-          # why we do not hardcode it.
-          export SCCACHE_GCS_BUCKET=$CACHE_GCS_BUCKET
-          export SCCACHE_GCS_RW_MODE=READ_WRITE
+          # The linux-premerge runners are hosted on GCP and have a different
+          # cache setup than the depot runners.
+          if [[ "${{ matrix.runs-on }}" = "llvm-premerge-linux-runners" ]]; then
+            # This environment variable is passes into the container through the
+            # runner pod definition. This differs between our two clusters which
+            # why we do not hardcode it.
+            export SCCACHE_GCS_BUCKET=$CACHE_GCS_BUCKET
+            export SCCACHE_GCS_RW_MODE=READ_WRITE
+          fi
+          env
 
           # Set the idle timeout to zero to ensure sccache runs for the
           # entire duration of the job. Otherwise it might stop if we run
           # several test suites in a row and discard statistics that we want
           # to save in the end.
           export SCCACHE_IDLE_TIMEOUT=0
-          sccache --start-server
+          export SCCACHE_CACHE_SIZE="2G"
+          mkdir artifacts
+          SCCACHE_LOG=info SCCACHE_ERROR_LOG=$(pwd)/artifacts/sccache.log sccache --start-server
 
-          ./.ci/monolithic-linux.sh "${projects_to_build}" "${project_check_targets}" "${runtimes_to_build}" "${runtimes_check_targets}" "${runtimes_check_targets_needs_reconfig}" "${enable_cir}"
+          # ./.ci/monolithic-linux.sh "${projects_to_build}" "${project_check_targets}" "${runtimes_to_build}" "${runtimes_check_targets}" "${runtimes_check_targets_needs_reconfig}" "${enable_cir}"
+          ./.ci/monolithic-linux.sh "${projects_to_build}" "${project_check_targets}" "" "" "" "${enable_cir}"
       - name: Upload Artifacts
+        # In some cases, Github will fail to upload the artifact. We want to
+        # continue anyways as a failed artifact upload is an infra failure, not
+        # a checks failure.
+        # https://github.com/actions/upload-artifact/issues/569
+        continue-on-error: true
         if: '!cancelled()'
-        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
-          name: Premerge Artifacts (Linux)
+          name: Premerge Artifacts (Linux ${{ runner.arch }})
           path: artifacts/
           retention-days: 5
           include-hidden-files: 'true'
+      - name: Upload Comment
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: ${{ always() && !startsWith(matrix.runs-on, 'ubuntu-24.04-arm') }}
+        continue-on-error: true
+        with:
+          name: workflow-args
+          path: |
+            comments
 
   premerge-checks-windows:
     name: Build and Test Windows
@@ -133,11 +173,13 @@ jobs:
     runs-on: macos-14
     if: >-
       github.repository_owner == 'llvm' &&
-      (startswith(github.ref_name, 'release/') ||
-       startswith(github.base_ref, 'release/')) &&
+      ((startswith(github.ref_name, 'release/') ||
+        startswith(github.base_ref, 'release/')) ||
+       (startswith(github.ref_name, 'dev/') ||
+        startswith(github.base_ref, 'dev/'))) &&
       (github.event_name != 'pull_request' || github.event.action != 'closed')
     steps:
-      - name: Checkout LLVM
+      - name: Checkout OpenCilk
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 2
@@ -146,15 +188,19 @@ jobs:
         with:
           max-size: "2000M"
       - name: Install Ninja
-        uses: llvm/actions/install-ninja@main
+        run: |
+          brew install ninja
+      - name: Compute projects to build
+        run: |
+          git diff --name-only HEAD~1...HEAD | python3 .ci/compute_projects.py >> $GITHUB_ENV
       - name: Build and Test
         run: |
-          source <(git diff --name-only HEAD~2..HEAD | python3 .ci/compute_projects.py)
-
           if [[ "${projects_to_build}" == "" ]]; then
             echo "No projects to build"
             exit 0
           fi
+
+          df -h
 
           echo "Building projects: ${projects_to_build}"
           echo "Running project checks targets: ${project_check_targets}"

--- a/.github/workflows/release-asset-audit.yml
+++ b/.github/workflows/release-asset-audit.yml
@@ -3,10 +3,10 @@ name: Release Asset Audit
 on:
   workflow_dispatch:
   release:
-  schedule:
-    # * is a special character in YAML so you have to quote this string
-    # Run once an hour
-    - cron:  '5 * * * *'
+  # schedule:
+  #   # * is a special character in YAML so you have to quote this string
+  #   # Run once an hour
+  #   - cron:  '5 * * * *'
 
   pull_request:
     paths:

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -893,10 +893,11 @@ TSTToUnaryTransformType(DeclSpec::TST SwitchTST) {
   }
 }
 
+namespace {
 // -1 if OK, -2 for nested hyperobject, or index for unsupported_hyperobject
 // diagnostic
-static int DeclContainsHyperobject(const RecordDecl *Decl, QualType &Bad,
-                                   SourceLocation &Where);
+int DeclContainsHyperobject(const RecordDecl *Decl, QualType &Bad,
+                            SourceLocation &Where);
 
 // It is forbidden to add new bits to the Type class so there is no
 // room for a cached or precomputed flag.  Do a deep search on every
@@ -974,8 +975,8 @@ int TypeContainsHyperobject(QualType Contained, QualType &Bad,
   }
 }
 
-static int DeclContainsHyperobject(const RecordDecl *Decl, QualType &Bad,
-                                   SourceLocation &Where) {
+int DeclContainsHyperobject(const RecordDecl *Decl, QualType &Bad,
+                            SourceLocation &Where) {
   if (Decl->isInvalidDecl())
     return -1;
   for (const FieldDecl *FD : Decl->fields()) {
@@ -989,6 +990,7 @@ static int DeclContainsHyperobject(const RecordDecl *Decl, QualType &Bad,
   }
   return -1;
 }
+} // namespace
 
 /// Convert the specified declspec to the appropriate type
 /// object.

--- a/llvm/examples/Kaleidoscope/Tapir/CMakeLists.txt
+++ b/llvm/examples/Kaleidoscope/Tapir/CMakeLists.txt
@@ -16,5 +16,3 @@ set(LLVM_LINK_COMPONENTS
 add_kaleidoscope_chapter(Kaleidoscope-Tapir
   toy.cpp
   )
-
-export_executable_symbols(Kaleidoscope-Tapir)

--- a/llvm/examples/Kaleidoscope/Tapir/KaleidoscopeJIT.h
+++ b/llvm/examples/Kaleidoscope/Tapir/KaleidoscopeJIT.h
@@ -23,12 +23,13 @@
 #include "llvm/ExecutionEngine/Orc/IRTransformLayer.h"
 #include "llvm/ExecutionEngine/Orc/JITTargetMachineBuilder.h"
 #include "llvm/ExecutionEngine/Orc/RTDyldObjectLinkingLayer.h"
+#include "llvm/ExecutionEngine/Orc/SelfExecutorProcessControl.h"
 #include "llvm/ExecutionEngine/Orc/Shared/ExecutorSymbolDef.h"
 #include "llvm/ExecutionEngine/SectionMemoryManager.h"
 #include "llvm/IR/DataLayout.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/LLVMContext.h"
-#include "llvm/Support/FormatVariadic.h"
+#include "llvm/Support/MemoryBuffer.h"
 #include <memory>
 
 namespace llvm {
@@ -115,10 +116,11 @@ private:
 public:
   KaleidoscopeJIT(std::unique_ptr<ExecutionSession> ES,
                   JITTargetMachineBuilder JTMB, DataLayout DL)
-      : ES(std::move(ES)), DL(std::move(DL)),
-        Mangle(*this->ES, this->DL),
+      : ES(std::move(ES)), DL(std::move(DL)), Mangle(*this->ES, this->DL),
         ObjectLayer(*this->ES,
-                    []() { return std::make_unique<SectionMemoryManager>(); }),
+                    [](const MemoryBuffer &) {
+                      return std::make_unique<SectionMemoryManager>();
+                    }),
         CompileLayer(*this->ES, ObjectLayer,
                      std::make_unique<ConcurrentIRCompiler>(std::move(JTMB))),
         InitHelperTransformLayer(
@@ -150,8 +152,8 @@ public:
     if (!DL)
       return DL.takeError();
 
-    return std::make_unique<KaleidoscopeJIT>(std::move(ES),
-                                             std::move(JTMB), std::move(*DL));
+    return std::make_unique<KaleidoscopeJIT>(std::move(ES), std::move(JTMB),
+                                             std::move(*DL));
   }
 
   const DataLayout &getDataLayout() const { return DL; }

--- a/llvm/examples/Kaleidoscope/Tapir/toy.cpp
+++ b/llvm/examples/Kaleidoscope/Tapir/toy.cpp
@@ -1,7 +1,6 @@
 #include "KaleidoscopeJIT.h"
 #include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/APSInt.h"
-#include "llvm/ADT/STLExtras.h"
 #include "llvm/Analysis/AliasAnalysisEvaluator.h"
 #include "llvm/Analysis/AssumptionCache.h"
 #include "llvm/Analysis/BasicAliasAnalysis.h"
@@ -9,6 +8,7 @@
 #include "llvm/Analysis/BranchProbabilityInfo.h"
 #include "llvm/Analysis/CallGraph.h"
 #include "llvm/Analysis/DependenceAnalysis.h"
+#include "llvm/Analysis/LastRunTrackingAnalysis.h"
 #include "llvm/Analysis/MemoryDependenceAnalysis.h"
 #include "llvm/Analysis/MemorySSA.h"
 #include "llvm/Analysis/OptimizationRemarkEmitter.h"
@@ -56,8 +56,6 @@
 #include "llvm/Transforms/Tapir.h"
 #include "llvm/Transforms/Tapir/LoopSpawningTI.h"
 #include "llvm/Transforms/Tapir/TapirToTarget.h"
-#include "llvm/Transforms/Utils.h"
-#include <algorithm>
 #include <cassert>
 #include <cctype>
 #include <cstdint>
@@ -1387,7 +1385,7 @@ static Value *CreateSyncRegion(Module &M) {
     return LogErrorV("No local task scope.");
   IRBuilder<> TmpB(TaskEntry, TaskEntry->begin());
   return TmpB.CreateCall(
-      Intrinsic::getDeclaration(&M, Intrinsic::syncregion_start), {});
+      Intrinsic::getOrInsertDeclaration(&M, Intrinsic::syncregion_start), {});
 }
 
 // Output spawn spawned_expr as:
@@ -1626,7 +1624,7 @@ Value *ParForExprAST::codegen() {
   // loop.
   std::vector<Metadata *> LoopMetadata = GetTapirLoopMetadata();
   if (!LoopMetadata.empty()) {
-    auto TempNode = MDNode::getTemporary(*TheContext, std::nullopt);
+    auto TempNode = MDNode::getTemporary(*TheContext, {});
     LoopMetadata.insert(LoopMetadata.begin(), TempNode.get());
     auto LoopID = MDNode::get(*TheContext, LoopMetadata);
     LoopID->replaceOperandWith(0, LoopID);
@@ -1722,6 +1720,8 @@ static void RunOptimizations() {
   MAM.registerPass([&] { return CallGraphAnalysis(); });
   MAM.registerPass([&] { return PassInstrumentationAnalysis(); });
   MAM.registerPass([&] { return ProfileSummaryAnalysis(); });
+  FAM.registerPass([&] { return LastRunTrackingAnalysis(); });
+  MAM.registerPass([&] { return LastRunTrackingAnalysis(); });
   // Cross-register analysis proxies.
   MAM.registerPass([&] { return FunctionAnalysisManagerModuleProxy(FAM); });
   FAM.registerPass([&] { return ModuleAnalysisManagerFunctionProxy(MAM); });
@@ -1923,7 +1923,7 @@ static void InitializeModule() {
 
   // Set the target triple to match the system.
   auto SysTargetTriple = sys::getDefaultTargetTriple();
-  TheModule->setTargetTriple(SysTargetTriple);
+  TheModule->setTargetTriple(Triple(SysTargetTriple));
   // Set an appropriate data layout
   TheModule->setDataLayout(TheJIT->getDataLayout());
 

--- a/llvm/lib/Transforms/Scalar/SROA.cpp
+++ b/llvm/lib/Transforms/Scalar/SROA.cpp
@@ -3778,12 +3778,14 @@ class AggLoadStoreRewriter : public InstVisitor<AggLoadStoreRewriter, bool> {
 
   /// Used to calculate offsets, and hence alignment, of subobjects.
   const DataLayout &DL;
-
+  // Used to calculate instruction insertion points.
+  const TaskInfo *TI;
   IRBuilderTy &IRB;
 
 public:
-  AggLoadStoreRewriter(const DataLayout &DL, IRBuilderTy &IRB)
-      : DL(DL), IRB(IRB) {}
+  AggLoadStoreRewriter(const DataLayout &DL, IRBuilderTy &IRB,
+                       const TaskInfo *TI)
+      : DL(DL), TI(TI), IRB(IRB) {}
 
   /// Rewrite loads and stores through a pointer and all pointers derived from
   /// it.
@@ -4220,7 +4222,8 @@ private:
     Type *SourceTy = GEPI.getSourceElementType();
     // We only handle arguments, constants, and static allocas here, so we can
     // insert GEPs at the end of the entry block.
-    IRB.SetInsertPoint(GEPI.getFunction()->getEntryBlock().getTerminator());
+    IRB.SetInsertPoint(
+        TI->getTaskFor(GEPI.getParent())->getEntry()->getTerminator());
     for (unsigned I = 0, E = Phi->getNumIncomingValues(); I != E; ++I) {
       Value *Op = Phi->getIncomingValue(I);
       BasicBlock *BB = Phi->getIncomingBlock(I);
@@ -5711,7 +5714,7 @@ SROA::runOnAlloca(AllocaInst &AI) {
   // First, split any FCA loads and stores touching this alloca to promote
   // better splitting and promotion opportunities.
   IRBuilderTy IRB(&AI);
-  AggLoadStoreRewriter AggRewriter(DL, IRB);
+  AggLoadStoreRewriter AggRewriter(DL, IRB, TI);
   Changed |= AggRewriter.rewrite(AI);
 
   // Build the slices using a recursive instruction-visiting builder.

--- a/llvm/lib/Transforms/Utils/CloneFunction.cpp
+++ b/llvm/lib/Transforms/Utils/CloneFunction.cpp
@@ -19,6 +19,7 @@
 #include "llvm/Analysis/InstructionSimplify.h"
 #include "llvm/Analysis/LoopInfo.h"
 #include "llvm/IR/AttributeMask.h"
+#include "llvm/IR/BasicBlock.h"
 #include "llvm/IR/CFG.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/DebugInfo.h"
@@ -27,6 +28,7 @@
 #include "llvm/IR/InstIterator.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/IntrinsicInst.h"
+#include "llvm/IR/Intrinsics.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/MDBuilder.h"
 #include "llvm/IR/Metadata.h"
@@ -34,6 +36,7 @@
 #include "llvm/Transforms/Utils/BasicBlockUtils.h"
 #include "llvm/Transforms/Utils/Cloning.h"
 #include "llvm/Transforms/Utils/Local.h"
+#include "llvm/Transforms/Utils/TapirUtils.h"
 #include "llvm/Transforms/Utils/ValueMapper.h"
 #include <map>
 #include <optional>
@@ -417,6 +420,14 @@ struct PruningFunctionCloner {
   ClonedCodeInfo *CodeInfo;
   bool HostFuncIsStrictFP;
 
+  const BasicBlock *DetachContinue = nullptr;
+  const BasicBlock *DetachUnwind = nullptr;
+  const Value *TaskFrame = nullptr;
+
+  bool currentlyCloningTaskBlocks() const {
+    return DetachContinue != nullptr || TaskFrame != nullptr;
+  }
+
   Instruction *cloneInstruction(BasicBlock::const_iterator II);
 
 public:
@@ -519,6 +530,16 @@ void PruningFunctionCloner::CloneBlock(
   if (BBEntry)
     return;
 
+  // If BB is the saved detach-continue or detach-unwind, then we're no longer
+  // cloning blocks inside a detached task.
+  if (BB == DetachContinue || BB == DetachUnwind) {
+    DetachContinue = nullptr;
+    DetachUnwind = nullptr;
+  }
+
+  // Determine if this block is in a task.
+  bool BBInTask = currentlyCloningTaskBlocks();
+
   // Nope, clone it now.
   BasicBlock *NewBB;
   Twine NewName(BB->hasName() ? Twine(BB->getName()) + NameSuffix : "");
@@ -565,6 +586,21 @@ void PruningFunctionCloner::CloneBlock(
     if (auto *IntrInst = dyn_cast<IntrinsicInst>(II))
       if (IntrInst->getIntrinsicID() == Intrinsic::fake_use)
         continue;
+
+    if (!BBInTask && !TaskFrame &&
+        isTapirIntrinsic(Intrinsic::taskframe_create, II)) {
+      TaskFrame = &*II;
+      BBInTask = true;
+    } else if (TaskFrame &&
+               (isTapirIntrinsic(Intrinsic::taskframe_use, II, TaskFrame) ||
+                isTapirIntrinsic(Intrinsic::taskframe_end, II, TaskFrame))) {
+      // Clearing the TaskFrame may lead to mistakes deducing that a block is
+      // not within a task when it actually is.  This is OK, because we're only
+      // using this information heuristically, to refine CodeInfo's analysis of
+      // whether the cloned blocks contain static or dynamic allocas.
+      TaskFrame = nullptr;
+      BBInTask = currentlyCloningTaskBlocks();
+    }
 
     Instruction *NewInst = cloneInstruction(II);
     NewInst->insertInto(NewBB, NewBB->end());
@@ -615,6 +651,9 @@ void PruningFunctionCloner::CloneBlock(
           CodeInfo->OperandBundleCallSites.push_back(NewInst);
     }
 
+    if (BBInTask)
+      // No need to check allocas.
+      continue;
     if (const AllocaInst *AI = dyn_cast<AllocaInst>(II)) {
       if (isa<ConstantInt>(AI->getArraySize()))
         hasStaticAllocas = true;
@@ -625,6 +664,14 @@ void PruningFunctionCloner::CloneBlock(
 
   // Finally, clone over the terminator.
   const Instruction *OldTI = BB->getTerminator();
+  if (TaskFrame && isTaskFrameResume(OldTI, TaskFrame))
+    // Clearing the TaskFrame may lead to mistakes deducing that a block is
+    // not within a task when it actually is.  This is OK, because we're only
+    // using this information heuristically, to refine CodeInfo's analysis of
+    // whether the cloned blocks contain static or dynamic allocas.
+    TaskFrame = nullptr;
+  // Don't update BBInTask here, so that the later updates to CodeInfo reflect
+  // the contents of this block.
   bool TerminatorDone = false;
   if (const BranchInst *BI = dyn_cast<BranchInst>(OldTI)) {
     if (BI->isConditional()) {
@@ -682,7 +729,37 @@ void PruningFunctionCloner::CloneBlock(
     }
 
     // Recursively clone any reachable successor blocks.
-    append_range(ToClone, successors(BB->getTerminator()));
+    if (const DetachInst *DI = dyn_cast<DetachInst>(BB->getTerminator())) {
+      if (DetachContinue) {
+        // Currently handling a spawned task, so this subtask needs no extra
+        // handling.  Add all successors.
+        append_range(ToClone, successors(BB->getTerminator()));
+      } else {
+        assert(!DetachUnwind &&
+               "Found a saved detach unwind but no saved detach-continue.");
+        // About to start cloning blocks in a spawned task.  Record the continue
+        // and unwind destinations, then push them onto the stack before the
+        // detached block.  With the successor filter below, this order
+        // partially ensures that the DFS traverses the task blocks first.
+        DetachContinue = DI->getContinue();
+        ToClone.push_back(DetachContinue);
+        if (DI->hasUnwindDest()) {
+          DetachUnwind = DI->getUnwindDest();
+          ToClone.push_back(DetachUnwind);
+        }
+        ToClone.push_back(DI->getDetached());
+      }
+    } else if (DetachContinue) {
+      // Currently handling a spawned task.  Filter any successors that match
+      // the detach-continue or detach-unwind, so the DFS does not traverse
+      // these blocks before traversing the whole spawned task.
+      for (const BasicBlock *Successor : successors(BB->getTerminator()))
+        if (Successor != DetachContinue && Successor != DetachUnwind)
+          ToClone.push_back(Successor);
+    } else {
+      // No spawned tasks to worry about.  Add all successors.
+      append_range(ToClone, successors(BB->getTerminator()));
+    }
   } else {
     // If we didn't create a new terminator, clone DbgVariableRecords from the
     // old terminator onto the new terminator.

--- a/llvm/lib/Transforms/Utils/InlineFunction.cpp
+++ b/llvm/lib/Transforms/Utils/InlineFunction.cpp
@@ -621,7 +621,8 @@ static bool isTaskFrameUnwind(const BasicBlock *UnwindEdge) {
   return isTaskFrameResume(UnwindEdge->getTerminator());
 }
 
-static void splitTaskFrameEnds(Instruction *TFCreate) {
+static void splitTaskFrameEnds(Instruction *TFCreate,
+                               SmallPtrSetImpl<BasicBlock *> &ToProcess) {
   // Split taskframe.end that use TFCreate.
   SmallVector<Instruction *, 8> TFEndToSplit;
   for (User *U : TFCreate->users())
@@ -632,7 +633,8 @@ static void splitTaskFrameEnds(Instruction *TFCreate) {
   for (Instruction *TFEnd : TFEndToSplit) {
     if (TFEnd != TFEnd->getParent()->getTerminator()->getPrevNode()) {
       BasicBlock::iterator Iter = ++TFEnd->getIterator();
-      SplitBlock(TFEnd->getParent(), &*Iter);
+      BasicBlock *NewBB = SplitBlock(TFEnd->getParent(), &*Iter);
+      ToProcess.insert(NewBB);
       // Try to attach debug info to the new terminator after the taskframe.end
       // call.
       Instruction *SplitTerminator = TFEnd->getParent()->getTerminator();
@@ -666,6 +668,7 @@ static void HandleInlinedTasksHelper(
     if (!BlocksToProcess.count(BB))
       continue;
 
+    // If we find a nested taskframe, handle it recursively.
     if (Instruction *TFCreate =
             FindTaskFrameCreateInBlock(BB, CurrentTaskFrame)) {
       // Split the block at the taskframe.create, if necessary.
@@ -678,7 +681,7 @@ static void HandleInlinedTasksHelper(
 
       // Split any blocks containing taskframe.end intrinsics that use
       // TFCreate.
-      splitTaskFrameEnds(TFCreate);
+      splitTaskFrameEnds(TFCreate, BlocksToProcess);
 
       // Create an unwind edge for the taskframe.
       BasicBlock *TaskFrameUnwindEdge =
@@ -823,23 +826,19 @@ static void HandleInlinedTasks(
 
   // Either finish the unreachable block or remove it, depending on whether it
   // is used.
-  if (!pred_empty(UnreachableBlk)) {
-    IRBuilder<> Builder(UnreachableBlk);
-    Builder.CreateUnreachable();
-  } else {
+  if (!pred_empty(UnreachableBlk))
+    IRBuilder<>(UnreachableBlk).CreateUnreachable();
+  else
     UnreachableBlk->eraseFromParent();
-  }
 }
 
 static void GetInlinedLPads(SmallPtrSetImpl<BasicBlock *> &BlocksToProcess,
                             SmallPtrSetImpl<LandingPadInst *> &InlinedLPads) {
   SmallVector<BasicBlock *, 32> Worklist;
   SmallPtrSet<BasicBlock *, 32> Visited;
-
-  // Push all blocks to process that are terminated by a resume onto the
-  // worklist.
+  // Find all resumes among the blocks to process
   for (BasicBlock *BB : BlocksToProcess)
-    if (isa<ResumeInst>(BB->getTerminator()))
+    if (succ_empty(BB))
       Worklist.push_back(BB);
 
   // Traverse the blocks to process from the resumes going backwards (through
@@ -856,7 +855,8 @@ static void GetInlinedLPads(SmallPtrSetImpl<BasicBlock *> &BlocksToProcess,
     // If BB is a landingpad...
     if (BB->isLandingPad()) {
       // Record BB's landingpad instruction.
-      InlinedLPads.insert(BB->getLandingPadInst());
+      if (!InlinedLPads.insert(BB->getLandingPadInst()).second)
+        continue;
 
       // Add predecessors of BB to the worklist, skipping predecessors via a
       // detached.rethrow or taskframe.resume.
@@ -871,7 +871,7 @@ static void GetInlinedLPads(SmallPtrSetImpl<BasicBlock *> &BlocksToProcess,
     // In the normal case, add predecessors of BB to the worklist, excluding
     // predecessors via reattach, detached.rethrow, or taskframe.resume
     for (BasicBlock *Predecessor : predecessors(BB))
-      if (!isa<ResumeInst>(Predecessor->getTerminator()) &&
+      if (!isa<ReattachInst>(Predecessor->getTerminator()) &&
           !isDetachedRethrow(Predecessor->getTerminator()) &&
           !isTaskFrameResume(Predecessor->getTerminator()))
         Worklist.push_back(Predecessor);
@@ -896,47 +896,15 @@ static void HandleInlinedLandingPad(InvokeInst *II, BasicBlock *FirstNewBlock,
   // rewrite.
   LandingPadInliningInfo Invoke(II);
 
-  // Special processing is needed to inline a function that contains a task.
-  if (InlinedCodeInfo.ContainsDetach) {
-    // Get the set of blocks for the inlined function.
-    SmallPtrSet<BasicBlock *, 32> BlocksToProcess;
-    for (Function::iterator BB = FirstNewBlock->getIterator(),
-                                 E = Caller->end(); BB != E; ++BB)
-      BlocksToProcess.insert(&*BB);
-
-    // Get all of the inlined landing pad instructions.
-    SmallPtrSet<LandingPadInst*, 16> InlinedLPads;
-    GetInlinedLPads(BlocksToProcess, InlinedLPads);
-
-    // Append the clauses from the outer landing pad instruction into the
-    // inlined landing pad instructions.
-    LandingPadInst *OuterLPad = Invoke.getLandingPadInst();
-    for (LandingPadInst *InlinedLPad : InlinedLPads) {
-      unsigned OuterNum = OuterLPad->getNumClauses();
-      InlinedLPad->reserveClauses(OuterNum);
-      for (unsigned OuterIdx = 0; OuterIdx != OuterNum; ++OuterIdx)
-        InlinedLPad->addClause(OuterLPad->getClause(OuterIdx));
-      if (OuterLPad->isCleanup())
-        InlinedLPad->setCleanup(true);
-    }
-
-    // Process inlined subtasks.
-    HandleInlinedTasks(BlocksToProcess, FirstNewBlock, TFCreate,
-                       Invoke.getOuterResumeDest(), Invoke, InlinedLPads);
-    // Now that everything is happy, we have one final detail.  The PHI nodes in
-    // the exception destination block still have entries due to the original
-    // invoke instruction. Eliminate these entries (which might even delete the
-    // PHI node) now.
-    InvokeDest->removePredecessor(II->getParent());
-    return;
-  }
+  // Get the set of blocks for the inlined function.
+  SmallPtrSet<BasicBlock *, 32> BlocksToProcess;
+  for (Function::iterator BB = FirstNewBlock->getIterator(), E = Caller->end();
+       BB != E; ++BB)
+    BlocksToProcess.insert(&*BB);
 
   // Get all of the inlined landing pad instructions.
-  SmallPtrSet<LandingPadInst*, 16> InlinedLPads;
-  for (Function::iterator I = FirstNewBlock->getIterator(), E = Caller->end();
-       I != E; ++I)
-    if (InvokeInst *II = dyn_cast<InvokeInst>(I->getTerminator()))
-      InlinedLPads.insert(II->getLandingPadInst());
+  SmallPtrSet<LandingPadInst *, 16> InlinedLPads;
+  GetInlinedLPads(BlocksToProcess, InlinedLPads);
 
   // Append the clauses from the outer landing pad instruction into the inlined
   // landing pad instructions.
@@ -950,19 +918,9 @@ static void HandleInlinedLandingPad(InvokeInst *II, BasicBlock *FirstNewBlock,
       InlinedLPad->setCleanup(true);
   }
 
-  for (Function::iterator BB = FirstNewBlock->getIterator(), E = Caller->end();
-       BB != E; ++BB) {
-    if (InlinedCodeInfo.ContainsCalls)
-      if (BasicBlock *NewBB = HandleCallsInBlockInlinedThroughInvoke(
-              &*BB, Invoke.getOuterResumeDest()))
-        // Update any PHI nodes in the exceptional block to indicate that there
-        // is now a new entry in them.
-        Invoke.addIncomingPHIValuesFor(NewBB);
-
-    // Forward any resumes that are remaining here.
-    if (ResumeInst *RI = dyn_cast<ResumeInst>(BB->getTerminator()))
-      Invoke.forwardResume(RI, InlinedLPads);
-  }
+  // Process inlined class and subtasks.
+  HandleInlinedTasks(BlocksToProcess, FirstNewBlock, TFCreate,
+                     Invoke.getOuterResumeDest(), Invoke, InlinedLPads);
 
   // Now that everything is happy, we have one final detail.  The PHI nodes in
   // the exception destination block still have entries due to the original
@@ -3550,10 +3508,8 @@ llvm::InlineResult llvm::InlineFunction(CallBase &CB, InlineFunctionInfo &IFI,
       // Create the normal return for the detached rethrow.
       BasicBlock *UnreachableBlk = BasicBlock::Create(
           Caller->getContext(), UnwindEdge->getName()+".unreachable", Caller);
-      { // Add an unreachable instruction to the end of UnreachableBlk.
-        IRBuilder<> Builder(UnreachableBlk);
-        Builder.CreateUnreachable();
-      }
+      // Add an unreachable instruction to the end of UnreachableBlk.
+      IRBuilder<>(UnreachableBlk).CreateUnreachable();
 
       // Create an unwind edge for the taskframe.
       BasicBlock *TaskFrameUnwindEdge =

--- a/llvm/test/CMakeLists.txt
+++ b/llvm/test/CMakeLists.txt
@@ -184,6 +184,7 @@ if(LLVM_BUILD_EXAMPLES)
     Kaleidoscope-Ch5
     Kaleidoscope-Ch6
     Kaleidoscope-Ch7
+    Kaleidoscope-Tapir
     LLJITWithThinLTOSummaries
     OrcV2CBindingsBasicUsage
     OrcV2CBindingsAddObjectFile

--- a/llvm/test/Transforms/Tapir/avoid-unnecessary-inline-taskframes.ll
+++ b/llvm/test/Transforms/Tapir/avoid-unnecessary-inline-taskframes.ll
@@ -1,0 +1,70 @@
+; Check that inlining does not insert taskframes unnecessarily due to allocas in tasks.
+;
+; RUN: opt < %s -passes="cgscc(devirt<4>(inline))" -S | FileCheck %s
+target datalayout = "e-m:o-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-n32:64-S128-Fn32"
+target triple = "arm64-apple-macosx26.0.0"
+
+; CHECK-NOT: call token @llvm.taskframe.create()
+
+; Function Attrs: nounwind willreturn memory(argmem: readwrite)
+declare token @llvm.syncregion.start() #0
+
+define fastcc { ptr, i32 } @"_ZN6parlay8internal13bucket_sort_rIPNSt3__110unique_ptrIxNS2_14default_deleteIxEEEES7_ZN44TestSampleSort_TestSortInplaceUniquePtr_Test8TestBodyEvE3$_2EEvNS_5sliceIT_SB_EENSA_IT0_SD_EET1_bb"() personality ptr null {
+entry:
+  %call11 = invoke fastcc i1 @"_ZN6parlay8internal11get_bucketsIPNSt3__110unique_ptrIxNS2_14default_deleteIxEEEEZN44TestSampleSort_TestSortInplaceUniquePtr_Test8TestBodyEvE3$_2EEbNS_5sliceIT_SB_EEPhT0_m"([2 x ptr] zeroinitializer, ptr null, i64 0)
+          to label %common.ret unwind label %lpad5
+
+common.ret:                                       ; preds = %lpad5, %entry
+  %common.ret.op = phi { ptr, i32 } [ zeroinitializer, %lpad5 ], [ zeroinitializer, %entry ]
+  ret { ptr, i32 } %common.ret.op
+
+lpad5:                                            ; preds = %entry
+  %0 = landingpad { ptr, i32 }
+          cleanup
+  br label %common.ret
+}
+
+define fastcc i1 @"_ZN6parlay8internal11get_bucketsIPNSt3__110unique_ptrIxNS2_14default_deleteIxEEEEZN44TestSampleSort_TestSortInplaceUniquePtr_Test8TestBodyEvE3$_2EEbNS_5sliceIT_SB_EEPhT0_m"([2 x ptr] %A.coerce, ptr %buckets, i64 %rounds) personality ptr null {
+entry:
+  %0 = call fastcc ptr @"_ZN6parlay8sequenceImNS_9allocatorImEELb0EE13from_functionIZNS_8internal11get_bucketsIPNSt3__110unique_ptrIxNS7_14default_deleteIxEEEEZN44TestSampleSort_TestSortInplaceUniquePtr_Test8TestBodyEvE3$_2EEbNS_5sliceIT_SG_EEPhT0_mEUlmE_EES3_mOSG_m"()
+  resume { ptr, i32 } zeroinitializer
+}
+
+define fastcc ptr @"_ZN6parlay8sequenceImNS_9allocatorImEELb0EE13from_functionIZNS_8internal11get_bucketsIPNSt3__110unique_ptrIxNS7_14default_deleteIxEEEEZN44TestSampleSort_TestSortInplaceUniquePtr_Test8TestBodyEvE3$_2EEbNS_5sliceIT_SG_EEPhT0_mEUlmE_EES3_mOSG_m"() {
+entry:
+  %call = call fastcc ptr @"_ZN6parlay8sequenceImNS_9allocatorImEELb0EEC1IZNS_8internal11get_bucketsIPNSt3__110unique_ptrIxNS7_14default_deleteIxEEEEZN44TestSampleSort_TestSortInplaceUniquePtr_Test8TestBodyEvE3$_2EEbNS_5sliceIT_SG_EEPhT0_mEUlmE_EEmOSG_NS3_18_from_function_tagEm"()
+  ret ptr %call
+}
+
+define fastcc ptr @"_ZN6parlay8sequenceImNS_9allocatorImEELb0EEC1IZNS_8internal11get_bucketsIPNSt3__110unique_ptrIxNS7_14default_deleteIxEEEEZN44TestSampleSort_TestSortInplaceUniquePtr_Test8TestBodyEvE3$_2EEbNS_5sliceIT_SG_EEPhT0_mEUlmE_EEmOSG_NS3_18_from_function_tagEm"() {
+entry:
+  %call = call fastcc ptr @"_ZN6parlay8sequenceImNS_9allocatorImEELb0EEC2IZNS_8internal11get_bucketsIPNSt3__110unique_ptrIxNS7_14default_deleteIxEEEEZN44TestSampleSort_TestSortInplaceUniquePtr_Test8TestBodyEvE3$_2EEbNS_5sliceIT_SG_EEPhT0_mEUlmE_EEmOSG_NS3_18_from_function_tagEm"()
+  ret ptr %call
+}
+
+define fastcc ptr @"_ZN6parlay8sequenceImNS_9allocatorImEELb0EEC2IZNS_8internal11get_bucketsIPNSt3__110unique_ptrIxNS7_14default_deleteIxEEEEZN44TestSampleSort_TestSortInplaceUniquePtr_Test8TestBodyEvE3$_2EEbNS_5sliceIT_SG_EEPhT0_mEUlmE_EEmOSG_NS3_18_from_function_tagEm"() {
+entry:
+  call fastcc void @"_ZN6parlay12parallel_forIZNS_8sequenceImNS_9allocatorImEELb0EEC1IZNS_8internal11get_bucketsIPNSt3__110unique_ptrIxNS8_14default_deleteIxEEEEZN44TestSampleSort_TestSortInplaceUniquePtr_Test8TestBodyEvE3$_2EEbNS_5sliceIT_SH_EEPhT0_mEUlmE_EEmOSH_NS4_18_from_function_tagEmEUlmE_EEvmmSM_lb"()
+  ret ptr null
+}
+
+define fastcc void @"_ZN6parlay12parallel_forIZNS_8sequenceImNS_9allocatorImEELb0EEC1IZNS_8internal11get_bucketsIPNSt3__110unique_ptrIxNS8_14default_deleteIxEEEEZN44TestSampleSort_TestSortInplaceUniquePtr_Test8TestBodyEvE3$_2EEbNS_5sliceIT_SH_EEPhT0_mEUlmE_EEmOSH_NS4_18_from_function_tagEmEUlmE_EEvmmSM_lb"() {
+entry:
+  %syncreg = call token @llvm.syncregion.start()
+  detach within %syncreg, label %pfor.body.entry, label %pfor.inc
+
+pfor.body.entry:                                  ; preds = %entry
+  %0 = call fastcc ptr @"_ZZN6parlay8sequenceImNS_9allocatorImEELb0EEC1IZNS_8internal11get_bucketsIPNSt3__110unique_ptrIxNS7_14default_deleteIxEEEEZN44TestSampleSort_TestSortInplaceUniquePtr_Test8TestBodyEvE3$_2EEbNS_5sliceIT_SG_EEPhT0_mEUlmE_EEmOSG_NS3_18_from_function_tagEmENKUlmE_clEm"()
+  reattach within %syncreg, label %pfor.inc
+
+pfor.inc:                                         ; preds = %pfor.body.entry, %entry
+  ret void
+}
+
+define fastcc ptr @"_ZZN6parlay8sequenceImNS_9allocatorImEELb0EEC1IZNS_8internal11get_bucketsIPNSt3__110unique_ptrIxNS7_14default_deleteIxEEEEZN44TestSampleSort_TestSortInplaceUniquePtr_Test8TestBodyEvE3$_2EEbNS_5sliceIT_SG_EEPhT0_mEUlmE_EEmOSG_NS3_18_from_function_tagEmENKUlmE_clEm"() {
+entry:
+  %ref.tmp = alloca i64, align 8
+  ret ptr %ref.tmp
+}
+
+attributes #0 = { nounwind willreturn memory(argmem: readwrite) }

--- a/llvm/test/Transforms/Tapir/inline-nounwind-detach-into-invoked-taskframe.ll
+++ b/llvm/test/Transforms/Tapir/inline-nounwind-detach-into-invoked-taskframe.ll
@@ -1,5 +1,5 @@
 ; Check that inlining a simple detach with no unwind into a taskframe with
-; an unwind destimation works as intended.
+; an unwind destination works as intended.
 ;
 ; RUN: opt < %s -passes="cgscc(devirt<4>(inline,function<eager-inv>(sroa<modify-cfg>)))" -S | FileCheck %s
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
@@ -22,12 +22,12 @@ for.cond86:                                       ; preds = %for.cond86, %entry
 
 ; CHECK: [[IF_ELSE_I]]:
 ; CHECK-NEXT: %[[TF_I:.+]] = call token @llvm.taskframe.create()
-; CHECK: %syncreg19.i.i5 = call token @llvm.syncregion.start()
-; CHECK-NEXT: detach within %syncreg19.i.i5, label %det.achd.i.i, label
+; CHECK: %syncreg19.i.i7 = call token @llvm.syncregion.start()
+; CHECK-NEXT: detach within %syncreg19.i.i7, label %det.achd.i.i, label
 ; CHECK-NOT: unwind label
 
 ; CHECK: det.achd.i.i:
-; CHECK-NEXT: reattach within %syncreg19.i.i5, label
+; CHECK-NEXT: reattach within %syncreg19.i.i7, label
 
 lpad90:                                           ; preds = %for.cond86
   %0 = landingpad { ptr, i32 }
@@ -37,6 +37,14 @@ lpad90:                                           ; preds = %for.cond86
 
 define linkonce_odr void @_ZN4gbbs9vertexMapINS_16vertexSubsetDataINS_5emptyEEENS_2bc37SSBetweennessCentrality_Back_Vertex_FIN6parlay8sequenceIbSaIbELb0EEENS7_IdSaIdELb0EEEEELi0EEEvRT_T0_m(ptr %V, ptr %f, i64 %granularity) {
 entry:
+  %syncreg = call token @llvm.syncregion.start()
+  detach within %syncreg, label %det.achd, label %cont
+
+det.achd:
+  call void null()
+  reattach within %syncreg, label %cont
+
+cont:
   br i1 poison, label %if.then, label %if.else
 
 common.ret:                                       ; preds = %if.else, %if.then
@@ -78,6 +86,7 @@ pfor.body.entry:                                  ; preds = %pfor.cond
   reattach within %syncreg, label %pfor.cond
 
 if.else:                                          ; preds = %entry
+  ; call void @_ZZN4gbbs9vertexMapINS_16vertexSubsetDataINS_5emptyEEENS_2bc37SSBetweennessCentrality_Back_Vertex_FIN6parlay8sequenceIbSaIbELb0EEENS7_IdSaIdELb0EEEEELi0EEEvRT_T0_mENKUlmE0_clEm()
   detach within %syncreg19, label %det.achd, label %det.cont
 
 det.achd:                                         ; preds = %if.else

--- a/llvm/test/Transforms/Tapir/sroa-gep-insert-in-task.ll
+++ b/llvm/test/Transforms/Tapir/sroa-gep-insert-in-task.ll
@@ -1,0 +1,47 @@
+; Check that SROA unfolds GEP phis appropriately for allocas in tasks.
+;
+; RUN: opt < %s -passes="function<eager-inv>(sroa<preserve-cfg>)" -S | FileCheck %s
+target datalayout = "e-m:o-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-n32:64-S128-Fn32"
+target triple = "arm64-apple-macosx26.0.0"
+
+%"struct.parlay::slice.922" = type { %"class.parlay::delayed_sequence<const std::__1::unique_ptr<long long> &, std::__1::unique_ptr<long long>, (lambda at /Users/neboat/Software/cilktest/parlaylib/include/parlay/internal/sample_sort.h:156:67)>::iterator.923", %"class.parlay::delayed_sequence<const std::__1::unique_ptr<long long> &, std::__1::unique_ptr<long long>, (lambda at /Users/neboat/Software/cilktest/parlaylib/include/parlay/internal/sample_sort.h:156:67)>::iterator.923" }
+%"class.parlay::delayed_sequence<const std::__1::unique_ptr<long long> &, std::__1::unique_ptr<long long>, (lambda at /Users/neboat/Software/cilktest/parlaylib/include/parlay/internal/sample_sort.h:156:67)>::iterator.923" = type { ptr, i64 }
+
+define { ptr, i32 } @_ZN44TestSampleSort_TestSortInplaceUniquePtr_Test8TestBodyEv() personality ptr null {
+entry:
+  %syncreg.i.i.i.i9.i = call token @llvm.syncregion.start()
+  sync within %syncreg.i.i.i.i9.i, label %sync.continue.i.i.i.i.i39
+
+sync.continue.i.i.i.i.i39:                        ; preds = %entry
+  detach within %syncreg.i.i.i.i9.i, label %pfor.body.entry.i.i.i152.i, label %pfor.inc.i.i.i89.i unwind label %lpad30.loopexit.i87.i
+
+pfor.body.entry.i.i.i152.i:                       ; preds = %sync.continue.i.i.i.i.i39
+  %agg.tmp20.i.i.i.i.i154.i = alloca %"struct.parlay::slice.922", align 8
+  br label %"_ZZN6parlay8internal10sliced_forIZNS0_20sample_sort_inplace_ImPNSt3__110unique_ptrIxNS3_14default_deleteIxEEEES8_ZN44TestSampleSort_TestSortInplaceUniquePtr_Test8TestBodyEvE3$_2EEvNS_5sliceIT0_SC_EENSB_IT1_SE_EERKT2_EUlmmmE_EEvmmRKT_jENKUlmE_clEm.exit.i.i.i.i"
+
+; CHECK: pfor.body.entry.i.i.i152.i:
+; CHECK: [[SROA_GEP:%.+]] = getelementptr i8, ptr %agg.tmp20.i.i.i.i.i154.i, i64 8 
+
+"_ZZN6parlay8internal10sliced_forIZNS0_20sample_sort_inplace_ImPNSt3__110unique_ptrIxNS3_14default_deleteIxEEEES8_ZN44TestSampleSort_TestSortInplaceUniquePtr_Test8TestBodyEvE3$_2EEvNS_5sliceIT0_SC_EENSB_IT1_SE_EERKT2_EUlmmmE_EEvmmRKT_jENKUlmE_clEm.exit.i.i.i.i": ; preds = %pfor.body.entry.i.i.i152.i
+  %agg.tmp20.i.i.i.i.i154.i.sink195 = phi ptr [ %agg.tmp20.i.i.i.i.i154.i, %pfor.body.entry.i.i.i152.i ]
+  %s.sroa.3.0.s2.sroa_idx.i.i.i.i52.i.i.i.i.i199.i = getelementptr i8, ptr %agg.tmp20.i.i.i.i.i154.i.sink195, i64 8
+  call fastcc void null([2 x ptr] zeroinitializer, ptr %agg.tmp20.i.i.i.i.i154.i, [2 x ptr] zeroinitializer)
+  reattach within %syncreg.i.i.i.i9.i, label %pfor.inc.i.i.i89.i
+
+; CHECK: "_ZZN6parlay8internal10sliced_forIZNS0_20sample_sort_inplace_ImPNSt3__110unique_ptrIxNS3_14default_deleteIxEEEES8_ZN44TestSampleSort_TestSortInplaceUniquePtr_Test8TestBodyEvE3$_2EEvNS_5sliceIT0_SC_EENSB_IT1_SE_EERKT2_EUlmmmE_EEvmmRKT_jENKUlmE_clEm.exit.i.i.i.i":
+; CHECK: phi ptr [ [[SROA_GEP]], %pfor.body.entry.i.i.i152.i ]
+; CHECK: reattach
+
+pfor.inc.i.i.i89.i:                               ; preds = %"_ZZN6parlay8internal10sliced_forIZNS0_20sample_sort_inplace_ImPNSt3__110unique_ptrIxNS3_14default_deleteIxEEEES8_ZN44TestSampleSort_TestSortInplaceUniquePtr_Test8TestBodyEvE3$_2EEvNS_5sliceIT0_SC_EENSB_IT1_SE_EERKT2_EUlmmmE_EEvmmRKT_jENKUlmE_clEm.exit.i.i.i.i", %sync.continue.i.i.i.i.i39
+  ret { ptr, i32 } zeroinitializer
+
+lpad30.loopexit.i87.i:                            ; preds = %sync.continue.i.i.i.i.i39
+  %lpad.loopexit87.i.i = landingpad { ptr, i32 }
+          cleanup
+  ret { ptr, i32 } %lpad.loopexit87.i.i
+}
+
+; Function Attrs: nounwind willreturn memory(argmem: readwrite)
+declare token @llvm.syncregion.start() #0
+
+attributes #0 = { nounwind willreturn memory(argmem: readwrite) }

--- a/llvm/test/Transforms/Tapir/taskframe-inline-resume-no-landingpad.ll
+++ b/llvm/test/Transforms/Tapir/taskframe-inline-resume-no-landingpad.ll
@@ -1,0 +1,118 @@
+; Check that inlining handles taskframes correctly when the inlined function
+; contains a resume without a landingpad.
+;
+; RUN: opt < %s -passes="cgscc(devirt<4>(inline))" -S | FileCheck %s
+target datalayout = "e-m:o-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-n32:64-S128-Fn32"
+target triple = "arm64-apple-macosx26.0.0"
+
+; Function Attrs: nounwind willreturn memory(argmem: readwrite)
+declare token @llvm.syncregion.start() #0
+
+define fastcc { ptr, i32 } @"_ZN6parlay8internal13bucket_sort_rIPNSt3__110unique_ptrIxNS2_14default_deleteIxEEEES7_ZN44TestSampleSort_TestSortInplaceUniquePtr_Test8TestBodyEvE3$_2EEvNS_5sliceIT_SB_EENSA_IT0_SD_EET1_bb"() personality ptr null {
+entry:
+  %syncreg = call token @llvm.syncregion.start()
+  detach within %syncreg, label %det.achd, label %cont
+
+det.achd:
+  call void null()
+  reattach within %syncreg, label %cont
+
+cont:
+  %call11 = invoke fastcc i1 @"_ZN6parlay8internal11get_bucketsIPNSt3__110unique_ptrIxNS2_14default_deleteIxEEEEZN44TestSampleSort_TestSortInplaceUniquePtr_Test8TestBodyEvE3$_2EEbNS_5sliceIT_SB_EEPhT0_m"([2 x ptr] zeroinitializer, ptr null, i64 0)
+          to label %common.ret unwind label %lpad5
+
+common.ret:                                       ; preds = %lpad5, %entry
+  %common.ret.op = phi { ptr, i32 } [ zeroinitializer, %lpad5 ], [ zeroinitializer, %cont ]
+  ret { ptr, i32 } %common.ret.op
+
+lpad5:                                            ; preds = %entry
+  %0 = landingpad { ptr, i32 }
+          cleanup
+  br label %common.ret
+}
+
+; CHECK: define {{.*}}{ ptr, i32 } @"_ZN6parlay8internal13bucket_sort_rIPNSt3__110unique_ptrIxNS2_14default_deleteIxEEEES7_ZN44TestSampleSort_TestSortInplaceUniquePtr_Test8TestBodyEvE3$_2EEvNS_5sliceIT_SB_EENSA_IT0_SD_EET1_bb"()
+
+; CHECK: cont:
+; CHECK-NEXT: %[[TF_I:.+]] = call token @llvm.taskframe.create()
+
+; CHECK: %[[TF_I_I:.+]] = call token @llvm.taskframe.create()
+; CHECK: %[[TF_I_I_I:.+]] = call token @llvm.taskframe.create()
+; CHECK: call void @llvm.taskframe.end(token %[[TF_I_I_I]])
+; CHECK: call void @llvm.taskframe.end(token %[[TF_I_I]])
+
+; CHECK-NOT: call void @llvm.taskframe.end(token %[[TF_I]])
+; CHECK-NOT: resume
+; CHECK: br label %[[LPAD_TF:.+]]
+
+; CHECK: [[LPAD_TF]]:
+; CHECK-NEXT: %[[EH:.+]] = phi [[EH_TYPE:.+]] [ {{.*}}, %{{.*}} ], [ {{.*}}, %{{.*}} ]
+; CHECK-NEXT: invoke void @llvm.taskframe.resume{{.*}}(token %[[TF_I]], [[EH_TYPE]] %[[EH]])
+; CHECK-NEXT: to label %{{.+}} unwind label %lpad5
+
+; CHECK: lpad5:
+; CHECK-NEXT: landingpad
+; CHECK-NEXT: cleanup
+; CHECK-NEXT: br label %common.ret
+
+define fastcc i1 @"_ZN6parlay8internal11get_bucketsIPNSt3__110unique_ptrIxNS2_14default_deleteIxEEEEZN44TestSampleSort_TestSortInplaceUniquePtr_Test8TestBodyEvE3$_2EEbNS_5sliceIT_SB_EEPhT0_m"([2 x ptr] %A.coerce, ptr %buckets, i64 %rounds) personality ptr null {
+entry:
+  %syncreg = call token @llvm.syncregion.start()
+  detach within %syncreg, label %det.achd, label %cont
+
+det.achd:
+  call void null()
+  reattach within %syncreg, label %cont
+
+cont:
+  %0 = call fastcc ptr @"_ZN6parlay8sequenceImNS_9allocatorImEELb0EE13from_functionIZNS_8internal11get_bucketsIPNSt3__110unique_ptrIxNS7_14default_deleteIxEEEEZN44TestSampleSort_TestSortInplaceUniquePtr_Test8TestBodyEvE3$_2EEbNS_5sliceIT_SG_EEPhT0_mEUlmE_EES3_mOSG_m"()
+  resume { ptr, i32 } zeroinitializer
+}
+
+define fastcc ptr @"_ZN6parlay8sequenceImNS_9allocatorImEELb0EE13from_functionIZNS_8internal11get_bucketsIPNSt3__110unique_ptrIxNS7_14default_deleteIxEEEEZN44TestSampleSort_TestSortInplaceUniquePtr_Test8TestBodyEvE3$_2EEbNS_5sliceIT_SG_EEPhT0_mEUlmE_EES3_mOSG_m"() {
+entry:
+  %syncreg = call token @llvm.syncregion.start()
+  detach within %syncreg, label %det.achd, label %cont
+
+det.achd:
+  call void null()
+  reattach within %syncreg, label %cont
+
+cont:
+  %call = call fastcc ptr @"_ZN6parlay8sequenceImNS_9allocatorImEELb0EEC1IZNS_8internal11get_bucketsIPNSt3__110unique_ptrIxNS7_14default_deleteIxEEEEZN44TestSampleSort_TestSortInplaceUniquePtr_Test8TestBodyEvE3$_2EEbNS_5sliceIT_SG_EEPhT0_mEUlmE_EEmOSG_NS3_18_from_function_tagEm"()
+  ret ptr %call
+}
+
+define fastcc ptr @"_ZN6parlay8sequenceImNS_9allocatorImEELb0EEC1IZNS_8internal11get_bucketsIPNSt3__110unique_ptrIxNS7_14default_deleteIxEEEEZN44TestSampleSort_TestSortInplaceUniquePtr_Test8TestBodyEvE3$_2EEbNS_5sliceIT_SG_EEPhT0_mEUlmE_EEmOSG_NS3_18_from_function_tagEm"() {
+entry:
+  %call = call fastcc ptr @"_ZN6parlay8sequenceImNS_9allocatorImEELb0EEC2IZNS_8internal11get_bucketsIPNSt3__110unique_ptrIxNS7_14default_deleteIxEEEEZN44TestSampleSort_TestSortInplaceUniquePtr_Test8TestBodyEvE3$_2EEbNS_5sliceIT_SG_EEPhT0_mEUlmE_EEmOSG_NS3_18_from_function_tagEm"()
+  ret ptr %call
+}
+
+define fastcc ptr @"_ZN6parlay8sequenceImNS_9allocatorImEELb0EEC2IZNS_8internal11get_bucketsIPNSt3__110unique_ptrIxNS7_14default_deleteIxEEEEZN44TestSampleSort_TestSortInplaceUniquePtr_Test8TestBodyEvE3$_2EEbNS_5sliceIT_SG_EEPhT0_mEUlmE_EEmOSG_NS3_18_from_function_tagEm"() {
+entry:
+  call fastcc void @"_ZN6parlay12parallel_forIZNS_8sequenceImNS_9allocatorImEELb0EEC1IZNS_8internal11get_bucketsIPNSt3__110unique_ptrIxNS8_14default_deleteIxEEEEZN44TestSampleSort_TestSortInplaceUniquePtr_Test8TestBodyEvE3$_2EEbNS_5sliceIT_SH_EEPhT0_mEUlmE_EEmOSH_NS4_18_from_function_tagEmEUlmE_EEvmmSM_lb"()
+  ret ptr null
+}
+
+define fastcc void @"_ZN6parlay12parallel_forIZNS_8sequenceImNS_9allocatorImEELb0EEC1IZNS_8internal11get_bucketsIPNSt3__110unique_ptrIxNS8_14default_deleteIxEEEEZN44TestSampleSort_TestSortInplaceUniquePtr_Test8TestBodyEvE3$_2EEbNS_5sliceIT_SH_EEPhT0_mEUlmE_EEmOSH_NS4_18_from_function_tagEmEUlmE_EEvmmSM_lb"() {
+entry:
+  %syncreg = call token @llvm.syncregion.start()
+  detach within %syncreg, label %pfor.body.entry, label %pfor.inc
+
+pfor.body.entry:                                  ; preds = %entry
+  %0 = call fastcc ptr @"_ZZN6parlay8sequenceImNS_9allocatorImEELb0EEC1IZNS_8internal11get_bucketsIPNSt3__110unique_ptrIxNS7_14default_deleteIxEEEEZN44TestSampleSort_TestSortInplaceUniquePtr_Test8TestBodyEvE3$_2EEbNS_5sliceIT_SG_EEPhT0_mEUlmE_EEmOSG_NS3_18_from_function_tagEmENKUlmE_clEm"()
+  reattach within %syncreg, label %pfor.inc
+
+pfor.inc:                                         ; preds = %pfor.body.entry, %entry
+  ; %1 = call fastcc ptr @"_ZZN6parlay8sequenceImNS_9allocatorImEELb0EEC1IZNS_8internal11get_bucketsIPNSt3__110unique_ptrIxNS7_14default_deleteIxEEEEZN44TestSampleSort_TestSortInplaceUniquePtr_Test8TestBodyEvE3$_2EEbNS_5sliceIT_SG_EEPhT0_mEUlmE_EEmOSG_NS3_18_from_function_tagEmENKUlmE_clEm"(i64 %n)
+  ret void
+}
+
+define fastcc ptr @"_ZZN6parlay8sequenceImNS_9allocatorImEELb0EEC1IZNS_8internal11get_bucketsIPNSt3__110unique_ptrIxNS7_14default_deleteIxEEEEZN44TestSampleSort_TestSortInplaceUniquePtr_Test8TestBodyEvE3$_2EEbNS_5sliceIT_SG_EEPhT0_mEUlmE_EEmOSG_NS3_18_from_function_tagEmENKUlmE_clEm"() {
+entry:
+  %ref.tmp = alloca i64, align 8
+  ret ptr %ref.tmp
+}
+
+attributes #0 = { nounwind willreturn memory(argmem: readwrite) }


### PR DESCRIPTION
- Port new LLVM GitHub Actions CI to perform CI checks on the opencilk-project repo.
- Fix some bugs with function inlining and SROA.
- Put methods for examining Hyperobject types into an anonymous namespace, to appease clang-tidy checks.