### PR TITLE
Refine grainsize analysis for parallel loops and integrate results into the OpenCilk runtime

### DIFF
--- a/llvm/include/llvm/Analysis/BranchProbabilityInfo.h
+++ b/llvm/include/llvm/Analysis/BranchProbabilityInfo.h
@@ -421,6 +421,7 @@ private:
   bool calcPointerHeuristics(const BasicBlock *BB);
   bool calcZeroHeuristics(const BasicBlock *BB, const TargetLibraryInfo *TLI);
   bool calcFloatingPointHeuristics(const BasicBlock *BB);
+  bool calcTapirHeuristics(const BasicBlock *BB);
 };
 
 /// Analysis pass which computes \c BranchProbabilityInfo.

--- a/llvm/include/llvm/Analysis/WorkSpanAnalysis.h
+++ b/llvm/include/llvm/Analysis/WorkSpanAnalysis.h
@@ -30,8 +30,10 @@
 // Tapir.
 
 namespace llvm {
+class BlockFrequencyInfo;
 class Loop;
 class LoopInfo;
+class OptimizationRemarkEmitter;
 class ScalarEvolution;
 class TargetLibraryInfo;
 class TargetTransformInfo;
@@ -50,8 +52,9 @@ unsigned getConstTripCount(const Loop *L, ScalarEvolution &SE);
 
 void estimateLoopCost(WSCost &LoopCost, const Loop *L, LoopInfo *LI,
                       ScalarEvolution *SE, const TargetTransformInfo &TTI,
-                      TargetLibraryInfo *TLI,
-                      const SmallPtrSetImpl<const Value *> &EphValues);
-}
+                      TargetLibraryInfo *TLI, BlockFrequencyInfo *BFI,
+                      const SmallPtrSetImpl<const Value *> &EphValues,
+                      OptimizationRemarkEmitter *ORE);
+} // namespace llvm
 
 #endif // LLVM_ANALYSIS_WORKSPANANALYSIS_H_

--- a/llvm/include/llvm/IR/Intrinsics.td
+++ b/llvm/include/llvm/IR/Intrinsics.td
@@ -1895,9 +1895,11 @@ def int_detached_rethrow : Intrinsic<[], [llvm_token_ty, llvm_any_ty],
 def int_sync_unwind
     : Intrinsic<[], [llvm_token_ty], [IntrArgMemOnly, IntrWillReturn, Throws]>;
 
-// Intrinsic to get the grainsize of a Tapir loop.
+// Intrinsic to get the grainsize of a Tapir loop.  The first argument is the
+// loop trip count.  The second argument is an upper bound on the grainsize or
+// 0 if no upper bound is statically known.
 def int_tapir_loop_grainsize
-    : Intrinsic<[llvm_anyint_ty], [LLVMMatchType<0>],
+    : Intrinsic<[llvm_anyint_ty], [LLVMMatchType<0>, LLVMMatchType<0>],
                 [IntrNoMem, IntrWillReturn, IntrSpeculatable]>;
 
 // Intrinsic to get the frame address of a spawned task.  Tapir

--- a/llvm/include/llvm/Transforms/Tapir/LoopStripMine.h
+++ b/llvm/include/llvm/Transforms/Tapir/LoopStripMine.h
@@ -10,7 +10,6 @@
 #define LLVM_TRANSFORMS_TAPIR_LOOPSTRIPMINE_H
 
 #include "llvm/ADT/DenseMap.h"
-#include "llvm/ADT/StringRef.h"
 #include "llvm/Analysis/TargetTransformInfo.h"
 #include "llvm/Support/InstructionCost.h"
 
@@ -33,9 +32,10 @@ void simplifyLoopAfterStripMine(Loop *L, bool SimplifyIVs, LoopInfo *LI,
                                 const TargetTransformInfo &TTI,
                                 AssumptionCache *AC);
 
-TargetTransformInfo::StripMiningPreferences gatherStripMiningPreferences(
-    Loop *L, ScalarEvolution &SE, const TargetTransformInfo &TTI,
-    std::optional<unsigned> UserCount);
+TargetTransformInfo::StripMiningPreferences
+gatherStripMiningPreferences(Loop *L, ScalarEvolution &SE,
+                             const TargetTransformInfo &TTI,
+                             std::optional<unsigned> UserCount);
 
 bool computeStripMineCount(Loop *L, const TargetTransformInfo &TTI,
                            InstructionCost LoopCost,

--- a/llvm/include/llvm/Transforms/Tapir/TapirLoopInfo.h
+++ b/llvm/include/llvm/Transforms/Tapir/TapirLoopInfo.h
@@ -13,10 +13,9 @@
 #ifndef TAPIR_LOOP_INFO_H_
 #define TAPIR_LOOP_INFO_H_
 
+#include "llvm/ADT/MapVector.h"
 #include "llvm/Analysis/LoopInfo.h"
 #include "llvm/Analysis/TapirTaskInfo.h"
-#include "llvm/ADT/MapVector.h"
-#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/ValueHandle.h"
 #include "llvm/Transforms/Tapir/LoweringUtils.h"
@@ -83,10 +82,10 @@ public:
   Task *getTask() const { return TheTask; }
 
   /// Top-level call to prepare a Tapir loop for outlining.
-  bool prepareForOutlining(
-    DominatorTree &DT, LoopInfo &LI, TaskInfo &TI,
-    PredicatedScalarEvolution &PSE, AssumptionCache &AC, const char *PassName,
-    OptimizationRemarkEmitter &ORE, const TargetTransformInfo &TTI);
+  bool prepareForOutlining(DominatorTree &DT, LoopInfo &LI, TaskInfo &TI,
+                           PredicatedScalarEvolution &PSE, AssumptionCache &AC,
+                           const char *PassName, OptimizationRemarkEmitter &ORE,
+                           const TargetTransformInfo &TTI);
 
   /// Gather all induction variables in this loop that need special handling
   /// during outlining.
@@ -146,9 +145,7 @@ public:
   Type *getWidestInductionType() const { return WidestIndTy; }
 
   /// Returns true if there is a primary induction variable for this Tapir loop.
-  bool hasPrimaryInduction() const {
-    return (nullptr != PrimaryInduction);
-  }
+  bool hasPrimaryInduction() const { return (nullptr != PrimaryInduction); }
 
   /// Get the primary induction variable for this Tapir loop.
   const std::pair<PHINode *, InductionDescriptor> &getPrimaryInduction() const {
@@ -162,6 +159,10 @@ public:
   /// Get the grainsize associated with this Tapir Loop.  A return value of 0
   /// indicates the absence of a specified grainsize.
   unsigned getGrainsize() const { return Grainsize; }
+
+  /// Get the grainsize bound associated with this Tapir Loop.  A return value
+  /// of 0 indicates the absence of a specified grainsize bound.
+  unsigned getGrainsizeBound() const { return GrainsizeBound; }
 
   /// Get the exit block assoicated with this Tapir loop.
   BasicBlock *getExitBlock() const { return ExitBlock; }
@@ -235,6 +236,11 @@ private:
   /// Tapir's grainsize intrinsic should be used.
   unsigned Grainsize = 0;
 
+  /// Grainsize bound to use for loop, if no exact grainsize is available.  A
+  /// value of 0 indicates that the runtime system's default grainsize bound
+  /// should be used.
+  unsigned GrainsizeBound = 0;
+
 public:
   /// Placeholder argument values.
   Argument *StartIterArg = nullptr;
@@ -244,10 +250,10 @@ public:
 
 /// Transforms an induction descriptor into a direct computation of its value at
 /// Index.
-Value *emitTransformedIndex(
-    IRBuilder<> &B, Value *Index, ScalarEvolution *SE, const DataLayout &DL,
-    const InductionDescriptor &ID);
+Value *emitTransformedIndex(IRBuilder<> &B, Value *Index, ScalarEvolution *SE,
+                            const DataLayout &DL,
+                            const InductionDescriptor &ID);
 
-}  // end namepsace llvm
+} // namespace llvm
 
 #endif

--- a/llvm/include/llvm/Transforms/Utils/TapirUtils.h
+++ b/llvm/include/llvm/Transforms/Utils/TapirUtils.h
@@ -274,7 +274,7 @@ public:
   };
 
 private:
-  enum HintKind { HK_STRATEGY, HK_GRAINSIZE };
+  enum HintKind { HK_STRATEGY, HK_GRAINSIZE, HK_GRAINSIZE_BOUND };
 
   /// Hint - associates name and validation with the hint value.
   struct Hint {
@@ -290,6 +290,7 @@ private:
       case HK_STRATEGY:
         return (Val < ST_END);
       case HK_GRAINSIZE:
+      case HK_GRAINSIZE_BOUND:
         return true;
       }
       return false;
@@ -300,13 +301,15 @@ private:
   Hint Strategy;
   /// Grainsize
   Hint Grainsize;
