### PR TITLE
Fix call-to-invoke promotion around taskframes

### DIFF
--- a/llvm/include/llvm/Transforms/Utils/TapirUtils.h
+++ b/llvm/include/llvm/Transforms/Utils/TapirUtils.h
@@ -250,6 +250,7 @@ BasicBlock *CreateSubTaskUnwindEdge(Intrinsic::ID TermFunc, Value *Token,
 /// call sites in a custom manner.
 void promoteCallsInTasksToInvokes(
     Function &F, const Twine Name = "cleanup",
+    bool IgnoreUnreachableBlocks = true,
     std::function<bool(CallBase *)> IgnoreFunctionCheck = nullptr);
 
 /// eraseTaskFrame - Remove the specified taskframe and all uses of it.  The

--- a/llvm/lib/Transforms/Instrumentation/ComprehensiveStaticInstrumentation.cpp
+++ b/llvm/lib/Transforms/Instrumentation/ComprehensiveStaticInstrumentation.cpp
@@ -749,7 +749,7 @@ void CSIImpl::setupCalls(Function &F) {
   if (F.doesNotThrow())
     return;
 
-  promoteCallsInTasksToInvokes(F, "csi.cleanup", [](CallBase *CB) {
+  promoteCallsInTasksToInvokes(F, "csi.cleanup", true, [](CallBase *CB) {
     if (const Function *F = CB->getCalledFunction()) {
       if (F->getName().starts_with("__asan")) {
         CB->setDoesNotThrow();
@@ -880,15 +880,25 @@ static void setupBlock(BasicBlock *BB, const TargetLibraryInfo *TLI,
 void CSIImpl::setupBlocks(Function &F, const TargetLibraryInfo *TLI,
                           DominatorTree *DT, LoopInfo *LI) {
   SmallPtrSet<BasicBlock *, 8> BlocksToSetup;
-  for (BasicBlock &BB : F) {
-    if (BB.isLandingPad())
-      BlocksToSetup.insert(&BB);
+  SmallVector<BasicBlock *, 8> Worklist;
+  SmallPtrSet<BasicBlock *, 8> Visited;
+  Worklist.push_back(&F.getEntryBlock());
+  while (!Worklist.empty()) {
+    BasicBlock *BB = Worklist.pop_back_val();
+    if (!Visited.insert(BB).second)
+      continue;
 
-    if (InvokeInst *II = dyn_cast<InvokeInst>(BB.getTerminator())) {
+    if (BB->isLandingPad())
+      BlocksToSetup.insert(BB);
+
+    if (InvokeInst *II = dyn_cast<InvokeInst>(BB->getTerminator())) {
       if (!isTapirPlaceholderSuccessor(II->getNormalDest()))
         BlocksToSetup.insert(II->getNormalDest());
-    } else if (SyncInst *SI = dyn_cast<SyncInst>(BB.getTerminator()))
+    } else if (SyncInst *SI = dyn_cast<SyncInst>(BB->getTerminator()))
       BlocksToSetup.insert(SI->getSuccessor(0));
+
+    for (BasicBlock *Succ : successors(BB))
+      Worklist.push_back(Succ);
   }
 
   DomTreeUpdater DTU(DT, DomTreeUpdater::UpdateStrategy::Lazy);
@@ -900,8 +910,14 @@ void CSIImpl::setupBlocks(Function &F, const TargetLibraryInfo *TLI,
 void CSIImpl::splitBlocksAtCalls(Function &F, DominatorTree *DT, LoopInfo *LI) {
   // Split basic blocks after call instructions.
   SmallVector<Instruction *, 32> CallsToSplit;
-  for (BasicBlock &BB : F)
-    for (Instruction &I : BB)
+  SmallVector<BasicBlock *, 8> Worklist;
+  SmallPtrSet<BasicBlock *, 8> Visited;
+  Worklist.push_back(&F.getEntryBlock());
+  while (!Worklist.empty()) {
+    BasicBlock *BB = Worklist.pop_back_val();
+    if (!Visited.insert(BB).second)
+      continue;
+    for (Instruction &I : *BB)
       if (isa<CallInst>(I) &&
           // Skip placeholder call instructions
           !callsPlaceholderFunction(I) &&
@@ -911,6 +927,10 @@ void CSIImpl::splitBlocksAtCalls(Function &F, DominatorTree *DT, LoopInfo *LI) {
           // If the call does not return, don't bother splitting
           !cast<CallInst>(&I)->doesNotReturn())
         CallsToSplit.push_back(&I);
+
+    for (BasicBlock *Succ : successors(BB))
+      Worklist.push_back(Succ);
+  }
 
   for (Instruction *Call : CallsToSplit)
     SplitBlock(Call->getParent(), Call->getNextNode(), DT, LI);

--- a/llvm/lib/Transforms/Instrumentation/ThreadSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/ThreadSanitizer.cpp
@@ -578,7 +578,8 @@ bool ThreadSanitizer::sanitizeFunction(Function &F,
     IRB.CreateCall(TsanFuncEntry, ReturnAddress);
 
     if (ClHandleCxxExceptions && !F.doesNotThrow())
-      promoteCallsInTasksToInvokes(F, "tsan_cleanup");
+      // TODO: Modify ThreadSanitizer to not instrument unreachable code.
+      promoteCallsInTasksToInvokes(F, "tsan_cleanup", false);
 
     EscapeEnumerator EE(F, "tsan_cleanup", ClHandleCxxExceptions);
     while (IRBuilder<> *AtExit = EE.Next()) {

--- a/llvm/lib/Transforms/Utils/TapirUtils.cpp
+++ b/llvm/lib/Transforms/Utils/TapirUtils.cpp
@@ -2126,6 +2126,8 @@ promoteCallsInTasksHelper(BasicBlock *EntryBlock, BasicBlock *UnwindEdge,
                           SmallVectorImpl<BasicBlock *> *ParentWorklist,
                           SmallPtrSetImpl<BasicBlock *> &Processed,
                           std::function<bool(CallBase *)> IgnoreFunctionCheck) {
+  LLVM_DEBUG(dbgs() << "Promoting calls in task at " << EntryBlock->getName()
+                    << "\n");
   SmallVector<DetachInst *, 8> DetachesToReplace;
   SmallVector<BasicBlock *, 32> Worklist;
   // TODO: See if we need a global Visited set over all recursive calls, i.e.,
@@ -2140,11 +2142,17 @@ promoteCallsInTasksHelper(BasicBlock *EntryBlock, BasicBlock *UnwindEdge,
 
     // Promote any calls in the block to invokes.
     while (BasicBlock *NewBB = maybePromoteCallInBlock(
-               BB, UnwindEdge, CurrentTaskFrame, IgnoreFunctionCheck))
+               BB, UnwindEdge, CurrentTaskFrame, IgnoreFunctionCheck)) {
+      // Mark BB as processed, to prevent it from being incorrectly processed in
+      // the future as a top-level taskframe.create or detaching block.
+      Processed.insert(BB);
       BB = cast<InvokeInst>(NewBB->getTerminator())->getNormalDest();
+    }
 
     Instruction *TFI = getTaskFrameInstructionInBlock(BB, CurrentTaskFrame);
     if (TFI && isTapirIntrinsic(Intrinsic::taskframe_create, TFI)) {
+      // Mark BB as processed, so it won't be processed again in the future as a
+      // top-level block.
       Processed.insert(BB);
       Instruction *TFCreate = TFI;
       if (TFCreate != CurrentTaskFrame) {
@@ -2160,10 +2168,14 @@ promoteCallsInTasksHelper(BasicBlock *EntryBlock, BasicBlock *UnwindEdge,
             CreateSubTaskUnwindEdge(Intrinsic::taskframe_resume, TFCreate,
                                     UnwindEdge, Unreachable, TFCreate);
 
+        LLVM_DEBUG(dbgs() << "Recursively promote calls in taskframe at "
+                          << NewBB->getName() << "\n");
         // Recursively check all blocks
         promoteCallsInTasksHelper(NewBB, TaskFrameUnwindEdge, Unreachable,
                                   TFCreate, &Worklist, Processed,
                                   IgnoreFunctionCheck);
+        LLVM_DEBUG(dbgs() << "Done recursively promoting calls in taskframe at "
+                          << NewBB->getName() << "\n");
 
         // Remove the unwind edge for the taskframe if it is not needed.
         if (pred_empty(TaskFrameUnwindEdge))
@@ -2180,6 +2192,9 @@ promoteCallsInTasksHelper(BasicBlock *EntryBlock, BasicBlock *UnwindEdge,
         // This taskframe.end does not terminate the basic block.  To make sure
         // the rest of the block is processed properly, split the block.
         BasicBlock *NewBB = SplitBlock(BB, TFI->getNextNode());
+        // Mark BB as processed, to prevent it from being incorrectly processed
+        // in the future as a top-level taskframe.create or detaching block.
+        Processed.insert(BB);
         ParentWorklist->push_back(NewBB);
       } else {
         // Add all successors of BB to the worklist.
@@ -2206,9 +2221,11 @@ promoteCallsInTasksHelper(BasicBlock *EntryBlock, BasicBlock *UnwindEdge,
       continue;
     }
 
-    // Process a detach instruction specially.  In particular, process th
+    // Process a detach instruction specially.  In particular, process the
     // spawned task recursively.
     if (DetachInst *DI = dyn_cast<DetachInst>(BB->getTerminator())) {
+      // Mark BB as processed, so it won't be processed again in the future as a
+      // top-level block.
       Processed.insert(BB);
 
       // Create an unwind edge for the subtask, which is terminated with a
@@ -2217,10 +2234,16 @@ promoteCallsInTasksHelper(BasicBlock *EntryBlock, BasicBlock *UnwindEdge,
           Intrinsic::detached_rethrow, DI->getSyncRegion(),
           DI->hasUnwindDest() ? DI->getUnwindDest() : UnwindEdge, Unreachable,
           DI);
+
+      LLVM_DEBUG(dbgs() << "Recursively promote calls in detached task at "
+                        << DI->getDetached()->getName() << "\n");
       // Recursively check all blocks in the detached task.
       promoteCallsInTasksHelper(DI->getDetached(), SubTaskUnwindEdge,
                                 Unreachable, CurrentTaskFrame, &Worklist,
                                 Processed, IgnoreFunctionCheck);
+      LLVM_DEBUG(
+          dbgs() << "Done recursively promoting calls in detached task at "
+                 << DI->getDetached()->getName() << "\n");
 
       // If the new unwind edge is not used, remove it.
       if (pred_empty(SubTaskUnwindEdge))
@@ -2301,9 +2324,12 @@ void llvm::promoteCallsInTasksToInvokes(
   // Recursively handle inlined tasks.
   SmallPtrSet<BasicBlock *, 8> Processed;
   for (BasicBlock *BB : ToProcess) {
-    if (!Processed.contains(BB))
+    if (!Processed.contains(BB)) {
+      LLVM_DEBUG(dbgs() << "Promoting calls in tasks from top-level block "
+                        << BB->getName() << "\n");
       promoteCallsInTasksHelper(BB, CleanupBB, UnreachableBlk, nullptr, nullptr,
                                 Processed, IgnoreFunctionCheck);
+    }
   }
 
   // Either finish inserting the cleanup block (and associated data) or remove

--- a/llvm/lib/Transforms/Utils/TapirUtils.cpp
+++ b/llvm/lib/Transforms/Utils/TapirUtils.cpp
@@ -2294,18 +2294,20 @@ static FunctionCallee getDefaultPersonalityFn(Module *M) {
 }
 
 void llvm::promoteCallsInTasksToInvokes(
-    Function &F, const Twine Name,
+    Function &F, const Twine Name, bool IgnoreUnreachableBlocks,
     std::function<bool(CallBase *)> IgnoreFunctionCheck) {
   // Collect blocks to process, in order to handle unreachable blocks.
   SmallVector<BasicBlock *, 8> ToProcess;
   ToProcess.push_back(&F.getEntryBlock());
-  for (BasicBlock &BB : F) {
-    Instruction *TFI = getTaskFrameInstructionInBlock(&BB, nullptr);
-    if (TFI && isTapirIntrinsic(Intrinsic::taskframe_create, TFI))
-      ToProcess.push_back(&BB);
+  if (!IgnoreUnreachableBlocks) {
+    for (BasicBlock &BB : F) {
+      Instruction *TFI = getTaskFrameInstructionInBlock(&BB, nullptr);
+      if (TFI && isTapirIntrinsic(Intrinsic::taskframe_create, TFI))
+        ToProcess.push_back(&BB);
 
-    if (isa<DetachInst>(BB.getTerminator()))
-      ToProcess.push_back(&BB);
+      if (isa<DetachInst>(BB.getTerminator()))
+        ToProcess.push_back(&BB);
+    }
   }
 
   // Create a cleanup block.

--- a/llvm/test/Transforms/Tapir/csi-setup-ignore-unreachable.ll
+++ b/llvm/test/Transforms/Tapir/csi-setup-ignore-unreachable.ll
@@ -1,0 +1,49 @@
+; Check that CSI-setup ignores unreachable code when promoting calls to invokes.
+;
+; RUN: opt < %s -passes="csi-setup" -S | FileCheck %s
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+define i32 @main() {
+entry:
+  %syncreg = call token @llvm.syncregion.start()
+  br label %__cilk_parent_epilogue.exit
+
+det.cont.tf:                                      ; No predecessors!
+  %0 = call token @llvm.taskframe.create()
+  %syncreg1 = call token @llvm.syncregion.start()
+  br label %det.cont3
+
+det.cont.tf.tf:                                   ; No predecessors!
+  %1 = call token @llvm.taskframe.create()
+  detach within %syncreg1, label %det.achd2, label %det.cont3
+
+det.achd2:                                        ; preds = %det.cont.tf.tf
+  call void @llvm.taskframe.use(token %1)
+  reattach within %syncreg1, label %det.cont3
+
+det.cont3:                                        ; preds = %det.achd2, %det.cont.tf.tf, %det.cont.tf
+  call void null()
+  br label %__cilk_parent_epilogue.exit
+
+__cilk_parent_epilogue.exit:                      ; preds = %det.cont3, %entry
+  ret i32 0
+}
+
+; CHECK: det.cont3:
+; CHECK-NOT: invoke void null()
+
+; Function Attrs: nounwind willreturn memory(argmem: readwrite)
+declare token @llvm.syncregion.start() #0
+
+; Function Attrs: nounwind willreturn memory(argmem: readwrite)
+declare token @llvm.taskframe.create() #0
+
+; Function Attrs: nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.taskframe.use(token) #0
+
+; uselistorder directives
+uselistorder ptr @llvm.syncregion.start, { 1, 0 }
+uselistorder ptr @llvm.taskframe.create, { 1, 0 }
+
+attributes #0 = { nounwind willreturn memory(argmem: readwrite) }

--- a/llvm/test/Transforms/Tapir/csi-setup-taskframes.ll
+++ b/llvm/test/Transforms/Tapir/csi-setup-taskframes.ll
@@ -1,0 +1,162 @@
+; Check that CSI-setup properly promotes calls to invokes around various kinds of taskframes.
+;
+; RUN: opt < %s -passes="csi-setup" -S | FileCheck %s
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+; Function Attrs: mustprogress noinline nounwind optnone uwtable
+define dso_local void @_Z1fv() #0 {
+entry:
+  ret void
+}
+
+; Function Attrs: mustprogress noinline norecurse optnone uwtable
+define dso_local noundef i32 @main() #1 {
+entry:
+  %retval = alloca i32, align 4
+  %syncreg = call token @llvm.syncregion.start()
+  %cleanup.dest.slot = alloca i32, align 4
+  store i32 0, ptr %retval, align 4
+  %0 = call token @llvm.taskframe.create()
+  detach within %syncreg, label %det.achd, label %det.cont
+
+det.achd:                                         ; preds = %entry
+  call void @llvm.taskframe.use(token %0)
+  call void @_Z1fv()
+  reattach within %syncreg, label %det.cont
+
+det.cont:                                         ; preds = %det.achd, %entry
+  %1 = call token @llvm.taskframe.create()
+  %syncreg1 = call token @llvm.syncregion.start()
+  %2 = call token @llvm.taskframe.create()
+  detach within %syncreg1, label %det.achd2, label %det.cont3
+
+det.achd2:                                        ; preds = %det.cont
+  call void @llvm.taskframe.use(token %2)
+  call void @_Z1fv()
+  reattach within %syncreg1, label %det.cont3
+
+det.cont3:                                        ; preds = %det.achd2, %det.cont
+  call void @_Z1fv()
+  sync within %syncreg1, label %sync.continue
+
+sync.continue:                                    ; preds = %det.cont3
+  call void @llvm.sync.unwind(token %syncreg1)
+  call void @llvm.taskframe.end(token %1)
+  %3 = call token @llvm.taskframe.create()
+  detach within %syncreg, label %det.achd4, label %det.cont5
+
+det.achd4:                                        ; preds = %sync.continue
+  call void @llvm.taskframe.use(token %3)
+  call void @_Z1fv()
+  reattach within %syncreg, label %det.cont5
+
+det.cont5:                                        ; preds = %det.achd4, %sync.continue
+  call void @_Z1fv()
+  sync within %syncreg, label %sync.continue6
+
+sync.continue6:                                   ; preds = %det.cont5
+  call void @llvm.sync.unwind(token %syncreg)
+  %4 = load i32, ptr %retval, align 4
+  ret i32 %4
+}
+
+; CHECK: define {{.*}}i32 @main()
+; CHECK: entry:
+; CHECK: br label %[[ENTRY_SPLIT:.+]]
+
+; CHECK: [[ENTRY_SPLIT]]:
+; CHECK-NEXT: %[[TF0:.+]] = call token @llvm.taskframe.create()
+; CHECK-NEXT: detach within %syncreg, label %det.achd, label %det.cont
+
+; CHECK: det.achd:
+; CHECK-NEXT: call void @llvm.taskframe.use(token %[[TF0]])
+; CHECK-NEXT: call void @_Z1fv()
+; CHECK-NEXT: reattach within %syncreg, label %det.cont
+
+; CHECK: det.cont:
+; CHECK-NEXT: %[[TF1:.+]] = call token @llvm.taskframe.create()
+; CHECK: br label %[[DET_CONT_SPLIT:.+]]
+
+; CHECK: [[DET_CONT_SPLIT]]:
+; CHECK-NEXT: %[[TF2:.+]] = call token @llvm.taskframe.create()
+; CHECK-NEXT: detach within %syncreg1, label %det.achd2, label %det.cont3
+
+; CHECK: det.achd2:
+; CHECK-NEXT: call void @llvm.taskframe.use(token %[[TF2]])
+; CHECK-NEXT: call void @_Z1fv()
+; CHECK-NEXT: reattach within %syncreg1, label %det.cont3
+
+; CHECK: det.cont3:
+; CHECK-NEXT: call void @_Z1fv()
+; CHECK-NEXT: sync within %syncreg1, label %sync.continue
+
+; CHECK: sync.continue:
+; CHECK-NEXT: invoke void @llvm.sync.unwind(token %syncreg1)
+; CHECK-NEXT: to label %[[SYNC_CONT_SPLIT:.+]] unwind label %[[CSI_CLEANUP5:.+]]
+
+; CHECK: [[SYNC_CONT_SPLIT]]:
+; CHECK-NEXT: call void @llvm.taskframe.end(token %[[TF1]])
+; CHECK-NEXT: br label %[[TF1_END_SPLIT:.+]]
+
+; CHECK: [[TF1_END_SPLIT]]:
+; CHECK-NEXT: %[[TF3:.+]] = call token @llvm.taskframe.create()
+; CHECK-NEXT: detach within %syncreg, label %det.achd4, label %det.cont5
+
+; CHECK: det.achd4:
+; CHECK-NEXT: call void @llvm.taskframe.use(token %[[TF3]])
+; CHECK-NEXT: call void @_Z1fv()
+; CHECK-NEXT: reattach within %syncreg, label %det.cont5
+
+; CHECK: det.cont5:
+; CHECK-NEXT: call void @_Z1fv()
+; CHECK-NEXT: sync within %syncreg, label %sync.continue6
+
+; CHECK: sync.continue6:
+; CHECK-NEXT: invoke void @llvm.sync.unwind(token %syncreg)
+; CHECK-NEXT: to label %[[SYNC_CONT6_SPLIT:.+]] unwind label %[[CSI_CLEANUP:.+]]
+
+; CHECK: [[SYNC_CONT6_SPLIT]]:
+; CHECK-NEXT: load i32
+; CHECK-NEXT: ret i32
+
+; CHECK: [[CSI_CLEANUP]]:
+; CHECK-NEXT: landingpad
+; CHECK-NEXT: cleanup
+; CHECK-NEXT: resume
+
+; CHECK: [[CSI_CLEANUP5]]:
+; CHECK-NEXT: %[[LPAD:.+]] = landingpad { ptr, i32 }
+; CHECK-NEXT: cleanup
+; CHECK-NEXT: invoke void @llvm.taskframe.resume.sl_p0i32s(token %[[TF1]], { ptr, i32 } %[[LPAD]])
+; CHECK-NEXT: to label %[[CSI_CLEANUP_UNREACHABLE:.+]] unwind label %[[CSI_CLEANUP]]
+
+; Function Attrs: nounwind willreturn memory(argmem: readwrite)
+declare token @llvm.syncregion.start() #2
+
+; Function Attrs: nounwind willreturn memory(argmem: readwrite)
+declare token @llvm.taskframe.create() #2
+
+; Function Attrs: nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.taskframe.use(token) #2
+
+; Function Attrs: willreturn memory(argmem: readwrite)
+declare void @llvm.sync.unwind(token) #3
+
+; Function Attrs: nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.taskframe.end(token) #2
+
+attributes #0 = { mustprogress noinline nounwind optnone uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #1 = { mustprogress noinline norecurse optnone uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #2 = { nounwind willreturn memory(argmem: readwrite) }
+attributes #3 = { willreturn memory(argmem: readwrite) }
+
+!llvm.module.flags = !{!0, !1, !2, !3, !4}
+!llvm.ident = !{!5}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 8, !"PIC Level", i32 2}
+!2 = !{i32 7, !"PIE Level", i32 2}
+!3 = !{i32 7, !"uwtable", i32 2}
+!4 = !{i32 7, !"frame-pointer", i32 2}
+!5 = !{!"clang version 21.1.3 (git@github.com:OpenCilk/opencilk-project.git e60c5d62805dcca1d1d8982f759586f545cdc051)"}


### PR DESCRIPTION
This PR fixes issues where basic blocks are incorrectly processed multiple times for calls to promote to invokes.  This PR fixes issue #410.