### PR TITLE
Fix builtin_setjmp for x86 when cf-protection is enabled

### DIFF
--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -36973,11 +36973,7 @@ void X86TargetLowering::emitSetJmpShadowStackFix(MachineInstr &MI,
   MVT PVT = getPointerTy(MF->getDataLayout());
   const TargetRegisterClass *PtrRC = getRegClassFor(PVT);
   Register ZReg = MRI.createVirtualRegister(PtrRC);
-  unsigned XorRROpc = (PVT == MVT::i64) ? X86::XOR64rr : X86::XOR32rr;
-  BuildMI(*MBB, MI, MIMD, TII->get(XorRROpc))
-      .addDef(ZReg)
-      .addReg(ZReg, RegState::Undef)
-      .addReg(ZReg, RegState::Undef);
+  BuildMI(*MBB, MI, MIMD, TII->get(X86::MOV32r0)).addDef(ZReg);
 
   // Read the current SSP Register value to the zeroed register.
   Register SSPCopyReg = MRI.createVirtualRegister(PtrRC);

--- a/llvm/test/CodeGen/X86/shadow-stack.ll
+++ b/llvm/test/CodeGen/X86/shadow-stack.ll
@@ -135,7 +135,7 @@ define i32 @foo(i32 %i) local_unnamed_addr {
 ; X86_64-NEXT:    movq %rsp, 16(%rax)
 ; X86_64-NEXT:    leaq LBB1_2(%rip), %rcx
 ; X86_64-NEXT:    movq %rcx, 8(%rax)
-; X86_64-NEXT:    xorq %rcx, %rcx
+; X86_64-NEXT:    xorl %rcx, %rcx
 ; X86_64-NEXT:    rdsspq %rcx
 ; X86_64-NEXT:    movq %rcx, 24(%rax)
 ; X86_64-NEXT:    #EH_SjLj_Setup LBB1_2


### PR DESCRIPTION
In emitSetJmpShadowStackFix use MOV32r0 rather than XOR to clear a register.

The fast register allocator generates bad code for the xor zero idiom generated at this stage of code generation.