+  /// Grainsize bound
+  Hint GrainsizeBound;
 
   /// Return the loop metadata prefix.
   static StringRef Prefix() { return "tapir.loop."; }
 
 public:
   static std::string printStrategy(enum SpawningStrategy Strat) {
-    switch(Strat) {
+    switch (Strat) {
     case TapirLoopHints::ST_SEQ:
       return "Spawn iterations sequentially";
     case TapirLoopHints::ST_DAC:
@@ -319,26 +322,18 @@ public:
   TapirLoopHints(const Loop *L)
       : Strategy("spawn.strategy", ST_SEQ, HK_STRATEGY),
         Grainsize("grainsize", 0, HK_GRAINSIZE),
-        TheLoop(L) {
+        GrainsizeBound("grainsize.bound", 0, HK_GRAINSIZE_BOUND), TheLoop(L) {
     // Populate values with existing loop metadata.
     getHintsFromMetadata();
   }
-
-  // /// Dumps all the hint information.
-  // std::string emitRemark() const {
-  //   TapirLoopReport R;
-  //   R << "Strategy = " << printStrategy(getStrategy());
-
-  //   return R.str();
-  // }
 
   enum SpawningStrategy getStrategy() const {
     return (SpawningStrategy)Strategy.Value;
   }
 
-  unsigned getGrainsize() const {
-    return Grainsize.Value;
-  }
+  unsigned getGrainsize() const { return Grainsize.Value; }
+
+  unsigned getGrainsizeBound() const { return GrainsizeBound.Value; }
 
   /// Clear Tapir Hints metadata.
   void clearHintsMetadata();
@@ -360,6 +355,12 @@ public:
   void setAlreadyStripMined() {
     Grainsize.Value = 1;
     Hint Hints[] = {Grainsize};
+    writeHintsToMetadata(Hints);
+  }
+
+  void setGrainsizeBound(unsigned V) {
+    GrainsizeBound.Value = V;
+    Hint Hints[] = {GrainsizeBound};
     writeHintsToMetadata(Hints);
   }
 
@@ -398,6 +399,6 @@ MDNode *CopyNonTapirLoopMetadata(MDNode *LoopID, MDNode *OrigLoopID);
 /// if not.
 Task *getTaskIfTapirLoop(const Loop *L, TaskInfo *TI);
 
-} // End llvm namespace
+} // namespace llvm
 
 #endif

--- a/llvm/lib/Analysis/BranchProbabilityInfo.cpp
+++ b/llvm/lib/Analysis/BranchProbabilityInfo.cpp
@@ -1051,6 +1051,24 @@ bool BranchProbabilityInfo::calcFloatingPointHeuristics(const BasicBlock *BB) {
   return true;
 }
 
+bool BranchProbabilityInfo::calcTapirHeuristics(const BasicBlock *BB) {
+  const DetachInst *DI = dyn_cast<DetachInst>(BB->getTerminator());
+  if (!DI)
+    return false;
+
+  uint32_t Denominator = (1 << 14);
+  ProbabilityList ProbList;
+  if (DI->hasUnwindDest())
+    ProbList = ProbabilityList({BranchProbability(Denominator - 2, Denominator),
+                                BranchProbability(1, Denominator),
+                                BranchProbability(1, Denominator)});
+  else
+    ProbList = ProbabilityList({BranchProbability(Denominator - 1, Denominator),
+                                BranchProbability(1, Denominator)});
+  setEdgeProbability(BB, ProbList);
+  return true;
+}
+
 void BranchProbabilityInfo::releaseMemory() {
   Probs.clear();
   Handles.clear();
@@ -1256,6 +1274,8 @@ void BranchProbabilityInfo::calculate(const Function &F, const LoopInfo &LoopI,
     if (BB->getTerminator()->getNumSuccessors() < 2)
       continue;
     if (calcMetadataWeights(BB))
+      continue;
+    if (calcTapirHeuristics(BB))
       continue;
     if (calcEstimatedHeuristics(BB))
       continue;

--- a/llvm/lib/Analysis/WorkSpanAnalysis.cpp
+++ b/llvm/lib/Analysis/WorkSpanAnalysis.cpp
@@ -14,12 +14,15 @@
 
 #include "llvm/Analysis/WorkSpanAnalysis.h"
 #include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/Analysis/BlockFrequencyInfo.h"
 #include "llvm/Analysis/CodeMetrics.h"
 #include "llvm/Analysis/LoopInfo.h"
-#include "llvm/Analysis/ProfileSummaryInfo.h"
+#include "llvm/Analysis/OptimizationRemarkEmitter.h"
 #include "llvm/Analysis/ScalarEvolution.h"
 #include "llvm/Analysis/TargetLibraryInfo.h"
 #include "llvm/Analysis/TargetTransformInfo.h"
+#include "llvm/IR/DiagnosticInfo.h"
+#include "llvm/Support/BlockFrequency.h"
 #include "llvm/Support/InstructionCost.h"
 
 using namespace llvm;
@@ -43,64 +46,130 @@ unsigned llvm::getConstTripCount(const Loop *L, ScalarEvolution &SE) {
 /// Recursive helper routine to estimate the amount of work in a loop.
 static void estimateLoopCostHelper(const Loop *L, CodeMetrics &Metrics,
                                    WSCost &LoopCost, LoopInfo *LI,
-                                   ScalarEvolution *SE) {
+                                   ScalarEvolution *SE, BlockFrequencyInfo *BFI,
+                                   OptimizationRemarkEmitter *ORE) {
   if (LoopCost.UnknownCost)
     return;
 
-  // TODO: Handle control flow within the loop intelligently, using
-  // BlockFrequencyInfo.
+  BlockFrequency LoopEntryFreq =
+      BFI ? BFI->getBlockFreq(L->getHeader()) : BlockFrequency();
   for (Loop *SubL : *L) {
     WSCost SubLoopCost;
-    estimateLoopCostHelper(SubL, Metrics, SubLoopCost, LI, SE);
+    BlockFrequency SubLoopEntryFreq =
+        BFI ? BFI->getBlockFreq(SubL->getHeader()) : BlockFrequency();
+    // Recursively evaluate the cost of the subloop.
+    estimateLoopCostHelper(SubL, Metrics, SubLoopCost, LI, SE, BFI, ORE);
+    int64_t TripCount = 1;
+
+    if (LoopEntryFreq.getFrequency() && SubLoopEntryFreq.getFrequency()) {
+      // Use block frequencies to scale the cost of the subloop.
+      if (ORE)
+        ORE->emit([&]() {
+          return OptimizationRemarkAnalysis(
+                     "work-span-analysis", "BFISubloopCost",
+                     SubL->getStartLoc(), SubL->getHeader())
+                 << "Using block-frequency analysis to estimate contribution "
+                    "of subloop.  Subloop-entry frequency in loop is "
+                 << ore::NV("SubloopFreq", SubLoopEntryFreq.getFrequency() /
+                                               LoopEntryFreq.getFrequency())
+                 << ".";
+        });
+      if (SubLoopEntryFreq < LoopEntryFreq) {
+        // Scale down the work of the subloop to lower its contribution to this
+        // loop's work.
+        SubLoopCost.Work /=
+            (LoopEntryFreq.getFrequency() / SubLoopEntryFreq.getFrequency());
+      } else if (SubLoopEntryFreq > LoopEntryFreq) {
+        // Scale up the subloop trip count to raise its contribution to this
+        // loop's work.
+        TripCount =
+            SubLoopEntryFreq.getFrequency() / LoopEntryFreq.getFrequency();
+      }
+    } else {
+      // Try to find a constant trip count for this loop.
+      TripCount = SE ? getConstTripCount(SubL, *SE) : 0;
+      if (!TripCount) {
+        if (ORE)
+          ORE->emit([&]() {
+            return OptimizationRemarkAnalysis(
+                       "work-span-analysis", "NoConstTripCount",
+                       SubL->getStartLoc(), SubL->getHeader())
+                   << "Could not determine constant trip count for subloop.";
+          });
+        // Could not compute a constant trip count.  Assume this subloop
+        // executes once.
+        LoopCost.UnknownCost = true;
+        TripCount = 1;
+      }
+    }
+
+    if (LoopEntryFreq.getFrequency() && SubLoopEntryFreq.getFrequency() &&
+        SubLoopEntryFreq < LoopEntryFreq)
+      SubLoopCost.Work /=
+          (LoopEntryFreq.getFrequency() / SubLoopEntryFreq.getFrequency());
     // Quit early if the size of this subloop is already too big.
     if (InstructionCost::getMax() == SubLoopCost.Work)
       LoopCost.Work = InstructionCost::getMax();
 
-    // Find a constant trip count if available
-    int64_t ConstTripCount = SE ? getConstTripCount(SubL, *SE) : 0;
-    // TODO: Use a more precise analysis to account for non-constant trip
-    // counts.
-    if (!ConstTripCount) {
-      LoopCost.UnknownCost = true;
-      // If we cannot compute a constant trip count, assume this subloop
-      // executes at least once.
-      ConstTripCount = 1;
+    // Check if this subloop suffices to make this loop huge.
+    if (InstructionCost::getMax() - LoopCost.Work <
+        (SubLoopCost.Work * TripCount)) {
+      if (ORE)
+        ORE->emit([&]() {
+          return OptimizationRemarkAnalysis("work-span-analysis",
+                                            "LargeSubloop", SubL->getStartLoc(),
+                                            SubL->getHeader())
+                 << "Subloop work makes this loop large.";
+        });
+      LoopCost.Work = InstructionCost::getMax();
+      return;
     }
 
-    // Check if the total size of this subloop is huge.
-    if (InstructionCost::getMax() / ConstTripCount < SubLoopCost.Work)
-      LoopCost.Work = InstructionCost::getMax();
-
-    // Check if this subloop suffices to make loop L huge.
-    if (InstructionCost::getMax() - LoopCost.Work <
-        (SubLoopCost.Work * ConstTripCount))
-      LoopCost.Work = InstructionCost::getMax();
-
-    // Add in the size of this subloop.
-    LoopCost.Work += (SubLoopCost.Work * ConstTripCount);
+    if (LoopCost.Work < InstructionCost::getMax())
+      // Add in the work of this subloop scaled by its trip count.
+      LoopCost.Work += (SubLoopCost.Work * TripCount);
   }
 
-  // After looking at all subloops, if we've concluded we have a huge loop size,
-  // return early.
-  if (InstructionCost::getMax() == LoopCost.Work)
-    return;
-
-  for (BasicBlock *BB : L->blocks())
+  // Add in the work of all other blocks in this loop that are not in some
+  // subloop.
+  for (BasicBlock *BB : L->blocks()) {
     if (LI->getLoopFor(BB) == L) {
+      InstructionCost BBCost = Metrics.NumBBInsts[BB];
+      BlockFrequency BBFreq = BFI ? BFI->getBlockFreq(BB) : BlockFrequency();
+      if (LoopEntryFreq.getFrequency() && BBFreq.getFrequency() &&
+          BBFreq < LoopEntryFreq) {
+        // Scale this basic-block cost by its relative frequency.
+        BBCost /= (LoopEntryFreq.getFrequency() / BBFreq.getFrequency());
+      }
       // Check if this BB suffices to make loop L huge.
-      if (InstructionCost::getMax() - LoopCost.Work < Metrics.NumBBInsts[BB]) {
+      if (InstructionCost::getMax() - LoopCost.Work < BBCost) {
+        if (ORE)
+          ORE->emit([&]() {
+            return OptimizationRemarkAnalysis("work-span-analysis", "LargeLoop",
+                                              L->getStartLoc(), BB)
+                   << "Loop contains a lot of work.";
+          });
         LoopCost.Work = InstructionCost::getMax();
         return;
       }
-      LoopCost.Work += Metrics.NumBBInsts[BB];
+      LoopCost.Work += BBCost;
     }
+  }
+
+  if (ORE)
+    ORE->emit([&]() {
+      return OptimizationRemarkAnalysis("work-span-analysis", "LargeSubloop",
+                                        L->getStartLoc(), L->getHeader())
+             << "Estimated loop work: " << ore::NV("LoopWork", LoopCost.Work)
+             << ".";
+    });
 }
 
 void llvm::estimateLoopCost(WSCost &LoopCost, const Loop *L, LoopInfo *LI,
                             ScalarEvolution *SE, const TargetTransformInfo &TTI,
-                            TargetLibraryInfo *TLI,
-                            const SmallPtrSetImpl<const Value *> &EphValues) {
-  // TODO: Use more precise analysis to estimate the work in each call.
+                            TargetLibraryInfo *TLI, BlockFrequencyInfo *BFI,
+                            const SmallPtrSetImpl<const Value *> &EphValues,
+                            OptimizationRemarkEmitter *ORE) {
   // TODO: Use vectorizability to enhance cost analysis.
 
   // Gather code metrics for all basic blocks in the loop.
@@ -108,5 +177,5 @@ void llvm::estimateLoopCost(WSCost &LoopCost, const Loop *L, LoopInfo *LI,
     LoopCost.Metrics.analyzeBasicBlock(BB, TTI, EphValues,
                                        /*PrepareForLTO*/ false, L, TLI);
 
-  estimateLoopCostHelper(L, LoopCost.Metrics, LoopCost, LI, SE);
+  estimateLoopCostHelper(L, LoopCost.Metrics, LoopCost, LI, SE, BFI, ORE);
 }

--- a/llvm/lib/Transforms/Tapir/LoopSpawningTI.cpp
+++ b/llvm/lib/Transforms/Tapir/LoopSpawningTI.cpp
@@ -1147,9 +1147,16 @@ static Value *computeGrainsize(TapirLoopInfo *TL) {
   Module *M = Preheader->getModule();
   IRBuilder<> B(Preheader->getTerminator());
   B.SetCurrentDebugLocation(TL->getDebugLoc());
+  // Determine the grainsize runtime bound
+  unsigned GrainsizeBound = TL->getGrainsizeBound();
+  // Make sure the grainsize bound fits in the available bit width.
+  if (IdxTy->getIntegerBitWidth() < 8 * sizeof(unsigned))
+    if (GrainsizeBound > (1 << IdxTy->getIntegerBitWidth()) - 1)
+      GrainsizeBound = (1 << IdxTy->getIntegerBitWidth()) - 1;
+  Value *GrainBoundVal = ConstantInt::get(IdxTy, GrainsizeBound);
   return B.CreateCall(Intrinsic::getOrInsertDeclaration(
                           M, Intrinsic::tapir_loop_grainsize, {IdxTy}),
-                      {TripCount});
+                      {TripCount, GrainBoundVal});
 }
 
 /// Get the grainsize of this loop either from metadata or by computing the

--- a/llvm/lib/Transforms/Tapir/LoopStripMine.cpp
+++ b/llvm/lib/Transforms/Tapir/LoopStripMine.cpp
@@ -54,8 +54,8 @@ static cl::opt<unsigned> StripMineCoarseningFactor(
     cl::desc("Use this coarsening factor for stripmining"));
 
 static cl::opt<bool> StripMineUnrollRemainder(
-  "stripmine-unroll-remainder", cl::Hidden,
-  cl::desc("Allow the loop remainder after stripmining to be unrolled."));
+    "stripmine-unroll-remainder", cl::Hidden,
+    cl::desc("Allow the loop remainder after stripmining to be unrolled."));
 
 /// Constants for stripmining cost analysis.
 namespace StripMineConstants {
@@ -144,17 +144,19 @@ void llvm::simplifyLoopAfterStripMine(Loop *L, bool SimplifyIVs, LoopInfo *LI,
 
 /// Gather the various unrolling parameters based on the defaults, compiler
 /// flags, TTI overrides and user specified parameters.
-TargetTransformInfo::StripMiningPreferences llvm::gatherStripMiningPreferences(
-    Loop *L, ScalarEvolution &SE, const TargetTransformInfo &TTI,
-    std::optional<unsigned> UserCount) {
+TargetTransformInfo::StripMiningPreferences
+llvm::gatherStripMiningPreferences(Loop *L, ScalarEvolution &SE,
+                                   const TargetTransformInfo &TTI,
+                                   std::optional<unsigned> UserCount) {
   TargetTransformInfo::StripMiningPreferences SMP;
 
   // Set up the defaults
   SMP.Count = 0;
   SMP.AllowExpensiveTripCount = false;
   SMP.DefaultCoarseningFactor =
-    (StripMineCoarseningFactor.getNumOccurrences() > 0) ?
-    StripMineCoarseningFactor : StripMineConstants::DefaultCoarseningFactor;
+      (StripMineCoarseningFactor.getNumOccurrences() > 0)
+          ? StripMineCoarseningFactor
+          : StripMineConstants::DefaultCoarseningFactor;
   SMP.UnrollRemainder = false;
 
   // Override with any target specific settings
@@ -232,8 +234,8 @@ static Task *getTapirLoopForStripMining(const Loop *L, TaskInfo &TI,
 
   BasicBlock *Preheader = L->getLoopPreheader();
   if (!Preheader) {
-    LLVM_DEBUG(dbgs()
-               << "  Can't stripmine: loop preheader-insertion failed.\n");
+    LLVM_DEBUG(
+        dbgs() << "  Can't stripmine: loop preheader-insertion failed.\n");
     if (ORE)
       ORE->emit(TapirLoopInfo::createMissedAnalysis(LSM_NAME, "NoPreheader", L)
                 << "loop lacks a preheader");
@@ -244,8 +246,8 @@ static Task *getTapirLoopForStripMining(const Loop *L, TaskInfo &TI,
 
   BasicBlock *LatchBlock = L->getLoopLatch();
   if (!LatchBlock) {
-    LLVM_DEBUG(dbgs()
-               << "  Can't stripmine: loop exit-block-insertion failed.\n");
+    LLVM_DEBUG(
+        dbgs() << "  Can't stripmine: loop exit-block-insertion failed.\n");
     if (ORE)
       ORE->emit(TapirLoopInfo::createMissedAnalysis(LSM_NAME, "NoLatch", L)
                 << "loop lacks a latch");
@@ -256,9 +258,9 @@ static Task *getTapirLoopForStripMining(const Loop *L, TaskInfo &TI,
   if (!L->isSafeToClone()) {
     LLVM_DEBUG(dbgs() << "  Can't stripmine: loop body cannot be cloned.\n");
     if (ORE)
-      ORE->emit(TapirLoopInfo::createMissedAnalysis(LSM_NAME, "UnsafeToClone",
-                                                    L)
-                << "loop is not safe to clone");
+      ORE->emit(
+          TapirLoopInfo::createMissedAnalysis(LSM_NAME, "UnsafeToClone", L)
+          << "loop is not safe to clone");
     return nullptr;
   }
 
@@ -285,9 +287,9 @@ static Task *getTapirLoopForStripMining(const Loop *L, TaskInfo &TI,
         dbgs()
         << "  Can't stripmine: loop not terminated by a conditional branch.\n");
     if (ORE)
-      ORE->emit(TapirLoopInfo::createMissedAnalysis(LSM_NAME, "NoLatchBranch",
-                                                    L)
-                << "loop latch is not terminated by a conditional branch");
+      ORE->emit(
+          TapirLoopInfo::createMissedAnalysis(LSM_NAME, "NoLatchBranch", L)
+          << "loop latch is not terminated by a conditional branch");
     return nullptr;
   }
 
@@ -300,21 +302,20 @@ static Task *getTapirLoopForStripMining(const Loop *L, TaskInfo &TI,
     LLVM_DEBUG(dbgs() << "  Can't stripmine: only loops with one conditional"
                          " latch exiting the loop can be stripmined.\n");
     if (ORE)
-      ORE->emit(TapirLoopInfo::createMissedAnalysis(LSM_NAME,
-                                                    "ComplexLatchBranch", L)
-                << "loop has multiple exiting conditional latches");
+      ORE->emit(
+          TapirLoopInfo::createMissedAnalysis(LSM_NAME, "ComplexLatchBranch", L)
+          << "loop has multiple exiting conditional latches");
     return nullptr;
   }
 
   if (Header->hasAddressTaken()) {
     // The loop-rotate pass can be helpful to avoid this in many cases.
-    LLVM_DEBUG(
-        dbgs() << "  Won't stripmine loop: address of header block is "
-        "taken.\n");
+    LLVM_DEBUG(dbgs() << "  Won't stripmine loop: address of header block is "
+                         "taken.\n");
     if (ORE)
-      ORE->emit(TapirLoopInfo::createMissedAnalysis(LSM_NAME,
-                                                    "HeaderAddressTaken", L)
-                << "loop header block has address taken");
+      ORE->emit(
+          TapirLoopInfo::createMissedAnalysis(LSM_NAME, "HeaderAddressTaken", L)
+          << "loop header block has address taken");
     return nullptr;
   }
 
@@ -323,9 +324,8 @@ static Task *getTapirLoopForStripMining(const Loop *L, TaskInfo &TI,
     for (auto &I : *BB)
       if (CallBase *CB = dyn_cast<CallBase>(&I))
         if (CB->isConvergent()) {
-          LLVM_DEBUG(
-              dbgs() << "  Won't stripmine loop: contains convergent "
-              "attribute.\n");
+          LLVM_DEBUG(dbgs() << "  Won't stripmine loop: contains convergent "
+                               "attribute.\n");
           if (ORE)
             ORE->emit(TapirLoopInfo::createMissedAnalysis(LSM_NAME,
                                                           "ConvergentLoop", L)
@@ -377,10 +377,11 @@ static void connectEpilog(TapirLoopInfo &TL, Value *EpilStartIter,
     // Compute the value of this induction at NewExit.
     const InductionDescriptor &II = InductionEntry.second;
     // Get the new step value for this Phi.
-    Value *PhiIter = !II.getStep()->getType()->isIntegerTy()
-      ? B.CreateCast(Instruction::SIToFP, EpilStartIter,
-                     II.getStep()->getType())
-      : B.CreateSExtOrTrunc(EpilStartIter, II.getStep()->getType());
+    Value *PhiIter =
+        !II.getStep()->getType()->isIntegerTy()
+            ? B.CreateCast(Instruction::SIToFP, EpilStartIter,
+                           II.getStep()->getType())
+            : B.CreateSExtOrTrunc(EpilStartIter, II.getStep()->getType());
     Value *NewPhiStart = emitTransformedIndex(B, PhiIter, SE, DL, II);
 
     // Update the PHI node in the epilog loop.
@@ -393,7 +394,7 @@ static void connectEpilog(TapirLoopInfo &TL, Value *EpilStartIter,
   Value *BrLoopExit = B.CreateIsNotNull(ModVal, "lcmp.mod");
   assert(Exit && "Loop must have a single exit block only");
   // Split the epilogue exit to maintain loop canonicalization guarantees
-  SmallVector<BasicBlock*, 4> Preds(predecessors(Exit));
+  SmallVector<BasicBlock *, 4> Preds(predecessors(Exit));
   SplitBlockPredecessors(Exit, Preds, ".epilog-lcssa", DT, LI, nullptr,
                          PreserveLCSSA);
   // Add the branch to the exit block (around the stripmining loop)
@@ -403,7 +404,7 @@ static void connectEpilog(TapirLoopInfo &TL, Value *EpilStartIter,
     DT->changeImmediateDominator(Exit, NewExit);
 
   // Split the main loop exit to maintain canonicalization guarantees.
-  SmallVector<BasicBlock*, 4> NewExitPreds{LoopDet};
+  SmallVector<BasicBlock *, 4> NewExitPreds{LoopDet};
   if (LoopEnd != NewExit)
     NewExitPreds.push_back(LoopEnd);
   SplitBlockPredecessors(NewExit, NewExitPreds, ".loopexit", DT, LI, nullptr,
@@ -828,7 +829,7 @@ Loop *llvm::StripMineLoop(Loop *L, unsigned Count, bool AllowExpensiveTripCount,
   // We will use the increment of the primary induction variable to derive
   // wrapping flags.
   Instruction *PrimaryInc =
-    cast<Instruction>(PrimaryInduction->getIncomingValueForBlock(Latch));
+      cast<Instruction>(PrimaryInduction->getIncomingValueForBlock(Latch));
 
   // Get all uses of the primary induction variable in the task.
   SmallVector<Use *, 4> PrimaryInductionUsesInTask;
@@ -851,7 +852,7 @@ Loop *llvm::StripMineLoop(Loop *L, unsigned Count, bool AllowExpensiveTripCount,
   }
 
   unsigned BEWidth =
-    cast<IntegerType>(TL.getWidestInductionType())->getBitWidth();
+      cast<IntegerType>(TL.getWidestInductionType())->getBitWidth();
 
   // Add 1 since the backedge count doesn't include the first loop iteration.
   const SCEV *TripCountSC = TL.getExitCount(BECountSC, PSE);
@@ -904,9 +905,9 @@ Loop *llvm::StripMineLoop(Loop *L, unsigned Count, bool AllowExpensiveTripCount,
     NewPreheader = SplitBlock(Preheader, Preheader->getTerminator(), DT, LI);
     NewPreheader->setName(Preheader->getName() + ".new");
     // Split LatchExit to create phi nodes from branch above.
-    SmallVector<BasicBlock*, 4> Preds(predecessors(LatchExit));
-    NewExit = SplitBlockPredecessors(LatchExit, Preds, ".strpm-lcssa",
-                                     DT, LI, nullptr, PreserveLCSSA);
+    SmallVector<BasicBlock *, 4> Preds(predecessors(LatchExit));
+    NewExit = SplitBlockPredecessors(LatchExit, Preds, ".strpm-lcssa", DT, LI,
+                                     nullptr, PreserveLCSSA);
     // NewExit gets its DebugLoc from LatchExit, which is not part of the
     // original Loop.
     // Fix this by setting Loop's DebugLoc to NewExit.
@@ -922,8 +923,8 @@ Loop *llvm::StripMineLoop(Loop *L, unsigned Count, bool AllowExpensiveTripCount,
   // Compute the number of extra iterations required, which is:
   //  extra iterations = run-time trip count % loop stripmine factor
   PreheaderBR = cast<BranchInst>(Preheader->getTerminator());
-  Value *BECount = Expander.expandCodeFor(BECountSC, BECountSC->getType(),
-                                          PreheaderBR);
+  Value *BECount =
+      Expander.expandCodeFor(BECountSC, BECountSC->getType(), PreheaderBR);
 
   // Loop structure should be the following:
   //  Epilog
@@ -958,16 +959,14 @@ Loop *llvm::StripMineLoop(Loop *L, unsigned Count, bool AllowExpensiveTripCount,
   } else {
     // As (BECount + 1) can potentially unsigned overflow we count
     // (BECount % Count) + 1 which is overflow safe as BECount % Count < Count.
-    Value *ModValTmp = B.CreateURem(BECount,
-                                    ConstantInt::get(BECount->getType(),
-                                                     Count));
-    Value *ModValAdd = B.CreateAdd(ModValTmp,
-                                   ConstantInt::get(ModValTmp->getType(), 1));
+    Value *ModValTmp =
+        B.CreateURem(BECount, ConstantInt::get(BECount->getType(), Count));
+    Value *ModValAdd =
+        B.CreateAdd(ModValTmp, ConstantInt::get(ModValTmp->getType(), 1));
     // At that point (BECount % Count) + 1 could be equal to Count.
     // To handle this case we need to take mod by Count one more time.
-    ModVal = B.CreateURem(ModValAdd,
-                          ConstantInt::get(BECount->getType(), Count),
-                          "xtraiter");
+    ModVal = B.CreateURem(
+        ModValAdd, ConstantInt::get(BECount->getType(), Count), "xtraiter");
   }
   Value *BranchVal = B.CreateICmpSLT(
       BECount, ConstantInt::get(BECount->getType(),
@@ -1129,22 +1128,22 @@ Loop *llvm::StripMineLoop(Loop *L, unsigned Count, bool AllowExpensiveTripCount,
   Module *M = F->getParent();
   if (ParallelEpilog) {
     ORE->emit([&]() {
-                return OptimizationRemark(LSM_NAME, "ParallelEpil",
-                                          L->getStartLoc(), L->getHeader())
-                  << "allowing epilog to execute in parallel with stripmined "
-                  << "loop";
-              });
-    BasicBlock *LoopDetach = SplitBlock(NewPreheader,
-                                        NewPreheader->getTerminator(), DT, LI);
+      return OptimizationRemark(LSM_NAME, "ParallelEpil", L->getStartLoc(),
+                                L->getHeader())
+             << "allowing epilog to execute in parallel with stripmined "
+             << "loop";
+    });
+    BasicBlock *LoopDetach =
+        SplitBlock(NewPreheader, NewPreheader->getTerminator(), DT, LI);
     LoopDetach->setName(NewPreheader->getName() + ".strpm.detachloop");
     {
-      SmallVector<BasicBlock*, 4> HeaderPreds;
+      SmallVector<BasicBlock *, 4> HeaderPreds;
       for (BasicBlock *Pred : predecessors(Header))
         if (Pred != Latch)
           HeaderPreds.push_back(Pred);
       LoopDetEntry =
-        SplitBlockPredecessors(Header, HeaderPreds, ".strpm.detachloop.entry",
-                               DT, LI, nullptr, PreserveLCSSA);
+          SplitBlockPredecessors(Header, HeaderPreds, ".strpm.detachloop.entry",
+                                 DT, LI, nullptr, PreserveLCSSA);
       NewSyncReg = CallInst::Create(
           Intrinsic::getOrInsertDeclaration(M, Intrinsic::syncregion_start), {},
           LoopDetEntry->getFirstInsertionPt());
@@ -1164,9 +1163,9 @@ Loop *llvm::StripMineLoop(Loop *L, unsigned Count, bool AllowExpensiveTripCount,
       // Insert a detach instruction to detach the stripmined loop.  We do this
       // early to simplify the operation of nesting the exception-handling code
       // in the task.
-      ReplaceInstWithInst(LoopDetach->getTerminator(),
-                          DetachInst::Create(LoopDetEntry, NewExit,
-                                             EHCont, SyncReg));
+      ReplaceInstWithInst(
+          LoopDetach->getTerminator(),
+          DetachInst::Create(LoopDetEntry, NewExit, EHCont, SyncReg));
       // Update the dominator tree to reflect LoopDetach as a new predecessor of
       // EHCont.
       BasicBlock *OldIDom = DT->getNode(EHCont)->getIDom()->getBlock();
@@ -1229,24 +1228,22 @@ Loop *llvm::StripMineLoop(Loop *L, unsigned Count, bool AllowExpensiveTripCount,
   // Move the detach/reattach instructions to surround the stripmined loop.
   BasicBlock *NewHeader;
   {
-    SmallVector<BasicBlock*, 4> HeaderPreds;
+    SmallVector<BasicBlock *, 4> HeaderPreds;
     for (BasicBlock *Pred : predecessors(Header))
       if (Pred != Latch)
         HeaderPreds.push_back(Pred);
-    NewHeader =
-      SplitBlockPredecessors(Header, HeaderPreds, ".strpm.outer",
-                             DT, LI, nullptr, PreserveLCSSA);
+    NewHeader = SplitBlockPredecessors(Header, HeaderPreds, ".strpm.outer", DT,
+                                       LI, nullptr, PreserveLCSSA);
   }
   BasicBlock *NewEntry =
-    SplitBlock(NewHeader, NewHeader->getTerminator(), DT, LI);
+      SplitBlock(NewHeader, NewHeader->getTerminator(), DT, LI);
   NewEntry->setName(TaskEntry->getName() + ".strpm.outer");
   SmallVector<BasicBlock *, 1> LoopReattachPreds{Latch};
-  BasicBlock *NewReattB =
-    SplitBlockPredecessors(LoopReattach, LoopReattachPreds, "", DT, LI,
-                           nullptr, PreserveLCSSA);
+  BasicBlock *NewReattB = SplitBlockPredecessors(
+      LoopReattach, LoopReattachPreds, "", DT, LI, nullptr, PreserveLCSSA);
   NewReattB->setName(Latch->getName() + ".reattach");
   BasicBlock *NewLatch =
-    SplitBlock(NewReattB, NewReattB->getTerminator(), DT, LI);
+      SplitBlock(NewReattB, NewReattB->getTerminator(), DT, LI);
   NewLatch->setName(Latch->getName() + ".strpm.outer");
 
   // Move static allocas from TaskEntry into NewEntry.
@@ -1255,9 +1252,9 @@ Loop *llvm::StripMineLoop(Loop *L, unsigned Count, bool AllowExpensiveTripCount,
   // Insert a new detach instruction
   BasicBlock *OrigUnwindDest = DI->getUnwindDest();
   if (OrigUnwindDest) {
-    ReplaceInstWithInst(NewHeader->getTerminator(),
-                        DetachInst::Create(NewEntry, NewLatch,
-                                           OrigUnwindDest, NewSyncReg));
+    ReplaceInstWithInst(
+        NewHeader->getTerminator(),
+        DetachInst::Create(NewEntry, NewLatch, OrigUnwindDest, NewSyncReg));
     // Update the PHI nodes in the unwind destination of the detach.
     for (PHINode &PN : OrigUnwindDest->phis())
       PN.setIncomingBlock(PN.getBasicBlockIndex(Header), NewHeader);
@@ -1271,11 +1268,9 @@ Loop *llvm::StripMineLoop(Loop *L, unsigned Count, bool AllowExpensiveTripCount,
     if (ParallelEpilog && NeedNestedSync)
       // We will insert a sync.unwind to OrigUnwindDest, which changes the
       // dominator.
-      NewDomCandidate =
-          DT->findNearestCommonDominator(NewHeader, LoopReattach);
+      NewDomCandidate = DT->findNearestCommonDominator(NewHeader, LoopReattach);
     while (OrigDUBB && (OrigDUBB != EHCont)) {
-      BasicBlock *OldIDom =
-        DT->getNode(OrigDUBB)->getIDom()->getBlock();
+      BasicBlock *OldIDom = DT->getNode(OrigDUBB)->getIDom()->getBlock();
       DT->changeImmediateDominator(
           OrigDUBB, DT->findNearestCommonDominator(OldIDom, NewDomCandidate));
       // Get the next block along the path.  If we reach the end of the path at
@@ -1339,9 +1334,8 @@ Loop *llvm::StripMineLoop(Loop *L, unsigned Count, bool AllowExpensiveTripCount,
   //
   // TODO: Generalize to handle non-power-of-2 counts.
   assert(isPowerOf2_32(Count) && "Count is not a power of 2.");
-  Value *TestVal = B2.CreateUDiv(TripCount,
-                                 ConstantInt::get(TripCount->getType(), Count),
-                                 "stripiter");
+  Value *TestVal = B2.CreateUDiv(
+      TripCount, ConstantInt::get(TripCount->getType(), Count), "stripiter");
   // Value *TestVal = B2.CreateSub(TripCount, ModVal, "stripiter", true, true);
 
   // Value *TestCmp = B2.CreateICmpUGT(TestVal,
@@ -1377,8 +1371,7 @@ Loop *llvm::StripMineLoop(Loop *L, unsigned Count, bool AllowExpensiveTripCount,
   // Value *IdxCmp = B2.CreateIsNull(IdxSub, NewIdx->getName() + ".ncmp");
   NewIdx->addIncoming(ConstantInt::get(TestVal->getType(), 0), LoopDetEntry);
   NewIdx->addIncoming(IdxAdd, NewLatch);
-  Value *IdxCmp = B2.CreateICmpEQ(IdxAdd, TestVal,
-                                  NewIdx->getName() + ".ncmp");
+  Value *IdxCmp = B2.CreateICmpEQ(IdxAdd, TestVal, NewIdx->getName() + ".ncmp");
   ReplaceInstWithInst(NewLatch->getTerminator(),
                       BranchInst::Create(LoopReattach, NewHeader, IdxCmp));
   DT->changeImmediateDominator(NewLatch, NewHeader);
@@ -1398,7 +1391,7 @@ Loop *llvm::StripMineLoop(Loop *L, unsigned Count, bool AllowExpensiveTripCount,
   // If necessary, add the nested sync right before LoopReattach.
   if (ParallelEpilog && NeedNestedSync) {
     BasicBlock *NewLoopReattach =
-      SplitBlock(LoopReattach, LoopReattach->getTerminator(), DT, LI);
+        SplitBlock(LoopReattach, LoopReattach->getTerminator(), DT, LI);
     BasicBlock *NestedSyncBlock = LoopReattach;
     LoopReattach = NewLoopReattach;
     NestedSyncBlock->setName(Header->getName() + ".strpm.detachloop.sync");
@@ -1407,8 +1400,8 @@ Loop *llvm::StripMineLoop(Loop *L, unsigned Count, bool AllowExpensiveTripCount,
     if (!OrigUnwindDest && F->doesNotThrow()) {
       // Insert a call to sync.unwind.
       CallInst *SyncUnwind = CallInst::Create(
-          Intrinsic::getOrInsertDeclaration(M, Intrinsic::sync_unwind), { NewSyncReg },
-          "", LoopReattach->getFirstNonPHIOrDbg());
+          Intrinsic::getOrInsertDeclaration(M, Intrinsic::sync_unwind),
+          {NewSyncReg}, "", LoopReattach->getFirstNonPHIOrDbg());
       // If the Tapir loop has an unwind destination, change the sync.unwind to
       // an invoke that unwinds to the cloned unwind destination.
       if (OrigUnwindDest) {
@@ -1461,8 +1454,7 @@ Loop *llvm::StripMineLoop(Loop *L, unsigned Count, bool AllowExpensiveTripCount,
   // Update all of the old PHI nodes
   B2.SetInsertPoint(NewEntry->getTerminator());
   Instruction *CountVal = cast<Instruction>(
-      B2.CreateMul(ConstantInt::get(NewIdx->getType(), Count),
-                   NewIdx));
+      B2.CreateMul(ConstantInt::get(NewIdx->getType(), Count), NewIdx));
   CountVal->copyIRFlags(PrimaryInduction);
   for (auto &InductionEntry : *TL.getInductionVars()) {
     PHINode *OrigPhi = InductionEntry.first;
@@ -1471,10 +1463,11 @@ Loop *llvm::StripMineLoop(Loop *L, unsigned Count, bool AllowExpensiveTripCount,
       // Nothing to do for this Phi
       continue;
     // Get the new step value for this Phi.
-    Value *PhiCount = !II.getStep()->getType()->isIntegerTy()
-      ? B2.CreateCast(Instruction::SIToFP, CountVal,
-                      II.getStep()->getType())
-      : B2.CreateSExtOrTrunc(CountVal, II.getStep()->getType());
+    Value *PhiCount =
+        !II.getStep()->getType()->isIntegerTy()
+            ? B2.CreateCast(Instruction::SIToFP, CountVal,
+                            II.getStep()->getType())
+            : B2.CreateSExtOrTrunc(CountVal, II.getStep()->getType());
     Value *NewStart = emitTransformedIndex(B2, PhiCount, SE, DL, II);
 
     // Get the old increment instruction for this Phi
@@ -1520,10 +1513,9 @@ Loop *llvm::StripMineLoop(Loop *L, unsigned Count, bool AllowExpensiveTripCount,
   // by the power-of-2 count to simplify the SCEV's of the induction variables
   // for later analysis passes.
   // Value *EpilStartIter = B2.CreateSub(TripCount, ModVal);
-  Value *EpilStartIter =
-    B2.CreateMul(B2.CreateUDiv(TripCount,
-                               ConstantInt::get(TripCount->getType(), Count)),
-                 ConstantInt::get(TripCount->getType(), Count));
+  Value *EpilStartIter = B2.CreateMul(
+      B2.CreateUDiv(TripCount, ConstantInt::get(TripCount->getType(), Count)),
+      ConstantInt::get(TripCount->getType(), Count));
   if (Instruction *ESIInst = dyn_cast<Instruction>(EpilStartIter))
     ESIInst->copyIRFlags(PrimaryInc);
   connectEpilog(TL, EpilStartIter, ModVal, EpilogPred, LoopReattach, NewExit,

--- a/llvm/lib/Transforms/Tapir/LoopStripMine.cpp
+++ b/llvm/lib/Transforms/Tapir/LoopStripMine.cpp
@@ -217,7 +217,8 @@ bool llvm::computeStripMineCount(
                                       TargetTransformInfo::TCK_SizeAndLatency) /
                LoopCost)
                   .getValue();
-
+  // Make sure the stripmine count is at least 1.
+  SMP.Count |= (SMP.Count == 0);
   return false;
 }
 
@@ -880,11 +881,11 @@ Loop *llvm::StripMineLoop(Loop *L, unsigned Count, bool AllowExpensiveTripCount,
   LLVM_DEBUG(dbgs() << "Stripmining loop using grainsize " << Count << "\n");
   using namespace ore;
   ORE->emit([&]() {
-              return OptimizationRemark(LSM_NAME, "Stripmined",
-                                        L->getStartLoc(), L->getHeader())
-                << "stripmined loop using count "
-                << NV("StripMineCount", Count);
-            });
+    return OptimizationRemark(LSM_NAME, "Stripmined", L->getStartLoc(),
+                              L->getHeader())
+           << "stripmined loop using grainsize " << NV("StripMineCount", Count)
+           << ".";
+  });
 
   // Loop structure is the following:
   //

--- a/llvm/lib/Transforms/Tapir/LoopStripMinePass.cpp
+++ b/llvm/lib/Transforms/Tapir/LoopStripMinePass.cpp
@@ -13,6 +13,7 @@
 #include "llvm/Transforms/Tapir/LoopStripMinePass.h"
 #include "llvm/ADT/PriorityWorklist.h"
 #include "llvm/Analysis/AssumptionCache.h"
+#include "llvm/Analysis/BlockFrequencyInfo.h"
 #include "llvm/Analysis/CodeMetrics.h"
 #include "llvm/Analysis/LoopAnalysisManager.h"
 #include "llvm/Analysis/LoopInfo.h"
@@ -86,14 +87,14 @@ static OptimizationRemarkAnalysis createMissedAnalysis(StringRef RemarkName,
 /// Approximate the work of the body of the loop L.  Returns several relevant
 /// properties of loop L via by-reference arguments.
 static InstructionCost approximateLoopCost(
-    const Loop *L, unsigned &NumCalls, bool &NotDuplicatable,
-    bool &Convergent, bool &IsRecursive, bool &UnknownSize,
-    const TargetTransformInfo &TTI, LoopInfo *LI, ScalarEvolution &SE,
-    const SmallPtrSetImpl<const Value *> &EphValues,
-    TargetLibraryInfo *TLI) {
+    const Loop *L, unsigned &NumCalls, bool &NotDuplicatable, bool &Convergent,
+    bool &IsRecursive, bool &UnknownSize, const TargetTransformInfo &TTI,
+    LoopInfo *LI, ScalarEvolution &SE,
+    const SmallPtrSetImpl<const Value *> &EphValues, TargetLibraryInfo *TLI,
+    BlockFrequencyInfo *BFI, OptimizationRemarkEmitter *ORE) {
 
   WSCost LoopCost;
-  estimateLoopCost(LoopCost, L, LI, &SE, TTI, TLI, EphValues);
+  estimateLoopCost(LoopCost, L, LI, &SE, TTI, TLI, BFI, EphValues, ORE);
 
   // Exclude calls to builtins when counting the calls.  This assumes that all
   // builtin functions are cheap.
@@ -106,11 +107,14 @@ static InstructionCost approximateLoopCost(
   return LoopCost.Work;
 }
 
-static bool tryToStripMineLoop(
-    Loop *L, DominatorTree &DT, LoopInfo *LI, ScalarEvolution &SE,
-    const TargetTransformInfo &TTI, AssumptionCache &AC, TaskInfo *TI,
-    OptimizationRemarkEmitter &ORE, TargetLibraryInfo *TLI, bool PreserveLCSSA,
-    std::optional<unsigned> ProvidedCount) {
+static bool tryToStripMineLoop(Loop *L, DominatorTree &DT, LoopInfo *LI,
+                               ScalarEvolution &SE,
+                               const TargetTransformInfo &TTI,
+                               AssumptionCache &AC, TaskInfo *TI,
+                               OptimizationRemarkEmitter &ORE,
+                               TargetLibraryInfo *TLI, BlockFrequencyInfo *BFI,
+                               bool PreserveLCSSA,
+                               std::optional<unsigned> ProvidedCount) {
   Task *T = getTaskIfTapirLoopStructure(L, TI);
   if (!T)
     return false;
@@ -119,8 +123,8 @@ static bool tryToStripMineLoop(
   if (TM_Disable == hasLoopStripmineTransformation(L))
     return false;
 
-  LLVM_DEBUG(dbgs() << "Loop Strip Mine: F["
-                    << L->getHeader()->getParent()->getName() << "] Loop %"
+  Function *F = L->getHeader()->getParent();
+  LLVM_DEBUG(dbgs() << "Loop Strip Mine: F[" << F->getName() << "] Loop %"
                     << L->getHeader()->getName() << "\n");
 
   if (!L->isLoopSimplifyForm()) {
@@ -144,7 +148,7 @@ static bool tryToStripMineLoop(
 
   InstructionCost LoopCost =
       approximateLoopCost(L, NumCalls, NotDuplicatable, Convergent, IsRecursive,
-                          UnknownSize, TTI, LI, SE, EphValues, TLI);
+                          UnknownSize, TTI, LI, SE, EphValues, TLI, BFI, &ORE);
   // Determine the iteration count of the eventual stripmined the loop.
   bool ExplicitCount = computeStripMineCount(L, TTI, LoopCost, SMP);
   ORE.emit([&]() {
@@ -358,7 +362,7 @@ public:
     OptimizationRemarkEmitter ORE(&F);
     bool PreserveLCSSA = mustPreserveAnalysisID(LCSSAID);
 
-    return tryToStripMineLoop(L, DT, LI, SE, TTI, AC, TI, ORE, &TLI,
+    return tryToStripMineLoop(L, DT, LI, SE, TTI, AC, TI, ORE, &TLI, nullptr,
                               PreserveLCSSA, ProvidedCount);
   }
 
@@ -403,6 +407,7 @@ PreservedAnalyses LoopStripMinePass::run(Function &F,
   auto &AC = AM.getResult<AssumptionAnalysis>(F);
   auto &TI = AM.getResult<TaskAnalysis>(F);
   auto &ORE = AM.getResult<OptimizationRemarkEmitterAnalysis>(F);
+  auto &BFI = AM.getResult<BlockFrequencyAnalysis>(F);
 
   LoopAnalysisManager *LAM = nullptr;
   if (auto *LAMProxy = AM.getCachedResult<LoopAnalysisManagerFunctionProxy>(F))
@@ -441,7 +446,7 @@ PreservedAnalyses LoopStripMinePass::run(Function &F,
     //   AllowPeeling = false;
     std::string LoopName = std::string(L.getName());
     bool LoopChanged =
-        tryToStripMineLoop(&L, DT, &LI, SE, TTI, AC, &TI, ORE, &TLI,
+        tryToStripMineLoop(&L, DT, &LI, SE, TTI, AC, &TI, ORE, &TLI, &BFI,
                            /*PreserveLCSSA*/ true, /*Count*/ std::nullopt);
     Changed |= LoopChanged;
 

--- a/llvm/lib/Transforms/Tapir/LoopStripMinePass.cpp
+++ b/llvm/lib/Transforms/Tapir/LoopStripMinePass.cpp
@@ -23,6 +23,7 @@
 #include "llvm/Analysis/TargetLibraryInfo.h"
 #include "llvm/Analysis/TargetTransformInfo.h"
 #include "llvm/Analysis/WorkSpanAnalysis.h"
+#include "llvm/IR/DiagnosticInfo.h"
 #include "llvm/IR/PassManager.h"
 #include "llvm/InitializePasses.h"
 #include "llvm/Pass.h"
@@ -79,7 +80,7 @@ static OptimizationRemarkAnalysis createMissedAnalysis(StringRef RemarkName,
     DL = TheLoop->getStartLoc();
 
   return OptimizationRemarkAnalysis(DEBUG_TYPE, RemarkName, DL, CodeRegion)
-         << "loop not stripmined: ";
+         << "Loop not stripmined: ";
 }
 
 /// Approximate the work of the body of the loop L.  Returns several relevant
@@ -123,9 +124,8 @@ static bool tryToStripMineLoop(
                     << L->getHeader()->getName() << "\n");
 
   if (!L->isLoopSimplifyForm()) {
-    LLVM_DEBUG(
-        dbgs() << "  Not stripmining loop which is not in loop-simplify "
-                  "form.\n");
+    LLVM_DEBUG(dbgs() << "  Not stripmining loop which is not in loop-simplify "
+                         "form.\n");
     return false;
   }
   bool StripMiningRequested =
@@ -147,6 +147,46 @@ static bool tryToStripMineLoop(
                           UnknownSize, TTI, LI, SE, EphValues, TLI);
   // Determine the iteration count of the eventual stripmined the loop.
   bool ExplicitCount = computeStripMineCount(L, TTI, LoopCost, SMP);
+  ORE.emit([&]() {
+    return OptimizationRemarkAnalysis(DEBUG_TYPE, "StripmineCount",
+                                      L->getStartLoc(), L->getHeader())
+           << "Found stripmine count " << ore::NV("StripmineCount", SMP.Count)
+           << (ExplicitCount ? " (from annotation or command-line option)."
+                             : ".");
+  });
+
+  // If the work in the loop body is big, then use a stripmine count of 1 for
+  // it.
+  LLVM_DEBUG(dbgs() << "  Loop cost = " << LoopCost
+                    << ", Stripmine count = " << SMP.Count
+                    << (ExplicitCount ? " (explicit count)\n" : "\n"));
+  if (SMP.Count <= 1) {
+    LLVM_DEBUG(dbgs() << "  Using grainsize 1 for big loop.\n");
+    if (Hints.getGrainsize() == 1)
+      return false;
+    ORE.emit([&]() {
+      return OptimizationRemark(DEBUG_TYPE, "BigLoop", L->getStartLoc(),
+                                L->getHeader())
+             << "using grainsize 1 for big loop";
+    });
+    Hints.setAlreadyStripMined();
+    return true;
+  }
+
+  // If the loop is recursive, set the stripmine count to be 1.
+  if (!ExplicitCount && IsRecursive) {
+    LLVM_DEBUG(dbgs() << "  Not stripmining loop that recursively calls the "
+                      << "containing function.\n");
+    if (Hints.getGrainsize() == 1)
+      return false;
+    ORE.emit([&]() {
+      return OptimizationRemark(DEBUG_TYPE, "RecursiveCalls", L->getStartLoc(),
+                                L->getHeader())
+             << "Using grainsize 1 for loop with recursive calls";
+    });
+    Hints.setAlreadyStripMined();
+    return true;
+  }
 
   // If the loop size is unknown, then we cannot compute a stripmining count for
   // it.
@@ -157,44 +197,14 @@ static bool tryToStripMineLoop(
     return false;
   }
 
-  // If the loop size is enormous, then we might want to use a stripmining count
-  // of 1 for it.
-  LLVM_DEBUG(dbgs() << "  Loop Cost = " << LoopCost << "\n");
-  if (!ExplicitCount && InstructionCost::getMax() == LoopCost) {
-    LLVM_DEBUG(dbgs() << "  Not stripmining loop with very large size.\n");
-    if (Hints.getGrainsize() == 1)
-      return false;
-    ORE.emit([&]() {
-               return OptimizationRemark(DEBUG_TYPE, "HugeLoop",
-                                         L->getStartLoc(), L->getHeader())
-                 << "using grainsize 1 for huge loop";
-             });
-    Hints.setAlreadyStripMined();
-    return true;
-  }
-
-  // If the loop is recursive, set the stripmine factor to be 1.
-  if (!ExplicitCount && IsRecursive) {
-    LLVM_DEBUG(dbgs() << "  Not stripmining loop that recursively calls the "
-                      << "containing function.\n");
-    if (Hints.getGrainsize() == 1)
-      return false;
-    ORE.emit([&]() {
-               return OptimizationRemark(DEBUG_TYPE, "RecursiveCalls",
-                                         L->getStartLoc(), L->getHeader())
-                 << "using grainsize 1 for loop with recursive calls";
-             });
-    Hints.setAlreadyStripMined();
-    return true;
-  }
-
   // TODO: We can stripmine loops if the stripmined version does not require a
   // prolog or epilog.
   if (NotDuplicatable) {
     LLVM_DEBUG(dbgs() << "  Not stripmining loop which contains "
                       << "non-duplicatable instructions.\n");
     ORE.emit(createMissedAnalysis("NotDuplicatable", L)
-             << "Cannot stripmine loop with non-duplicatable instructions.");
+             << "Cannot stripmine loop containing instructions that cannot be "
+                "duplicated.");
     return false;
   }
 
@@ -204,46 +214,57 @@ static bool tryToStripMineLoop(
   if (Convergent) {
     LLVM_DEBUG(dbgs() << "  Skipping loop with convergent operations.\n");
     ORE.emit(createMissedAnalysis("Convergent", L)
-             << "Cannot stripmine loop with convergent instructions.");
+             << "Cannot stripmine loop containing convergent instructions.");
     return false;
   }
 
-  // If the loop contains potentially expensive function calls, then we don't
-  // want to stripmine it.
+  // If the loop contains potentially expensive function calls, then the
+  // stripmine count might be an underestimate.  Avoid stripmining these loops
+  // unless we would use grainsize 1 or stripmining is explicitly requested.
   if (NumCalls > 0 && !ExplicitCount && !StripMiningRequested) {
     LLVM_DEBUG(dbgs() << "  Skipping loop with expensive function calls.\n");
     ORE.emit(createMissedAnalysis("ExpensiveCalls", L)
-             << "Not stripmining loop with potentially expensive calls.");
+             << "Loop contains function calls with unknown cost.");
     return false;
   }
 
   // Make sure the count is a power of 2.
+  // TODO: Support stripmining by not a power of 2.
   if (!isPowerOf2_32(SMP.Count))
     SMP.Count = NextPowerOf2(SMP.Count);
-  if (SMP.Count < 2) {
-    if (Hints.getGrainsize() == 1)
-      return false;
-    ORE.emit([&]() {
-               return OptimizationRemark(DEBUG_TYPE, "LargeLoop",
-                                         L->getStartLoc(), L->getHeader())
-                 << "using grainsize 1 for large loop";
-             });
-    Hints.setAlreadyStripMined();
-    return true;
-  }
 
   // Find a constant trip count if available
   unsigned ConstTripCount = getConstTripCount(L, SE);
 
-  // Stripmining factor (Count) must be less or equal to TripCount.
+  // Stripmining factor (Count) must be less or equal to TripCount, or else it's
+  // better to just execute this loop serially.
   if (ConstTripCount && SMP.Count >= ConstTripCount) {
-    ORE.emit(createMissedAnalysis("FullStripMine", L)
-             << "Stripmining count larger than loop trip count.");
-    ORE.emit(DiagnosticInfoOptimizationFailure(
-                 DEBUG_TYPE, "UnprofitableParallelLoop",
-                 L->getStartLoc(), L->getHeader())
-             << "Parallel loop does not appear profitable to parallelize.");
-    return false;
+    ORE.emit([&]() {
+      return OptimizationRemarkAnalysis(DEBUG_TYPE, "FullStripMine",
+                                        L->getStartLoc(), L->getHeader())
+             << "stripmine count (" << ore::NV("StripmineCount", SMP.Count)
+             << ") exceeds loop trip count ("
+             << ore::NV("ConstTripCount", ConstTripCount) << ").";
+    });
+
+    // Serialize the loop's detach, since it appears to be too small to be worth
+    // parallelizing.
+    ORE.emit([&]() {
+      return OptimizationRemark(DEBUG_TYPE, "SerializingSmallLoop",
+                                L->getStartLoc(), L->getHeader())
+             << "Serializing parallel loop that appears not to be profitable "
+                "to parallelize.";
+    });
+    SerializeDetach(cast<DetachInst>(L->getHeader()->getTerminator()), T,
+                    /*ReplaceWithTaskFrame=*/taskContainsSync(T), &DT);
+    Hints.clearHintsMetadata();
+    L->setDerivedFromTapirLoop();
+    // Update TaskInfo manually using the updated DT.
+    if (TI)
+      // FIXME: Recalculating TaskInfo for the whole function is wasteful.
+      // Optimize this routine in the future.
+      TI->recalculate(*L->getHeader()->getParent(), DT);
+    return true;
   }
 
   // When is it worthwhile to allow the epilog to run in parallel with the
@@ -292,8 +313,6 @@ static bool tryToStripMineLoop(
 
   // Copy metadata to remainder loop
   if (RemainderLoop && OrigLoopID) {
-    // Optional<MDNode *> RemainderLoopID = makeFollowupLoopID(
-    //     OrigLoopID, {}, "tapir.loop");
     MDNode *NewRemainderLoopID =
         CopyNonTapirLoopMetadata(RemainderLoop->getLoopID(), OrigLoopID);
     RemainderLoop->setLoopID(NewRemainderLoopID);
@@ -388,11 +407,6 @@ PreservedAnalyses LoopStripMinePass::run(Function &F,
   LoopAnalysisManager *LAM = nullptr;
   if (auto *LAMProxy = AM.getCachedResult<LoopAnalysisManagerFunctionProxy>(F))
     LAM = &LAMProxy->getManager();
-
-  // const ModuleAnalysisManager &MAM =
-  //     AM.getResult<ModuleAnalysisManagerFunctionProxy>(F).getManager();
-  // ProfileSummaryInfo *PSI =
-  //     MAM.getCachedResult<ProfileSummaryAnalysis>(*F.getParent());
 
   bool Changed = false;
 

--- a/llvm/lib/Transforms/Tapir/LoopStripMinePass.cpp
+++ b/llvm/lib/Transforms/Tapir/LoopStripMinePass.cpp
@@ -229,6 +229,13 @@ static bool tryToStripMineLoop(Loop *L, DominatorTree &DT, LoopInfo *LI,
     LLVM_DEBUG(dbgs() << "  Skipping loop with expensive function calls.\n");
     ORE.emit(createMissedAnalysis("ExpensiveCalls", L)
              << "Loop contains function calls with unknown cost.");
+    ORE.emit([&]() {
+      return OptimizationRemarkAnalysis(DEBUG_TYPE, "BoundRuntimeGrainsize",
+                                        L->getStartLoc(), L->getHeader())
+             << "Applying runtime grainsize bound: "
+             << ore::NV("GrainsizeBound", SMP.Count) << ".";
+    });
+    Hints.setGrainsizeBound(SMP.Count);
     return false;
   }
 

--- a/llvm/lib/Transforms/Tapir/OpenCilkABI.cpp
+++ b/llvm/lib/Transforms/Tapir/OpenCilkABI.cpp
@@ -230,10 +230,14 @@ void OpenCilkABI::prepareModule() {
       FunctionType::get(VoidTy, {PtrTy, Int32Ty}, false);
   FunctionType *CilkRTSPauseFrameFnTy =
       FunctionType::get(VoidTy, {PtrTy, PtrTy, PtrTy, BoolTy}, false);
-  FunctionType *Grainsize8FnTy = FunctionType::get(Int8Ty, {Int8Ty}, false);
-  FunctionType *Grainsize16FnTy = FunctionType::get(Int16Ty, {Int16Ty}, false);
-  FunctionType *Grainsize32FnTy = FunctionType::get(Int32Ty, {Int32Ty}, false);
-  FunctionType *Grainsize64FnTy = FunctionType::get(Int64Ty, {Int64Ty}, false);
+  FunctionType *Grainsize8FnTy =
+      FunctionType::get(Int8Ty, {Int8Ty, Int8Ty}, false);
+  FunctionType *Grainsize16FnTy =
+      FunctionType::get(Int16Ty, {Int16Ty, Int16Ty}, false);
+  FunctionType *Grainsize32FnTy =
+      FunctionType::get(Int32Ty, {Int32Ty, Int32Ty}, false);
+  FunctionType *Grainsize64FnTy =
+      FunctionType::get(Int64Ty, {Int64Ty, Int64Ty}, false);
   FunctionType *Lookup0Ty = FunctionType::get(PtrTy, {PtrTy}, false);
   FunctionType *Lookup1Ty = FunctionType::get(PtrTy, {PtrTy, PtrTy}, false);
   FunctionType *Lookup2Ty =
@@ -658,6 +662,7 @@ void OpenCilkABI::MarkSpawner(Function &F) {
 /// Lower a call to get the grainsize of a Tapir loop.
 Value *OpenCilkABI::lowerGrainsizeCall(CallInst *GrainsizeCall) {
   Value *Limit = GrainsizeCall->getArgOperand(0);
+  Value *Bound = GrainsizeCall->getArgOperand(1);
   IRBuilder<> Builder(GrainsizeCall);
 
   // Select the appropriate __cilkrts_grainsize function, based on the type.
@@ -673,7 +678,7 @@ Value *OpenCilkABI::lowerGrainsizeCall(CallInst *GrainsizeCall) {
   else
     llvm_unreachable("No CilkRTSGrainsize call matches type for Tapir loop.");
 
-  Value *Grainsize = Builder.CreateCall(CilkRTSGrainsizeCall, Limit);
+  Value *Grainsize = Builder.CreateCall(CilkRTSGrainsizeCall, {Limit, Bound});
 
   // Replace uses of grainsize intrinsic call with this grainsize value.
   GrainsizeCall->replaceAllUsesWith(Grainsize);

--- a/llvm/lib/Transforms/Tapir/SerializeSmallTasks.cpp
+++ b/llvm/lib/Transforms/Tapir/SerializeSmallTasks.cpp
@@ -12,6 +12,7 @@
 
 #include "llvm/Transforms/Tapir/SerializeSmallTasks.h"
 #include "llvm/Analysis/AssumptionCache.h"
+#include "llvm/Analysis/BlockFrequencyInfo.h"
 #include "llvm/Analysis/CodeMetrics.h"
 #include "llvm/Analysis/GlobalsModRef.h"
 #include "llvm/Analysis/LoopInfo.h"
@@ -35,13 +36,17 @@ static cl::opt<bool> SerializeUnprofitableLoops(
   "serialize-unprofitable-loops", cl::Hidden, cl::init(true),
   cl::desc("Serialize any Tapir tasks found to be unprofitable."));
 
-static bool trySerializeSmallLoop(
-    Loop *L, DominatorTree &DT, LoopInfo *LI, ScalarEvolution &SE,
-    const TargetTransformInfo &TTI, AssumptionCache &AC, TaskInfo *TI,
-    OptimizationRemarkEmitter &ORE, TargetLibraryInfo *TLI) {
+static bool trySerializeSmallLoop(Loop *L, DominatorTree &DT, LoopInfo *LI,
+                                  ScalarEvolution &SE,
+                                  const TargetTransformInfo &TTI,
+                                  AssumptionCache &AC, TaskInfo *TI,
+                                  OptimizationRemarkEmitter &ORE,
+                                  TargetLibraryInfo *TLI,
+                                  BlockFrequencyInfo *BFI) {
   bool Changed = false;
   for (Loop *SubL : *L)
-    Changed |= trySerializeSmallLoop(SubL, DT, LI, SE, TTI, AC, TI, ORE, TLI);
+    Changed |=
+        trySerializeSmallLoop(SubL, DT, LI, SE, TTI, AC, TI, ORE, TLI, BFI);
 
   Task *T = getTaskIfTapirLoopStructure(L, TI);
   if (!T)
@@ -60,7 +65,7 @@ static bool trySerializeSmallLoop(
   CodeMetrics::collectEphemeralValues(L, &AC, EphValues);
 
   WSCost LoopCost;
-  estimateLoopCost(LoopCost, L, LI, &SE, TTI, TLI, EphValues);
+  estimateLoopCost(LoopCost, L, LI, &SE, TTI, TLI, BFI, EphValues, &ORE);
 
   // If the work in the loop is larger than the maximum value we can deal with,
   // then it's not small.
@@ -165,7 +170,8 @@ bool SerializeSmallTasks::runOnFunction(Function &F) {
   bool Changed = false;
   if (SerializeUnprofitableLoops)
     for (Loop *L : *LI)
-      Changed |= trySerializeSmallLoop(L, DT, LI, SE, TTI, AC, &TI, ORE, &TLI);
+      Changed |= trySerializeSmallLoop(L, DT, LI, SE, TTI, AC, &TI, ORE, &TLI,
+                                       nullptr);
 
   if (Changed)
     // Recalculate TaskInfo
@@ -190,7 +196,7 @@ PreservedAnalyses SerializeSmallTasksPass::run(Function &F,
   auto &DT = AM.getResult<DominatorTreeAnalysis>(F);
   auto &AC = AM.getResult<AssumptionAnalysis>(F);
   auto &ORE = AM.getResult<OptimizationRemarkEmitterAnalysis>(F);
-
+  auto &BFI = AM.getResult<BlockFrequencyAnalysis>(F);
 
   LLVM_DEBUG(dbgs() << "SerializeSmallTasks running on function " << F.getName()
              << "\n");
@@ -198,7 +204,8 @@ PreservedAnalyses SerializeSmallTasksPass::run(Function &F,
   bool Changed = false;
   if (SerializeUnprofitableLoops)
     for (Loop *L : LI)
-      Changed |= trySerializeSmallLoop(L, DT, &LI, SE, TTI, AC, &TI, ORE, &TLI);
+      Changed |=
+          trySerializeSmallLoop(L, DT, &LI, SE, TTI, AC, &TI, ORE, &TLI, &BFI);
 
   if (!Changed)
     return PreservedAnalyses::all();

--- a/llvm/lib/Transforms/Tapir/TapirLoopInfo.cpp
+++ b/llvm/lib/Transforms/Tapir/TapirLoopInfo.cpp
@@ -57,6 +57,10 @@ void TapirLoopInfo::readTapirLoopMetadata(OptimizationRemarkEmitter &ORE) {
   // Get a grainsize for this Tapir loop from the metadata, if the metadata
   // gives a grainsize.
   Grainsize = Hints.getGrainsize();
+
+  // Get a grainsize bound for this Tapir loop from the metadata, if the
+  // metadata gives a grainsize bound.
+  GrainsizeBound = Hints.getGrainsizeBound();
 }
 
 static Type *convertPointerToIntegerType(const DataLayout &DL, Type *Ty) {
@@ -120,7 +124,7 @@ void TapirLoopInfo::addInductionPhi(PHINode *Phi,
   // }
 
   LLVM_DEBUG(dbgs() << "TapirLoop: Found an induction variable: " << *Phi
-             << "\n");
+                    << "\n");
 }
 
 /// Gather all induction variables in this loop that need special handling
@@ -173,8 +177,8 @@ bool TapirLoopInfo::collectIVs(PredicatedScalarEvolution &PSE,
   }
 
   if (!PrimaryInduction) {
-    LLVM_DEBUG(dbgs()
-               << "TapirLoop: Did not find a primary integer induction var.\n");
+    LLVM_DEBUG(
+        dbgs() << "TapirLoop: Did not find a primary integer induction var.\n");
     if (ORE)
       ORE->emit(createMissedAnalysis(PassName, "NoInductionVariable", L)
                 << "canonical loop induction variable could not be identified");
@@ -204,13 +208,14 @@ void TapirLoopInfo::replaceNonPrimaryIVs(PredicatedScalarEvolution &PSE) {
   for (auto &InductionEntry : Inductions) {
     PHINode *OrigPhi = InductionEntry.first;
     InductionDescriptor II = InductionEntry.second;
-    if (OrigPhi == PrimaryInduction) continue;
+    if (OrigPhi == PrimaryInduction)
+      continue;
     LLVM_DEBUG(dbgs() << "Replacing Phi " << *OrigPhi << "\n");
     // If Induction is not canonical, replace it with some computation based on
     // PrimaryInduction.
     Type *StepType = II.getStep()->getType();
     Instruction::CastOps CastOp =
-      CastInst::getCastOpcode(PrimaryInduction, true, StepType, true);
+        CastInst::getCastOpcode(PrimaryInduction, true, StepType, true);
     Value *CRD = B.CreateCast(CastOp, PrimaryInduction, StepType, "cast.crd");
     Value *PhiRepl = emitTransformedIndex(B, CRD, PSE.getSE(), DL, II);
     PhiRepl->setName(OrigPhi->getName() + ".tl.repl");
@@ -232,15 +237,14 @@ bool TapirLoopInfo::getLoopCondition(const char *PassName,
 
   // Check that the latch is terminated by a branch instruction.  The
   // LoopRotate pass can be helpful to ensure this property.
-  BranchInst *BI =
-    dyn_cast<BranchInst>(L->getLoopLatch()->getTerminator());
+  BranchInst *BI = dyn_cast<BranchInst>(L->getLoopLatch()->getTerminator());
   if (!BI || BI->isUnconditional()) {
-    LLVM_DEBUG(dbgs()
-               << "Loop-latch terminator is not a conditional branch.\n");
+    LLVM_DEBUG(
+        dbgs() << "Loop-latch terminator is not a conditional branch.\n");
     if (ORE)
-      ORE->emit(TapirLoopInfo::createMissedAnalysis(PassName, "NoLatchBranch",
-                                                    L)
-                << "loop latch is not terminated by a conditional branch");
+      ORE->emit(
+          TapirLoopInfo::createMissedAnalysis(PassName, "NoLatchBranch", L)
+          << "loop latch is not terminated by a conditional branch");
     return false;
   }
   // Check that the condition is an integer-equality comparison.  The
@@ -249,16 +253,16 @@ bool TapirLoopInfo::getLoopCondition(const char *PassName,
   {
     const ICmpInst *Cond = dyn_cast<ICmpInst>(BI->getCondition());
     if (!Cond) {
-      LLVM_DEBUG(dbgs() <<
-                 "Loop-latch condition is not an integer comparison.\n");
+      LLVM_DEBUG(
+          dbgs() << "Loop-latch condition is not an integer comparison.\n");
       if (ORE)
         ORE->emit(TapirLoopInfo::createMissedAnalysis(PassName, "NotIntCmp", L)
                   << "loop-latch condition is not an integer comparison");
       return false;
     }
     if (!Cond->isEquality()) {
-      LLVM_DEBUG(dbgs() <<
-                 "Loop-latch condition is not an equality comparison.\n");
+      LLVM_DEBUG(
+          dbgs() << "Loop-latch condition is not an equality comparison.\n");
       // TODO: Find a reasonable analysis message to give to users.
       // if (ORE)
       //   ORE->emit(TapirLoopInfo::createMissedAnalysis(PassName,
@@ -293,13 +297,14 @@ static Value *getEscapeValue(Instruction *UI, const InductionDescriptor &II,
   IRBuilder<> B(&*UI->getParent()->getFirstInsertionPt());
   Value *EffTripCount = TripCount;
   if (!PostInc)
-    EffTripCount = B.CreateSub(
-        TripCount, ConstantInt::get(TripCount->getType(), 1));
+    EffTripCount =
+        B.CreateSub(TripCount, ConstantInt::get(TripCount->getType(), 1));
 
-  Value *Count = !II.getStep()->getType()->isIntegerTy()
-    ? B.CreateCast(Instruction::SIToFP, EffTripCount,
-                   II.getStep()->getType())
-    : B.CreateSExtOrTrunc(EffTripCount, II.getStep()->getType());
+  Value *Count =
+      !II.getStep()->getType()->isIntegerTy()
+          ? B.CreateCast(Instruction::SIToFP, EffTripCount,
+                         II.getStep()->getType())
+          : B.CreateSExtOrTrunc(EffTripCount, II.getStep()->getType());
   if (PostInc)
     Count->setName("cast.count");
   else
@@ -314,7 +319,8 @@ static Value *getEscapeValue(Instruction *UI, const InductionDescriptor &II,
 /// form, with all external PHIs that use the IV having one input value, coming
 /// from the remainder loop.  We need those PHIs to also have a correct value
 /// for the IV when arriving directly from the middle block.
-void TapirLoopInfo::fixupIVUsers(PHINode *OrigPhi, const InductionDescriptor &II,
+void TapirLoopInfo::fixupIVUsers(PHINode *OrigPhi,
+                                 const InductionDescriptor &II,
                                  PredicatedScalarEvolution &PSE) {
   // There are two kinds of external IV usages - those that use the value
   // computed in the last iteration (the PHI) and those that use the penultimate
@@ -352,15 +358,15 @@ void TapirLoopInfo::fixupIVUsers(PHINode *OrigPhi, const InductionDescriptor &II
 
   for (auto &I : MissingVals) {
     LLVM_DEBUG(dbgs() << "Replacing external IV use:" << *I.first << " with "
-               << *I.second << "\n");
+                      << *I.second << "\n");
     PHINode *PHI = cast<PHINode>(I.first);
     PHI->replaceAllUsesWith(I.second);
     PHI->eraseFromParent();
   }
 }
 
-const SCEV *TapirLoopInfo::getBackedgeTakenCount(
-    PredicatedScalarEvolution &PSE) const {
+const SCEV *
+TapirLoopInfo::getBackedgeTakenCount(PredicatedScalarEvolution &PSE) const {
   Loop *L = getLoop();
   ScalarEvolution *SE = PSE.getSE();
   const SCEV *BackedgeTakenCount = PSE.getBackedgeTakenCount();
@@ -393,8 +399,8 @@ const SCEV *TapirLoopInfo::getExitCount(const SCEV *BackedgeTakenCount,
     ExitCount = BackedgeTakenCount;
   else
     // Get the total trip count from the count by adding 1.
-    ExitCount = SE->getAddExpr(
-        BackedgeTakenCount, SE->getOne(BackedgeTakenCount->getType()));
+    ExitCount = SE->getAddExpr(BackedgeTakenCount,
+                               SE->getOne(BackedgeTakenCount->getType()));
   return ExitCount;
 }
 
@@ -554,9 +560,9 @@ bool TapirLoopInfo::prepareForOutlining(
 /// Index.
 ///
 /// Copied from lib/Transforms/Vectorize/LoopVectorize.cpp
-Value *llvm::emitTransformedIndex(
-    IRBuilder<> &B, Value *Index, ScalarEvolution *SE, const DataLayout &DL,
-    const InductionDescriptor &ID) {
+Value *llvm::emitTransformedIndex(IRBuilder<> &B, Value *Index,
+                                  ScalarEvolution *SE, const DataLayout &DL,
+                                  const InductionDescriptor &ID) {
 
   SCEVExpander Exp(*SE, DL, "induction");
   const auto *Step = ID.getStep();

--- a/llvm/lib/Transforms/Utils/TapirUtils.cpp
+++ b/llvm/lib/Transforms/Utils/TapirUtils.cpp
@@ -71,7 +71,7 @@ bool llvm::isTapirHyperobjectIntrinsic(const Instruction *I) {
 /// detached.rethrow uses \p SyncRegion.
 bool llvm::isDetachedRethrow(const Instruction *I, const Value *SyncRegion) {
   return isa<InvokeInst>(I) &&
-      isTapirIntrinsic(Intrinsic::detached_rethrow, I, SyncRegion);
+         isTapirIntrinsic(Intrinsic::detached_rethrow, I, SyncRegion);
 }
 bool llvm::isDetachedRethrow(BasicBlock::const_iterator It,
                              const Value *SyncRegion) {
@@ -83,7 +83,7 @@ bool llvm::isDetachedRethrow(BasicBlock::const_iterator It,
 /// taskframe.resume uses \p TaskFrame.
 bool llvm::isTaskFrameResume(const Instruction *I, const Value *TaskFrame) {
   return isa<InvokeInst>(I) &&
-      isTapirIntrinsic(Intrinsic::taskframe_resume, I, TaskFrame);
+         isTapirIntrinsic(Intrinsic::taskframe_resume, I, TaskFrame);
 }
 bool llvm::isTaskFrameResume(BasicBlock::const_iterator It,
                              const Value *TaskFrame) {
@@ -166,8 +166,7 @@ bool llvm::isPlaceholderSuccessor(const BasicBlock *B) {
     if (!isDetachedRethrow(Pred->getTerminator()) &&
         !isTaskFrameResume(Pred->getTerminator()))
       return false;
-    if (B == cast<InvokeInst>(
-            Pred->getTerminator())->getUnwindDest())
+    if (B == cast<InvokeInst>(Pred->getTerminator())->getUnwindDest())
       return false;
   }
   return true;
@@ -192,8 +191,7 @@ Spindle *llvm::getTaskFrameForTask(Task *T) {
 
 // Removes the given sync.unwind instruction, if it is dead.  Returns true if
 // the sync.unwind was removed, false otherwise.
-bool llvm::removeDeadSyncUnwind(CallBase *SyncUnwind,
-                                DomTreeUpdater *DTU) {
+bool llvm::removeDeadSyncUnwind(CallBase *SyncUnwind, DomTreeUpdater *DTU) {
   assert(isSyncUnwind(SyncUnwind) &&
          "removeDeadSyncUnwind not called on a sync.unwind.");
   const Value *SyncRegion = SyncUnwind->getArgOperand(0);
@@ -275,7 +273,8 @@ static bool isUsedByLifetimeMarker(Value *V) {
   for (User *U : V->users()) {
     if (IntrinsicInst *II = dyn_cast<IntrinsicInst>(U)) {
       switch (II->getIntrinsicID()) {
-      default: break;
+      default:
+        break;
       case Intrinsic::lifetime_start:
       case Intrinsic::lifetime_end:
         return true;
@@ -319,7 +318,8 @@ bool llvm::MoveStaticAllocasInBlock(
   BasicBlock::iterator InsertPoint = Entry->begin();
   for (BasicBlock::iterator I = Block->begin(), E = Block->end(); I != E;) {
     AllocaInst *AI = dyn_cast<AllocaInst>(I++);
-    if (!AI) continue;
+    if (!AI)
+      continue;
 
     if (!allocaWouldBeStaticInEntry(AI)) {
       ContainsDynamicAllocas = true;
@@ -344,7 +344,8 @@ bool llvm::MoveStaticAllocasInBlock(
   // Move any syncregion_start's into the entry basic block.
   for (BasicBlock::iterator I = Block->begin(), E = Block->end(); I != E;) {
     IntrinsicInst *II = dyn_cast<IntrinsicInst>(I++);
-    if (!II) continue;
+    if (!II)
+      continue;
     if (Intrinsic::syncregion_start != II->getIntrinsicID())
       continue;
 
@@ -417,7 +418,7 @@ class LandingPadInliningInfo {
   /// PHI for EH values from landingpad insts.
   PHINode *InnerEHValuesPHI = nullptr;
 
-  SmallVector<Value*, 8> UnwindDestPHIValues;
+  SmallVector<Value *, 8> UnwindDestPHIValues;
 
   /// Dominator tree to update.
   DominatorTree *DT = nullptr;
@@ -470,9 +471,7 @@ public:
 
   /// The outer unwind destination is the target of unwind edges introduced for
   /// calls within the inlined function.
-  BasicBlock *getOuterResumeDest() const {
-    return OuterResumeDest;
-  }
+  BasicBlock *getOuterResumeDest() const { return OuterResumeDest; }
 
   BasicBlock *getInnerResumeDest();
 
@@ -502,7 +501,8 @@ public:
 
 /// Get or create a target for the branch from ResumeInsts.
 BasicBlock *LandingPadInliningInfo::getInnerResumeDest() {
-  if (InnerResumeDest) return InnerResumeDest;
+  if (InnerResumeDest)
+    return InnerResumeDest;
 
   // Split the outer resume destionation.
   BasicBlock::iterator SplitPoint;
@@ -510,9 +510,8 @@ BasicBlock *LandingPadInliningInfo::getInnerResumeDest() {
     SplitPoint = ++cast<Instruction>(SpawnerLPad)->getIterator();
   else
     SplitPoint = OuterResumeDest->getFirstNonPHIIt();
-  InnerResumeDest =
-    OuterResumeDest->splitBasicBlock(SplitPoint,
-                                     OuterResumeDest->getName() + ".body");
+  InnerResumeDest = OuterResumeDest->splitBasicBlock(
+      SplitPoint, OuterResumeDest->getName() + ".body");
   if (DT)
     // OuterResumeDest dominates InnerResumeDest, which dominates all other
     // nodes dominated by OuterResumeDest.
@@ -534,9 +533,9 @@ BasicBlock *LandingPadInliningInfo::getInnerResumeDest() {
   BasicBlock::iterator I = OuterResumeDest->begin();
   for (unsigned i = 0, e = UnwindDestPHIValues.size(); i != e; ++i, ++I) {
     PHINode *OuterPHI = cast<PHINode>(I);
-    PHINode *InnerPHI = PHINode::Create(OuterPHI->getType(), PHICapacity,
-                                        OuterPHI->getName() + ".lpad-body",
-                                        InsertPoint);
+    PHINode *InnerPHI =
+        PHINode::Create(OuterPHI->getType(), PHICapacity,
+                        OuterPHI->getName() + ".lpad-body", InsertPoint);
     OuterPHI->replaceAllUsesWith(InnerPHI);
     InnerPHI->addIncoming(OuterPHI, OuterResumeDest);
   }
@@ -574,8 +573,8 @@ void LandingPadInliningInfo::forwardTaskResume(InvokeInst *TR) {
 
   BranchInst::Create(Dest, Src);
   if (DT)
-    DT->changeImmediateDominator(
-        Dest, DT->findNearestCommonDominator(Dest, Src));
+    DT->changeImmediateDominator(Dest,
+                                 DT->findNearestCommonDominator(Dest, Src));
 
   // Update the PHIs in the destination. They were inserted in an order which
   // makes this work.
@@ -625,11 +624,12 @@ void LandingPadInliningInfo::forwardTaskResume(InvokeInst *TR) {
   }
 }
 
-static void handleDetachedLandingPads(
-    DetachInst *DI, BasicBlock *EHContinue, Value *LPadValInEHContinue,
-    SmallPtrSetImpl<LandingPadInst *> &InlinedLPads,
-    SmallVectorImpl<Instruction *> &DetachedRethrows,
-    DominatorTree *DT = nullptr, TaskInfo *TI = nullptr) {
+static void
+handleDetachedLandingPads(DetachInst *DI, BasicBlock *EHContinue,
+                          Value *LPadValInEHContinue,
+                          SmallPtrSetImpl<LandingPadInst *> &InlinedLPads,
+                          SmallVectorImpl<Instruction *> &DetachedRethrows,
+                          DominatorTree *DT = nullptr, TaskInfo *TI = nullptr) {
   LandingPadInliningInfo DetUnwind(DI, EHContinue, LPadValInEHContinue, DT, TI);
 
   // Append the clauses from the outer landing pad instruction into the inlined
@@ -695,7 +695,7 @@ void llvm::cloneEHBlocks(Function *F,
 
   // For all new successors, remove the predecessors not in EHBlockPreds.
   for (BasicBlock *NewSucc : NewSuccSet) {
-    for (BasicBlock::iterator I = NewSucc->begin(); isa<PHINode>(I); ) {
+    for (BasicBlock::iterator I = NewSucc->begin(); isa<PHINode>(I);) {
       PHINode *PN = cast<PHINode>(I++);
 
       // NOTE! This loop walks backwards for a reason! First off, this minimizes
@@ -734,8 +734,7 @@ void llvm::cloneEHBlocks(Function *F,
           DT->changeImmediateDominator(cast<BasicBlock>(VMap[EHBlock]),
                                        cast<BasicBlock>(VMap[IDomBB]));
         } else {
-          DT->changeImmediateDominator(cast<BasicBlock>(VMap[EHBlock]),
-                                       IDomBB);
+          DT->changeImmediateDominator(cast<BasicBlock>(VMap[EHBlock]), IDomBB);
         }
       }
     }
@@ -822,9 +821,9 @@ void llvm::cloneEHBlocks(Function *F,
 }
 
 // Helper function to find landingpads in the specified taskframe.
-static void getTaskFrameLandingPads(
-    Value *TaskFrame, Instruction *TaskFrameResume,
-    SmallPtrSetImpl<LandingPadInst *> &InlinedLPads) {
+static void
+getTaskFrameLandingPads(Value *TaskFrame, Instruction *TaskFrameResume,
+                        SmallPtrSetImpl<LandingPadInst *> &InlinedLPads) {
   const BasicBlock *TaskFrameBB = cast<Instruction>(TaskFrame)->getParent();
   SmallVector<BasicBlock *, 8> Worklist;
   SmallPtrSet<BasicBlock *, 8> Visited;
@@ -955,7 +954,7 @@ void llvm::SerializeDetach(DetachInst *DI, BasicBlock *ParentEntry,
   // Move static alloca instructions in the task entry to the appropriate entry
   // block.
   bool ContainsDynamicAllocas =
-    MoveStaticAllocasInBlock(ParentEntry, TaskEntry, ExitPoints);
+      MoveStaticAllocasInBlock(ParentEntry, TaskEntry, ExitPoints);
   // If the cloned loop contained dynamic alloca instructions, wrap the inlined
   // code with llvm.stacksave/llvm.stackrestore intrinsics.
   if (ContainsDynamicAllocas) {
@@ -1015,8 +1014,8 @@ void llvm::SerializeDetach(DetachInst *DI, BasicBlock *ParentEntry,
       if (!ReattachDom)
         ReattachDom = I->getParent();
       else
-        ReattachDom = DT->findNearestCommonDominator(ReattachDom,
-                                                     I->getParent());
+        ReattachDom =
+            DT->findNearestCommonDominator(ReattachDom, I->getParent());
     }
 
     // If we're replacing the detach with a taskframe, insert a taskframe.end
@@ -1098,7 +1097,7 @@ void llvm::AnalyzeTaskForSerialization(
     for (BasicBlock *BB : S->blocks()) {
       if (isa<ReattachInst>(BB->getTerminator())) {
         assert(cast<ReattachInst>(BB->getTerminator())->getSyncRegion() ==
-               SyncRegion &&
+                   SyncRegion &&
                "Reattach in task does not match sync region with detach.");
         Reattaches.push_back(BB->getTerminator());
       } else if (InvokeInst *II = dyn_cast<InvokeInst>(BB->getTerminator())) {
@@ -1252,8 +1251,8 @@ const BasicBlock *llvm::GetDetachedCtx(const BasicBlock *BB) {
         const InvokeInst *II = cast<InvokeInst>(PredBB->getTerminator());
         TaskFramesToIgnore.insert(II->getArgOperand(0));
       } else if (endsUnassociatedTaskFrame(PredBB)) {
-        const CallBase *TFEnd = cast<CallBase>(
-            PredBB->getTerminator()->getPrevNode());
+        const CallBase *TFEnd =
+            cast<CallBase>(PredBB->getTerminator()->getPrevNode());
         TaskFramesToIgnore.insert(TFEnd->getArgOperand(0));
       }
 
@@ -1303,7 +1302,7 @@ bool llvm::mayBeUnsynced(const BasicBlock *BB) {
       // If we find a predecessor via reattach instructions, then
       // wconservatively return that we may not be synced.
       if (isa<ReattachInst>(PredBB->getTerminator()))
-          return true;
+        return true;
 
       // If we find a predecessor via a detached.rethrow, then conservatively
       // return that we may not be synced.
@@ -1316,8 +1315,8 @@ bool llvm::mayBeUnsynced(const BasicBlock *BB) {
         const InvokeInst *II = cast<InvokeInst>(PredBB->getTerminator());
         TaskFramesToIgnore.insert(II->getArgOperand(0));
       } else if (endsUnassociatedTaskFrame(PredBB)) {
-        const CallBase *TFEnd = cast<CallBase>(
-            PredBB->getTerminator()->getPrevNode());
+        const CallBase *TFEnd =
+            cast<CallBase>(PredBB->getTerminator()->getPrevNode());
         TaskFramesToIgnore.insert(TFEnd->getArgOperand(0));
       }
 
@@ -1357,12 +1356,15 @@ bool llvm::isDetachContinueEdge(const Instruction *TI, const BasicBlock *Succ) {
 /// - even after ignoring all reattach edges.
 bool llvm::isCriticalContinueEdge(const Instruction *TI, unsigned SuccNum) {
   assert(SuccNum < TI->getNumSuccessors() && "Illegal edge specification!");
-  if (TI->getNumSuccessors() == 1) return false;
+  if (TI->getNumSuccessors() == 1)
+    return false;
 
   // Edge must come from a detach.
-  if (!isa<DetachInst>(TI)) return false;
+  if (!isa<DetachInst>(TI))
+    return false;
   // Edge must go to the continuation.
-  if (SuccNum != 1) return false;
+  if (SuccNum != 1)
+    return false;
 
   const BasicBlock *Dest = TI->getSuccessor(SuccNum);
   const_pred_iterator I = pred_begin(Dest), E = pred_end(Dest);
@@ -1371,11 +1373,13 @@ bool llvm::isCriticalContinueEdge(const Instruction *TI, unsigned SuccNum) {
   assert(I != E && "No preds, but we have an edge to the block?");
   const BasicBlock *DetachPred = TI->getParent();
   for (; I != E; ++I) {
-    if (DetachPred == *I) continue;
+    if (DetachPred == *I)
+      continue;
     // Even if a reattach instruction isn't associated with the detach
     // instruction TI, we can safely skip it, because it will be associated with
     // a different detach instruction that precedes this block.
-    if (isa<ReattachInst>((*I)->getTerminator())) continue;
+    if (isa<ReattachInst>((*I)->getTerminator()))
+      continue;
     return true;
   }
   return false;
@@ -1408,7 +1412,8 @@ void llvm::GetDetachedCFG(const DetachInst &DI, const DominatorTree &DT,
   while (!Todo.empty()) {
     BasicBlock *BB = Todo.pop_back_val();
 
-    if (!TaskBlocks.insert(BB).second) continue;
+    if (!TaskBlocks.insert(BB).second)
+      continue;
 
     LLVM_DEBUG(dbgs() << "  Found block " << BB->getName() << "\n");
 
@@ -1421,7 +1426,8 @@ void llvm::GetDetachedCFG(const DetachInst &DI, const DominatorTree &DT,
       // terminates a nested detached CFG.  If it terminates a nested detached
       // CFG, it can simply be ignored, because the corresponding nested detach
       // instruction will be processed later.
-      if (RI->getDetachContinue() != Continue) continue;
+      if (RI->getDetachContinue() != Continue)
+        continue;
       assert(RI->getSyncRegion() == SyncRegion &&
              "Reattach terminating detached CFG has nonmatching sync region.");
       TaskReturns.insert(BB);
@@ -1455,14 +1461,14 @@ void llvm::GetDetachedCFG(const DetachInst &DI, const DominatorTree &DT,
       } else {
         for (BasicBlock *Succ : successors(BB)) {
           if (DT.dominates(DetachEdge, Succ)) {
-            LLVM_DEBUG(dbgs() <<
-                       "Adding successor " << Succ->getName() << "\n");
+            LLVM_DEBUG(dbgs()
+                       << "Adding successor " << Succ->getName() << "\n");
             Todo.push_back(Succ);
           } else {
             // We assume that this block is an exception-handling block and save
             // it for later processing.
-            LLVM_DEBUG(dbgs() <<
-                       "  Exit block to search " << Succ->getName() << "\n");
+            LLVM_DEBUG(dbgs()
+                       << "  Exit block to search " << Succ->getName() << "\n");
             EHBlocks.insert(Succ);
             WorkListEH.push_back(Succ);
           }
@@ -1502,10 +1508,10 @@ void llvm::GetDetachedCFG(const DetachInst &DI, const DominatorTree &DT,
       // Make sure that the control flow through these exception-handling blocks
       // doesn't reattach to the detached CFG's continuation.
       LLVM_DEBUG({
-          if (ReattachInst *RI = dyn_cast<ReattachInst>(BB->getTerminator()))
-            assert(RI->getSuccessor(0) != Continue &&
-                   "Exit block reaches a reattach to the continuation.");
-        });
+        if (ReattachInst *RI = dyn_cast<ReattachInst>(BB->getTerminator()))
+          assert(RI->getSuccessor(0) != Continue &&
+                 "Exit block reaches a reattach to the continuation.");
+      });
 
       // Stop searching down this path upon finding a detached rethrow.
       if (isDetachedRethrow(BB->getTerminator(), SyncRegion)) {
@@ -1526,16 +1532,16 @@ void llvm::GetDetachedCFG(const DetachInst &DI, const DominatorTree &DT,
   }
 
   LLVM_DEBUG({
-      dbgs() << "Exit blocks:";
-      for (BasicBlock *Exit : EHBlocks) {
-        if (DT.dominates(DetachEdge, Exit))
-          dbgs() << "(dominated)";
-        else
-          dbgs() << "(shared)";
-        dbgs() << *Exit;
-      }
-      dbgs() << "\n";
-    });
+    dbgs() << "Exit blocks:";
+    for (BasicBlock *Exit : EHBlocks) {
+      if (DT.dominates(DetachEdge, Exit))
+        dbgs() << "(dominated)";
+      else
+        dbgs() << "(shared)";
+      dbgs() << *Exit;
+    }
+    dbgs() << "\n";
+  });
 }
 
 // Helper function to find PHI nodes that depend on the landing pad in the
@@ -1549,7 +1555,8 @@ void llvm::getDetachUnwindPHIUses(DetachInst *DI,
     LPad = UnwindDest->getLandingPadInst();
     assert(LPad && "Unwind of detach is not a landing pad.");
   }
-  if (!LPad) return;
+  if (!LPad)
+    return;
 
   // Walk the chain of uses of this landing pad to find all PHI nodes that
   // depend on it, directly or indirectly.
@@ -1560,7 +1567,8 @@ void llvm::getDetachUnwindPHIUses(DetachInst *DI,
 
   while (!WorkList.empty()) {
     User *Curr = WorkList.pop_back_val();
-    if (!Visited.insert(Curr).second) continue;
+    if (!Visited.insert(Curr).second)
+      continue;
 
     // If we find a PHI-node user, add it to UnwindPHIs
     if (PHINode *PN = dyn_cast<PHINode>(Curr))
@@ -1674,7 +1682,7 @@ bool llvm::splitTaskFrameCreateBlocks(Function &F, DominatorTree *DT,
               if (Intrinsic::taskframe_use == UI->getIntrinsicID()) {
                 if (BasicBlock *Pred = UI->getParent()->getSinglePredecessor())
                   if (DetachInst *DI =
-                      dyn_cast<DetachInst>(Pred->getTerminator())) {
+                          dyn_cast<DetachInst>(Pred->getTerminator())) {
                     // Record this detach as using a taskframe.
                     DetachesWithTaskFrames.push_back(DI);
                     break;
@@ -1707,7 +1715,7 @@ bool llvm::splitTaskFrameCreateBlocks(Function &F, DominatorTree *DT,
       LLVM_DEBUG(dbgs() << "Splitting at " << *I << "\n");
       StringRef OldName = I->getParent()->getName();
       SplitBlock(I->getParent(), I, DT, LI, MSSAU);
-      I->getParent()->setName(OldName+".tf");
+      I->getParent()->setName(OldName + ".tf");
       Changed = true;
     }
 
@@ -1826,7 +1834,7 @@ void llvm::fixupTaskFrameExternalUses(Spindle *TF, const TaskInfo &TI,
         InvokeInst *TFResume = cast<InvokeInst>(BB->getTerminator());
         assert((nullptr == TFResumeContin) ||
                (TFResumeContin == TFResume->getUnwindDest()) &&
-               "Multiple taskframe.resume destinations found");
+                   "Multiple taskframe.resume destinations found");
         TFResumeContin = TFResume->getUnwindDest();
       }
     }
@@ -1853,8 +1861,8 @@ void llvm::fixupTaskFrameExternalUses(Spindle *TF, const TaskInfo &TI,
         // If we find a live use outside of the task, it's an output.
         if (Instruction *UI = dyn_cast<Instruction>(U.getUser())) {
           if (!taskFrameEncloses(TF, UI->getParent(), TI)) {
-            LLVM_DEBUG(dbgs() << "  ToRewrite: " << I << " (user " << *UI
-                       << ")\n");
+            LLVM_DEBUG(dbgs()
+                       << "  ToRewrite: " << I << " (user " << *UI << ")\n");
             ToRewrite[&I].push_back(&U);
           }
         }
@@ -1865,8 +1873,9 @@ void llvm::fixupTaskFrameExternalUses(Spindle *TF, const TaskInfo &TI,
       if (DetachInst *DI = dyn_cast<DetachInst>(BB->getTerminator()))
         if (!taskFrameContains(
                 TF, cast<Instruction>(DI->getSyncRegion())->getParent(), TI)) {
-          LLVM_DEBUG(dbgs() << "  Sync region to localize: "
-                     << *DI->getSyncRegion() << "(user " << *DI << ")\n");
+          LLVM_DEBUG(dbgs()
+                     << "  Sync region to localize: " << *DI->getSyncRegion()
+                     << "(user " << *DI << ")\n");
           // Only record the detach.  We can find associated reattaches and
           // detached-rethrows later.
           SyncRegionsToLocalize[DI->getSyncRegion()].push_back(DI);
@@ -1875,8 +1884,9 @@ void llvm::fixupTaskFrameExternalUses(Spindle *TF, const TaskInfo &TI,
       if (SyncInst *SI = dyn_cast<SyncInst>(BB->getTerminator()))
         if (!taskFrameContains(
                 TF, cast<Instruction>(SI->getSyncRegion())->getParent(), TI)) {
-          LLVM_DEBUG(dbgs() << "  Sync region to localize: "
-                     << *SI->getSyncRegion() << "(user " << *SI << ")\n");
+          LLVM_DEBUG(dbgs()
+                     << "  Sync region to localize: " << *SI->getSyncRegion()
+                     << "(user " << *SI << ")\n");
           SyncRegionsToLocalize[SI->getSyncRegion()].push_back(SI);
         }
     }
@@ -1924,7 +1934,8 @@ void llvm::fixupTaskFrameExternalUses(Spindle *TF, const TaskInfo &TI,
     Spindle *ParentS = TF->getTaskFrameParent()
                            ? TF->getTaskFrameParent()
                            : TF->getParentTask()->getEntrySpindle();
-    BasicBlock::iterator ParentInsertionPt = ParentS->getTaskFrameFirstInsertionPt();
+    BasicBlock::iterator ParentInsertionPt =
+        ParentS->getTaskFrameFirstInsertionPt();
     IRBuilder<> Builder(&*ParentInsertionPt);
     Type *TFInstrTy = TFInstr.first->getType();
     AllocaInst *AI = Builder.CreateAlloca(TFInstrTy);
@@ -2019,16 +2030,16 @@ BasicBlock *llvm::CreateSubTaskUnwindEdge(Intrinsic::ID TermFunc, Value *Token,
   LandingPadInst *OldLPad = UnwindEdge->getLandingPadInst();
 
   // Create a new unwind edge for the detached rethrow.
-  BasicBlock *NewUnwindEdge = BasicBlock::Create(
-      Caller->getContext(), UnwindEdge->getName(), Caller);
+  BasicBlock *NewUnwindEdge =
+      BasicBlock::Create(Caller->getContext(), UnwindEdge->getName(), Caller);
   IRBuilder<> Builder(NewUnwindEdge);
   // Get a debug location from ParentI.
   if (const DebugLoc &Loc = ParentI->getDebugLoc())
     Builder.SetCurrentDebugLocation(Loc);
 
   // Add a landingpad to the new unwind edge.
-  LandingPadInst *LPad = Builder.CreateLandingPad(OldLPad->getType(), 0,
-                                                  OldLPad->getName());
+  LandingPadInst *LPad =
+      Builder.CreateLandingPad(OldLPad->getType(), 0, OldLPad->getName());
   LPad->setCleanup(true);
 
   // Add the terminator-function invocation.
@@ -2039,9 +2050,10 @@ BasicBlock *llvm::CreateSubTaskUnwindEdge(Intrinsic::ID TermFunc, Value *Token,
   return NewUnwindEdge;
 }
 
-static BasicBlock *maybePromoteCallInBlock(
-    BasicBlock *BB, BasicBlock *UnwindEdge, const Value *TaskFrame,
-    std::function<bool(CallBase *)> IgnoreFunctionCheck) {
+static BasicBlock *
+maybePromoteCallInBlock(BasicBlock *BB, BasicBlock *UnwindEdge,
+                        const Value *TaskFrame,
+                        std::function<bool(CallBase *)> IgnoreFunctionCheck) {
   for (BasicBlock::iterator BBI = BB->begin(), E = BB->end(); BBI != E;) {
     Instruction *I = &*BBI++;
 
@@ -2108,11 +2120,12 @@ static Instruction *getTaskFrameInstructionInBlock(BasicBlock *BB,
 }
 
 // Recursively handle inlined tasks.
-static void promoteCallsInTasksHelper(
-    BasicBlock *EntryBlock, BasicBlock *UnwindEdge, BasicBlock *Unreachable,
-    Value *CurrentTaskFrame, SmallVectorImpl<BasicBlock *> *ParentWorklist,
-    SmallPtrSetImpl<BasicBlock *> &Processed,
-    std::function<bool(CallBase *)> IgnoreFunctionCheck) {
+static void
+promoteCallsInTasksHelper(BasicBlock *EntryBlock, BasicBlock *UnwindEdge,
+                          BasicBlock *Unreachable, Value *CurrentTaskFrame,
+                          SmallVectorImpl<BasicBlock *> *ParentWorklist,
+                          SmallPtrSetImpl<BasicBlock *> &Processed,
+                          std::function<bool(CallBase *)> IgnoreFunctionCheck) {
   SmallVector<DetachInst *, 8> DetachesToReplace;
   SmallVector<BasicBlock *, 32> Worklist;
   // TODO: See if we need a global Visited set over all recursive calls, i.e.,
@@ -2143,9 +2156,9 @@ static void promoteCallsInTasksHelper(
           NewBB = BB;
 
         // Create an unwind edge for the taskframe.
-        BasicBlock *TaskFrameUnwindEdge = CreateSubTaskUnwindEdge(
-            Intrinsic::taskframe_resume, TFCreate, UnwindEdge,
-            Unreachable, TFCreate);
+        BasicBlock *TaskFrameUnwindEdge =
+            CreateSubTaskUnwindEdge(Intrinsic::taskframe_resume, TFCreate,
+                                    UnwindEdge, Unreachable, TFCreate);
 
         // Recursively check all blocks
         promoteCallsInTasksHelper(NewBB, TaskFrameUnwindEdge, Unreachable,
@@ -2161,8 +2174,7 @@ static void promoteCallsInTasksHelper(
                                        CurrentTaskFrame)) {
       // If we find a taskframe.end in this block that ends the current
       // taskframe, add this block to the parent search.
-      assert(ParentWorklist &&
-             "Unexpected taskframe.end: no parent worklist");
+      assert(ParentWorklist && "Unexpected taskframe.end: no parent worklist");
       if (BB->getTerminator()->getPrevNode() != TFI ||
           !isa<BranchInst>(BB->getTerminator())) {
         // This taskframe.end does not terminate the basic block.  To make sure
@@ -2244,9 +2256,9 @@ static void promoteCallsInTasksHelper(
   // Replace detaches that now require unwind destinations.
   while (!DetachesToReplace.empty()) {
     DetachInst *DI = DetachesToReplace.pop_back_val();
-    ReplaceInstWithInst(DI, DetachInst::Create(
-                            DI->getDetached(), DI->getContinue(), UnwindEdge,
-                            DI->getSyncRegion()));
+    ReplaceInstWithInst(DI,
+                        DetachInst::Create(DI->getDetached(), DI->getContinue(),
+                                           UnwindEdge, DI->getSyncRegion()));
   }
 }
 
@@ -2279,12 +2291,12 @@ void llvm::promoteCallsInTasksToInvokes(
   Type *ExnTy = StructType::get(PointerType::getUnqual(C), Type::getInt32Ty(C));
 
   LandingPadInst *LPad =
-      LandingPadInst::Create(ExnTy, 1, Name+".lpad", CleanupBB);
+      LandingPadInst::Create(ExnTy, 1, Name + ".lpad", CleanupBB);
   LPad->setCleanup(true);
   ResumeInst *RI = ResumeInst::Create(LPad, CleanupBB);
 
   // Create the normal return for the task resumes.
-  BasicBlock *UnreachableBlk = BasicBlock::Create(C, Name+".unreachable", &F);
+  BasicBlock *UnreachableBlk = BasicBlock::Create(C, Name + ".unreachable", &F);
 
   // Recursively handle inlined tasks.
   SmallPtrSet<BasicBlock *, 8> Processed;
@@ -2388,26 +2400,25 @@ void llvm::TapirLoopHints::setHint(StringRef Name, Metadata *Arg) {
     return;
   unsigned Val = C->getZExtValue();
 
-  Hint *Hints[] = {&Strategy, &Grainsize};
+  Hint *Hints[] = {&Strategy, &Grainsize, &GrainsizeBound};
   for (auto *H : Hints) {
     if (Name == H->Name) {
       if (H->validate(Val))
         H->Value = Val;
       else
-        LLVM_DEBUG(dbgs() << "Tapir: ignoring invalid hint '" <<
-                   Name << "'\n");
+        LLVM_DEBUG(dbgs() << "Tapir: ignoring invalid hint '" << Name << "'\n");
       break;
     }
   }
 }
 
 /// Create a new hint from name / value pair.
-MDNode *llvm::TapirLoopHints::createHintMetadata(
-    StringRef Name, unsigned V) const {
+MDNode *llvm::TapirLoopHints::createHintMetadata(StringRef Name,
+                                                 unsigned V) const {
   LLVMContext &Context = TheLoop->getHeader()->getContext();
-  Metadata *MDs[] = {MDString::get(Context, Name),
-                     ConstantAsMetadata::get(
-                         ConstantInt::get(Type::getInt32Ty(Context), V))};
+  Metadata *MDs[] = {
+      MDString::get(Context, Name),
+      ConstantAsMetadata::get(ConstantInt::get(Type::getInt32Ty(Context), V))};
   return MDNode::get(Context, MDs);
 }
 
@@ -2466,7 +2477,7 @@ void llvm::TapirLoopHints::writeHintsToClonedMetadata(ArrayRef<Hint> HintTypes,
     return;
 
   LLVMContext &Context =
-    cast<BasicBlock>(VMap[TheLoop->getHeader()])->getContext();
+      cast<BasicBlock>(VMap[TheLoop->getHeader()])->getContext();
   SmallVector<Metadata *, 4> MDs;
 
   // Reserve first location for self reference to the LoopID metadata node.
@@ -2505,7 +2516,8 @@ void llvm::TapirLoopHints::writeHintsToClonedMetadata(ArrayRef<Hint> HintTypes,
 /// Sets current hints into loop metadata, keeping other values intact.
 void llvm::TapirLoopHints::clearHintsMetadata() {
   Hint Hints[] = {Hint("spawn.strategy", ST_SEQ, HK_STRATEGY),
-                  Hint("grainsize", 0, HK_GRAINSIZE)};
+                  Hint("grainsize", 0, HK_GRAINSIZE),
+                  Hint("grainsize.bound", 0, HK_GRAINSIZE_BOUND)};
   LLVMContext &Context = TheLoop->getHeader()->getContext();
   SmallVector<Metadata *, 4> MDs;
 
@@ -2535,8 +2547,10 @@ void llvm::TapirLoopHints::clearHintsMetadata() {
 /// Returns true if Tapir-loop hints require loop outlining during lowering.
 bool llvm::hintsDemandOutlining(const TapirLoopHints &Hints) {
   switch (Hints.getStrategy()) {
-  case TapirLoopHints::ST_DAC: return true;
-  default: return false;
+  case TapirLoopHints::ST_DAC:
+    return true;
+  default:
+    return false;
   }
 }
 
@@ -2579,10 +2593,11 @@ Task *llvm::getTaskIfTapirLoop(const Loop *L, TaskInfo *TI) {
 
   TapirLoopHints Hints(L);
 
-  LLVM_DEBUG(dbgs() << "Loop hints:"
+  LLVM_DEBUG(
+      dbgs() << "Loop hints:"
              << " strategy = " << Hints.printStrategy(Hints.getStrategy())
              << " grainsize = " << Hints.getGrainsize()
-             << "\n");
+             << " grainsize bound = " << Hints.getGrainsizeBound() << "\n");
 
   // Check that this loop has the structure of a Tapir loop.
   Task *T = getTaskIfTapirLoopStructure(L, TI);

--- a/llvm/test/Other/new-pm-defaults.ll
+++ b/llvm/test/Other/new-pm-defaults.ll
@@ -258,6 +258,8 @@
 ; CHECK-O2-NEXT: Running pass: LCSSAPass
 ; CHECK-O2-NEXT: Running pass: IndVarSimplifyPass
 ; CHECK-O2-NEXT: Running pass: LoopStripMinePass
+; CHECK-O2-NEXT: Running analysis: BlockFrequencyAnalysis on foo
+; CHECK-O2-NEXT: Running analysis: BranchProbabilityAnalysis on foo
 ; CHECK-O2-NEXT: Running pass: TaskSimplifyPass on foo
 ; CHECK-O2-NEXT: Running pass: LoopSimplifyPass
 ; CHECK-O2-NEXT: Running pass: LCSSAPass
@@ -273,6 +275,8 @@
 ; CHECK-O3-NEXT: Running pass: LCSSAPass
 ; CHECK-O3-NEXT: Running pass: IndVarSimplifyPass
 ; CHECK-O3-NEXT: Running pass: LoopStripMinePass
+; CHECK-O3-NEXT: Running analysis: BlockFrequencyAnalysis on foo
+; CHECK-O3-NEXT: Running analysis: BranchProbabilityAnalysis on foo
 ; CHECK-O3-NEXT: Running pass: TaskSimplifyPass on foo
 ; CHECK-O3-NEXT: Running pass: LoopSimplifyPass
 ; CHECK-O3-NEXT: Running pass: LCSSAPass

--- a/llvm/test/Other/new-pm-thinlto-postlink-defaults.ll
+++ b/llvm/test/Other/new-pm-thinlto-postlink-defaults.ll
@@ -180,6 +180,8 @@
 ; CHECK-POSTLINK-O2-NEXT: Running pass: LCSSAPass
 ; CHECK-POSTLINK-O2-NEXT: Running pass: IndVarSimplifyPass
 ; CHECK-POSTLINK-O2-NEXT: Running pass: LoopStripMinePass on foo
+; CHECK-POSTLINK-O2-NEXT: Running analysis: BlockFrequencyAnalysis on foo
+; CHECK-POSTLINK-O2-NEXT: Running analysis: BranchProbabilityAnalysis on foo
 ; CHECK-POSTLINK-O2-NEXT: Running pass: TaskSimplifyPass on foo
 ; CHECK-POSTLINK-O2-NEXT: Running pass: LoopSimplifyPass on foo
 ; CHECK-POSTLINK-O2-NEXT: Running pass: LCSSAPass on foo
@@ -194,6 +196,8 @@
 ; CHECK-POSTLINK-O3-NEXT: Running pass: LCSSAPass
 ; CHECK-POSTLINK-O3-NEXT: Running pass: IndVarSimplifyPass
 ; CHECK-POSTLINK-O3-NEXT: Running pass: LoopStripMinePass on foo
+; CHECK-POSTLINK-O3-NEXT: Running analysis: BlockFrequencyAnalysis on foo
+; CHECK-POSTLINK-O3-NEXT: Running analysis: BranchProbabilityAnalysis on foo
 ; CHECK-POSTLINK-O3-NEXT: Running pass: TaskSimplifyPass on foo
 ; CHECK-POSTLINK-O3-NEXT: Running pass: LoopSimplifyPass on foo
 ; CHECK-POSTLINK-O3-NEXT: Running pass: LCSSAPass on foo

--- a/llvm/test/Transforms/Tapir/bfi-bpi.ll
+++ b/llvm/test/Transforms/Tapir/bfi-bpi.ll
@@ -1,0 +1,81 @@
+; Check branch probabilities and block frequencies around Tapir instructions.
+; Specifically, the CFG edge to a detached block should be heavily favored.
+;
+; RUN: opt < %s -passes="print<block-freq>,print<branch-prob>" -disable-output 2>&1 | FileCheck %s
+target datalayout = "e-m:o-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-n32:64-S128-Fn32"
+target triple = "arm64-apple-macosx26.0.0"
+
+; Function Attrs: nounwind ssp uwtable(sync)
+define void @foo(i32 noundef %n) local_unnamed_addr #0 {
+entry:
+  %syncreg = tail call token @llvm.syncregion.start()
+  %syncreg1 = tail call token @llvm.syncregion.start()
+  detach within %syncreg, label %det.achd, label %det.cont
+
+det.achd:                                         ; preds = %entry
+  tail call void @bar() #3
+  reattach within %syncreg, label %det.cont
+
+det.cont:                                         ; preds = %det.achd, %entry
+  %cmp = icmp sgt i32 %n, 0
+  br i1 %cmp, label %pfor.cond, label %cleanup
+
+pfor.cond:                                        ; preds = %det.cont, %pfor.inc
+  %__begin.0 = phi i32 [ %inc, %pfor.inc ], [ 0, %det.cont ]
+  detach within %syncreg1, label %pfor.body.entry, label %pfor.inc
+
+pfor.body.entry:                                  ; preds = %pfor.cond
+  tail call void @bar() #3
+  reattach within %syncreg1, label %pfor.inc
+
+pfor.inc:                                         ; preds = %pfor.body.entry, %pfor.cond
+  %inc = add nuw nsw i32 %__begin.0, 1
+  %exitcond.not = icmp eq i32 %inc, %n
+  br i1 %exitcond.not, label %pfor.cond.cleanup, label %pfor.cond, !llvm.loop !5
+
+pfor.cond.cleanup:                                ; preds = %pfor.inc
+  sync within %syncreg1, label %cleanup
+
+cleanup:                                          ; preds = %pfor.cond.cleanup, %det.cont
+  sync within %syncreg, label %sync.continue4
+
+sync.continue4:                                   ; preds = %cleanup
+  ret void
+}
+
+; CHECK-LABEL: block-frequency-info: foo
+; Check that the integral frequencies of detached blocks match those of their parents in the 3 most significant figures.
+; CHECK: entry: float = 1.0, int = [[ENTRY_FREQ:[0-9][0-9][0-9]]]{{[0-9]*}}
+; CHECK-NEXT: det.achd: float = {{.*}}, int = [[ENTRY_FREQ]]{{[0-9]*}}
+; CHECK-NEXT: det.cont: float = 1.0, int = [[ENTRY_FREQ]]{{[0-9]*}}
+; CHECK-NEXT: pfor.cond: float = {{.*}}, int = [[PFOR_COND_FREQ:[0-9][0-9][0-9]]]{{[0-9]*}}
+; CHECK-NEXT: pfor.body.entry: float = {{.*}}, int = [[PFOR_COND_FREQ]]{{[0-9]*}}
+; CHECK-NEXT: pfor.inc: float = {{.*}}, int = [[PFOR_COND_FREQ]]{{[0-9]*}}
+
+; CHECK-LABEL: Branch Probabilities
+; CHECK: edge %entry -> %det.achd probability is {{.*}} = 99.99% [HOT edge]
+; CHECK: edge %det.achd -> %det.cont probability is {{.*}} = 100.00% [HOT edge]
+; CHECK: edge %pfor.cond -> %pfor.body.entry probability is {{.*}} = 99.99% [HOT edge]
+
+; Function Attrs: mustprogress nounwind willreturn memory(argmem: readwrite)
+declare token @llvm.syncregion.start() #1
+
+declare void @bar(...) local_unnamed_addr #2
+
+attributes #0 = { nounwind ssp uwtable(sync) "frame-pointer"="non-leaf" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="apple-m1" "target-features"="+aes,+altnzcv,+ccdp,+ccidx,+ccpp,+complxnum,+crc,+dit,+dotprod,+flagm,+fp-armv8,+fp16fml,+fptoint,+fullfp16,+jsconv,+lse,+neon,+pauth,+perfmon,+predres,+ras,+rcpc,+rdm,+sb,+sha2,+sha3,+specrestrict,+ssbs,+v8.1a,+v8.2a,+v8.3a,+v8.4a,+v8a" }
+attributes #1 = { mustprogress nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { "frame-pointer"="non-leaf" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="apple-m1" "target-features"="+aes,+altnzcv,+ccdp,+ccidx,+ccpp,+complxnum,+crc,+dit,+dotprod,+flagm,+fp-armv8,+fp16fml,+fptoint,+fullfp16,+jsconv,+lse,+neon,+pauth,+perfmon,+predres,+ras,+rcpc,+rdm,+sb,+sha2,+sha3,+specrestrict,+ssbs,+v8.1a,+v8.2a,+v8.3a,+v8.4a,+v8a" }
+attributes #3 = { nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 8, !"PIC Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 1}
+!3 = !{i32 7, !"frame-pointer", i32 1}
+!4 = !{!"clang version 21.1.3 (git@github.com:OpenCilk/opencilk-project.git 25825e88610ce6e13e15addeb237e6e602d5ec49)"}
+!5 = distinct !{!5, !6, !7, !8}
+!6 = !{!"llvm.loop.mustprogress"}
+!7 = !{!"tapir.loop.spawn.strategy", i32 1}
+!8 = !{!"llvm.loop.unroll.disable"}

--- a/llvm/test/Transforms/Tapir/canonical-iv-size.ll
+++ b/llvm/test/Transforms/Tapir/canonical-iv-size.ll
@@ -65,7 +65,7 @@ pfor.cond.preheader:                              ; preds = %while.body
 
 ; CHECK: pfor.cond.preheader:
 ; CHECK-NOT: br label
-; CHECK: %[[GRAINSIZE:.+]] = call i32 @llvm.tapir.loop.grainsize.i32(i32 %0)
+; CHECK: %[[GRAINSIZE:.+]] = call i32 @llvm.tapir.loop.grainsize.i32(i32 %0, i32 0)
 ; CHECK: call {{.*}}void @doTimeStep.outline_pfor.cond.ls2(
 ; CHECK: i32 0,
 ; CHECK: i32 %0,

--- a/llvm/test/Transforms/Tapir/cilkplus-get-nworkers.ll
+++ b/llvm/test/Transforms/Tapir/cilkplus-get-nworkers.ll
@@ -13,7 +13,7 @@ entry:
 
 pfor.cond.preheader:                              ; preds = %entry
   %wide.trip.count = zext nneg i32 %n to i64
-  %0 = call i64 @llvm.tapir.loop.grainsize.i64(i64 %wide.trip.count)
+  %0 = call i64 @llvm.tapir.loop.grainsize.i64(i64 %wide.trip.count, i64 0)
   call fastcc void @normalize.outline_pfor.cond.ls1(i64 0, i64 %wide.trip.count, i64 %0, ptr %in, ptr %out, i32 %n) #4
   br label %cleanup
 
@@ -33,7 +33,7 @@ declare token @llvm.syncregion.start() #1
 declare double @norm(ptr noundef, i32 noundef) local_unnamed_addr #2
 
 ; Function Attrs: nounwind speculatable willreturn memory(none)
-declare i64 @llvm.tapir.loop.grainsize.i64(i64) #3
+declare i64 @llvm.tapir.loop.grainsize.i64(i64, i64) #3
 
 ; Function Attrs: nounwind ssp uwtable(sync)
 define internal fastcc void @normalize.outline_pfor.cond.ls1(i64 %indvars.iv.start.ls1, i64 %end.ls1, i64 %grainsize.ls1, ptr noalias noundef align 1 %in.ls1, ptr noalias nocapture noundef writeonly align 1 %out.ls1, i32 noundef %n.ls1) unnamed_addr #0 {

--- a/llvm/test/Transforms/Tapir/detach-trivial-unwind.ll
+++ b/llvm/test/Transforms/Tapir/detach-trivial-unwind.ll
@@ -45,7 +45,7 @@ entry:
 
 pfor.cond.preheader:                              ; preds = %entry
   %wide.trip.count = zext nneg i32 %n to i64
-  %0 = call i64 @llvm.tapir.loop.grainsize.i64(i64 %wide.trip.count)
+  %0 = call i64 @llvm.tapir.loop.grainsize.i64(i64 %wide.trip.count, i64 0)
   invoke fastcc void @_Z4loopiPc.outline_pfor.cond.ls1(i64 0, i64 %wide.trip.count, i64 %0, ptr %array)
           to label %pfor.cond.cleanup unwind label %lpad2.loopexit
 
@@ -269,7 +269,7 @@ declare i64 @__isoc23_strtol(ptr noundef, ptr noundef, i32 noundef) local_unname
 declare i32 @llvm.smax.i32(i32, i32) #9
 
 ; Function Attrs: nounwind speculatable willreturn memory(none)
-declare i64 @llvm.tapir.loop.grainsize.i64(i64) #10
+declare i64 @llvm.tapir.loop.grainsize.i64(i64, i64) #10
 
 ; Function Attrs: mustprogress uwtable
 define internal fastcc void @_Z4loopiPc.outline_pfor.cond.ls1(i64 %indvars.iv.start.ls1, i64 %end.ls1, i64 %grainsize.ls1, ptr nocapture noundef writeonly align 1 %array.ls1) unnamed_addr #0 personality ptr @__gxx_personality_v0 {

--- a/llvm/test/Transforms/Tapir/exception-spawn-in-parfor-loop-spawning.ll
+++ b/llvm/test/Transforms/Tapir/exception-spawn-in-parfor-loop-spawning.ll
@@ -613,9 +613,6 @@ unreachable:                                      ; preds = %lpad30, %lpad21, %l
 ; Function Attrs: nounwind
 declare void @llvm.assume(i1) #6
 
-; Function Attrs: nounwind readnone speculatable
-declare i32 @llvm.tapir.loop.grainsize.i32(i32) #7
-
 ; CHECK-LABEL: define internal fastcc void @_Z15parfor_trycatchi.outline_pfor.cond48.ls1(
 ; CHECK: %[[DACSYNCREG:.+]] = tail call token @llvm.syncregion.start()
 

--- a/llvm/test/Transforms/Tapir/loop-stripmine.ll
+++ b/llvm/test/Transforms/Tapir/loop-stripmine.ll
@@ -350,13 +350,13 @@ declare dso_local i32 @foo(double*, i32) local_unnamed_addr #5
 ; CHECK:  %[[STRPLOOPITER:.+]] = add nsw i64 %[[TRIPCOUNT:.+]], -1
 ; CHECK:  %[[XTRAITER:.+]] = and i64 %[[TRIPCOUNT]], 31
 ; CHECK:  %[[ICMP:.+]] = icmp slt i64 %[[STRPLOOPITER]], 31
-; CHECK:  br i1 %[[ICMP]], label %[[EPILCHECK:.+]], label %[[STRPLOOPPH:.+]], !dbg !51
+; CHECK:  br i1 %[[ICMP]], label %[[EPILCHECK:.+]], label %[[STRPLOOPPH:.+]], !dbg !52
 
 ; CHECK: [[STRPLOOPPH]]:
-; CHECK-NEXT: br label %[[STRPLOOPDETACH:.+]], !dbg !51
+; CHECK-NEXT: br label %[[STRPLOOPDETACH:.+]], !dbg !52
 
 ; CHECK: [[STRPLOOPDETACH]]:
-; CHECK-NEXT: detach within %syncreg, label %[[STRPLOOPDETACHENTRY:.+]], label %[[STRPLOOPDETACHCONT:.+]], !dbg !51
+; CHECK-NEXT: detach within %syncreg, label %[[STRPLOOPDETACHENTRY:.+]], label %[[STRPLOOPDETACHCONT:.+]], !dbg !52
 
 ; CHECK: [[STRPLOOPDETACHCONT]]:
 ; CHECK-NEXT: br label %[[EPILCHECK]]
@@ -365,10 +365,10 @@ declare dso_local i32 @foo(double*, i32) local_unnamed_addr #5
 ; CHECK: br i1 {{.+}}, label %[[EPILPH:.+]], label
 
 ; CHECK: [[EPILPH]]:
-; CHECK: br label %[[EPILHEADER:.+]], !dbg !51
+; CHECK: br label %[[EPILHEADER:.+]], !dbg !52
 
 ; CHECK: [[EPILHEADER]]:
-; CHECK: br label %[[EPILBODY:.+]], !dbg !51
+; CHECK: br label %[[EPILBODY:.+]], !dbg !52
 
 ; CHECK: [[EPILBODY]]:
 ; CHECK-NEXT: call ptr @llvm.stacksave.p0()
@@ -379,17 +379,17 @@ declare dso_local i32 @foo(double*, i32) local_unnamed_addr #5
 
 ; CHECK: [[STRPLOOPDETACHENTRY]]:
 ; CHECK: %[[NEWSYNCREG:.+]] = call token @llvm.syncregion.start()
-; CHECK: br label %[[STRPLOOPOUTERHEAD:.+]], !dbg !51
+; CHECK: br label %[[STRPLOOPOUTERHEAD:.+]], !dbg !52
 
 ; CHECK: [[STRPLOOPOUTERHEAD]]:
-; CHECK: detach within %[[NEWSYNCREG]], label %[[STRPLOOPINNERENTRY:.+]], label %{{.+}}, !dbg !51
+; CHECK: detach within %[[NEWSYNCREG]], label %[[STRPLOOPINNERENTRY:.+]], label %{{.+}}, !dbg !52
 
 ; CHECK: [[STRPLOOPINNERENTRY]]:
 ; CHECK: alloca [7 x double]
-; CHECK: br label %[[STRPLOOPINNERHEAD:.+]], !dbg !51
+; CHECK: br label %[[STRPLOOPINNERHEAD:.+]], !dbg !52
 
 ; CHECK: [[STRPLOOPINNERHEAD]]:
-; CHECK: br label %[[STRPLOOPINNERBODY:.+]], !dbg !51
+; CHECK: br label %[[STRPLOOPINNERBODY:.+]], !dbg !52
 
 ; CHECK: [[STRPLOOPINNERBODY]]:
 ; CHECK: call ptr @llvm.stacksave.p0()


### PR DESCRIPTION
This PR makes the following changes to grainsize analysis for parallel loops:
- Use branch-prediction information, via block-frequency analysis, into the analysis of the work of a Tapir loop.
- Modify loop stripmining to more eagerly use grainsize 1 for parallel loops that appear to have sufficient work.
- Modify loop stripmining to serialize loops that don't appear profitable to parallelize, rather than simply raise a warning.  This change better accommodates compiller-generated specializations of parallel loops.
- Allow loop stripmining to determine and record upper bounds on grainsize.
- Modify OpenCilkABI to report grainsize bounds to the runtime system via its `__cilkrts_cilk_for_grainsize` ABI functions.

This PR also cleans up the code formatting of relevant files.