### PR TITLE
Strip hyperobject wrapper when evaluating c++14 constexpr constructor

### DIFF
--- a/clang/lib/AST/APValue.cpp
+++ b/clang/lib/AST/APValue.cpp
@@ -821,7 +821,7 @@ void APValue::printPretty(raw_ostream &Out, const PrintingPolicy &Policy,
     else if (isLValueOnePastTheEnd())
       Out << "*(&";
 
-    QualType ElemTy = Base.getType().getNonReferenceType();
+    QualType ElemTy = Base.getType().getNonReferenceType().stripHyperobject();
     if (const ValueDecl *VD = Base.dyn_cast<const ValueDecl*>()) {
       Out << *VD;
     } else if (TypeInfoLValue TI = Base.dyn_cast<TypeInfoLValue>()) {

--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -87,7 +87,10 @@ namespace {
       CurrentSourceLocExprScope::SourceLocExprScopeGuard;
 
   static QualType getType(APValue::LValueBase B) {
-    return B.getType();
+    QualType Ty = B.getType();
+    if (!Ty.isNull())
+      Ty = Ty.stripHyperobject();
+    return Ty;
   }
 
   /// Get an LValue path entry, which is known to not be an array index, as a

--- a/clang/test/Cilk/constexpr-ctor.cpp
+++ b/clang/test/Cilk/constexpr-ctor.cpp
@@ -1,0 +1,28 @@
+// RUN: %clang_cc1 %s -x c++ --std=c++20 -fopencilk -verify -fsyntax-only
+// expected-no-diagnostics
+template<typename Data> class vector {
+  using size_type = unsigned long;
+
+  using pointer = Data *;
+
+  pointer __begin_ = nullptr;
+
+public:
+  constexpr  explicit vector(size_type __n) {
+    if (__n > 0) {
+      __vallocate(__n);
+    }
+  }
+  constexpr void __vallocate(size_type __n) {
+    __begin_ = nullptr;
+  }
+  constexpr ~vector() { }
+};
+
+extern "C" void identity(void *);
+extern "C" void reduce(void *, void *);
+
+int main() {
+  static vector<double> cilk_reducer(identity, reduce) foo(3);
+  return 0;
+}


### PR DESCRIPTION
Initialization of a reducer where the underlying object has a `constexpr` constructor can cause crashes when the type of the `Decl` does not match the type of the initializer.

The better approach may be to suppress `constexpr` processing in such cases because `constexpr` reducers do not make sense.