### PR TITLE
Choose OpenCilk personality in compiler

### DIFF
--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -2123,22 +2123,7 @@ void ToolChain::AddTapirRuntimeLibArgs(const ArgList &Args,
           Args, UseAsan ? "opencilk-pedigrees-asan" : "opencilk-pedigrees",
           StaticOpenCilk ? ToolChain::FT_Static : ToolChain::FT_Shared)));
 
-    // Link the correct Cilk personality fn
-    if (getDriver().CCCIsCXX())
-      CmdArgs.push_back(Args.MakeArgString(getOpenCilkRT(
-          Args,
-          UseAsan ? "opencilk-asan-personality-cpp"
-                  : "opencilk-personality-cpp",
-          StaticOpenCilk ? ToolChain::FT_Static : ToolChain::FT_Shared)));
-    else
-      CmdArgs.push_back(Args.MakeArgString(getOpenCilkRT(
-          Args,
-          UseAsan ? "opencilk-asan-personality-c" : "opencilk-personality-c",
-          StaticOpenCilk ? ToolChain::FT_Static : ToolChain::FT_Shared)));
-
-    // Link the opencilk runtime.  We do this after linking the personality
-    // function, to ensure that symbols are resolved correctly when using static
-    // linking.
+    // Link the opencilk runtime.
     CmdArgs.push_back(Args.MakeArgString(getOpenCilkRT(
         Args, UseAsan ? "opencilk-asan" : "opencilk",
         StaticOpenCilk ? ToolChain::FT_Static : ToolChain::FT_Shared)));

--- a/clang/lib/Driver/ToolChains/Darwin.cpp
+++ b/clang/lib/Driver/ToolChains/Darwin.cpp
@@ -3983,26 +3983,12 @@ void DarwinClang::AddLinkTapirRuntime(const ArgList &Args,
                                      : "opencilk-pedigrees",
                              RLO, !StaticOpenCilk);
 
-    // Link the correct Cilk personality fn
-    if (getDriver().CCCIsCXX())
-      AddLinkTapirRuntimeLib(Args, CmdArgs,
-                             UseAsan ? "opencilk-asan-personality-cpp"
-                                     : "opencilk-personality-cpp",
-                             RLO, !StaticOpenCilk);
-    else
-      AddLinkTapirRuntimeLib(Args, CmdArgs,
-                             UseAsan ? "opencilk-asan-personality-c"
-                                     : "opencilk-personality-c",
-                             RLO, !StaticOpenCilk);
-
     if (!StaticOpenCilk)
       // Add rpath flag for linking the final Tapir runtime library, to avoid
       // warnings about ignoring duplicate rpaths.
       RLO = RuntimeLinkOptions(RLO | RLO_AddRPath);
 
-    // Link the opencilk runtime.  We do this after linking the personality
-    // function, to ensure that symbols are resolved correctly when using static
-    // linking.
+    // Link the opencilk runtime.
     AddLinkTapirRuntimeLib(Args, CmdArgs,
                            UseAsan ? "opencilk-asan" : "opencilk", RLO,
                            !StaticOpenCilk);

--- a/llvm/include/llvm/IR/EHPersonalities.h
+++ b/llvm/include/llvm/IR/EHPersonalities.h
@@ -35,6 +35,7 @@ enum class EHPersonality {
   Wasm_CXX,
   XL_CXX,
   ZOS_CXX,
+  Cilk_C,
   Cilk_CXX
 };
 

--- a/llvm/lib/IR/EHPersonalities.cpp
+++ b/llvm/lib/IR/EHPersonalities.cpp
@@ -51,7 +51,8 @@ EHPersonality llvm::classifyEHPersonality(const Value *Pers) {
       .Case("__gxx_wasm_personality_v0", EHPersonality::Wasm_CXX)
       .Case("__xlcxx_personality_v1", EHPersonality::XL_CXX)
       .Case("__zos_cxx_personality_v2", EHPersonality::ZOS_CXX)
-      .Case("__cilk_personality_v0", EHPersonality::Cilk_CXX)
+      .Case("__cilk_personality_cpp_v0", EHPersonality::Cilk_CXX)
+      .Case("__cilk_personality_c_v0", EHPersonality::Cilk_C)
       .Default(EHPersonality::Unknown);
 }
 
@@ -85,8 +86,10 @@ StringRef llvm::getEHPersonalityName(EHPersonality Pers) {
     return "__xlcxx_personality_v1";
   case EHPersonality::ZOS_CXX:
     return "__zos_cxx_personality_v2";
+  case EHPersonality::Cilk_C:
+    return "__cilk_personality_c_v0";
   case EHPersonality::Cilk_CXX:
-    return "__cilk_personality_v0";
+    return "__cilk_personality_cpp_v0";
   case EHPersonality::Unknown:
     llvm_unreachable("Unknown EHPersonality!");
   }

--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -4542,6 +4542,7 @@ static bool isCatchAll(EHPersonality Personality, Constant *TypeInfo) {
   case EHPersonality::Wasm_CXX:
   case EHPersonality::XL_CXX:
   case EHPersonality::ZOS_CXX:
+  case EHPersonality::Cilk_C:
   case EHPersonality::Cilk_CXX:
     return TypeInfo->isNullValue();
   }

--- a/llvm/lib/Transforms/Tapir/OpenCilkABI.cpp
+++ b/llvm/lib/Transforms/Tapir/OpenCilkABI.cpp
@@ -24,6 +24,7 @@
 #include "llvm/IR/DiagnosticInfo.h"
 #include "llvm/IR/DiagnosticPrinter.h"
 #include "llvm/IR/Dominators.h"
+#include "llvm/IR/EHPersonalities.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/InlineAsm.h"
 #include "llvm/IR/InstIterator.h"
@@ -642,11 +643,27 @@ void OpenCilkABI::MarkSpawner(Function &F) {
   // If the spawner F might throw, then we mark F with the Cilk personality
   // function, which ensures that the Cilk stack frame of F is properly unwound.
   if (!F.doesNotThrow()) {
+    EHPersonality P = EHPersonality::Cilk_C;
+    if (F.hasPersonalityFn()) {
+      switch (classifyEHPersonality(F.getPersonalityFn())) {
+      case EHPersonality::GNU_CXX:
+        P = EHPersonality::Cilk_CXX;
+        break;
+      case EHPersonality::GNU_C:
+      case EHPersonality::Unknown:
+        P = EHPersonality::Cilk_C;
+        break;
+      default:
+        llvm_unreachable("Unsupported exception handling in spawner");
+        break;
+      }
+    }
+
     LLVMContext &C = M.getContext();
     // Get the type of the Cilk personality function the same way that clang and
     // EscapeEnumerator get the type of a personality function.
     Function *Personality = cast<Function>(
-        M.getOrInsertFunction("__cilk_personality_v0",
+        M.getOrInsertFunction(getEHPersonalityName(P),
                               FunctionType::get(Type::getInt32Ty(C), true))
             .getCallee());
     F.setPersonalityFn(Personality);

--- a/llvm/lib/Transforms/Utils/InlineFunction.cpp
+++ b/llvm/lib/Transforms/Utils/InlineFunction.cpp
@@ -2851,6 +2851,18 @@ struct TaskFrameScope {
   }
 };
 
+static bool CilkSuperset(EHPersonality Caller, EHPersonality Callee)
+{
+  switch (Callee) {
+  case EHPersonality::Cilk_C:
+    return Caller == EHPersonality::GNU_C;
+  case EHPersonality::Cilk_CXX:
+    return Caller == EHPersonality::GNU_CXX;
+  default:
+    return false;
+  }
+}
+
 /// This function inlines the called function into the basic block of the
 /// caller. This returns false if it is not possible to inline this call.
 /// The program is still in a well defined state if this occurs though.
@@ -2966,10 +2978,8 @@ llvm::InlineResult llvm::InlineFunction(CallBase &CB, InlineFunctionInfo &IFI,
         // CalledPersonality is a superset.
         Caller->setPersonalityFn(CalledPersonality);
 
-      else if (classifyEHPersonality(CalledPersonality) ==
-                   EHPersonality::Cilk_CXX &&
-               classifyEHPersonality(CallerPersonality) ==
-                   EHPersonality::GNU_CXX)
+      else if (CilkSuperset(classifyEHPersonality(CallerPersonality),
+                            classifyEHPersonality(CalledPersonality)))
         // The Cilk personality is a superset of the caller's.
         Caller->setPersonalityFn(CalledPersonality);
 
@@ -2986,9 +2996,8 @@ llvm::InlineResult llvm::InlineFunction(CallBase &CB, InlineFunctionInfo &IFI,
         //   GNU_CXX.
         // Otherwise, declare that we can't inline.
         if (CalledEHPersonality != getDefaultEHPersonality(T) &&
-            (classifyEHPersonality(CallerPersonality) !=
-                 EHPersonality::Cilk_CXX ||
-             CalledEHPersonality != EHPersonality::GNU_CXX))
+            !CilkSuperset(classifyEHPersonality(CallerPersonality),
+                          CalledEHPersonality))
           return InlineResult::failure("incompatible personality");
       }
     }

--- a/llvm/test/Transforms/Tapir/cilk-gxx-personality-inline.ll
+++ b/llvm/test/Transforms/Tapir/cilk-gxx-personality-inline.ll
@@ -4,7 +4,7 @@
 ; RUN: opt < %s -passes='always-inline' -S | FileCheck %s
 
 ; Function Attrs: alwaysinline
-define weak_odr void @_Z12conv2d_loopsIfEvPT_PKS0_S3_llllllllllllllllllll() #0 personality i32 (...)* @__cilk_personality_v0 {
+define weak_odr void @_Z12conv2d_loopsIfEvPT_PKS0_S3_llllllllllllllllllll() #0 personality i32 (...)* @__cilk_personality_cpp_v0 {
 pfor.end326:
   ret void
 }
@@ -39,11 +39,11 @@ lpad265:                                          ; preds = %invoke.cont266
 ; CHECK: define weak_odr void @_Z12conv2d_loopsIfEvPT_PKS0_S3_llllllllllllllllllll()
 
 ; CHECK: define void @conv2d_f32(
-; CHECK: personality ptr @__cilk_personality_v0 {
+; CHECK: personality ptr @__cilk_personality_cpp_v0 {
 ; CHECK: ret void
 
 ; CHECK: define void @_Z15conv2d_f32_wrapN5boost6python5numpy7ndarrayES2_NS0_5tupleES3_S3_NS0_4listES4_S4_()
-; CHECK: personality ptr @__cilk_personality_v0 {
+; CHECK: personality ptr @__cilk_personality_cpp_v0 {
 
 ; Function Attrs: nofree nosync nounwind willreturn
 declare i8* @llvm.stacksave() #3
@@ -57,7 +57,7 @@ declare i8* @llvm.frameaddress.p0i8(i32 immarg) #5
 ; Function Attrs: nounwind
 declare i32 @llvm.eh.sjlj.setjmp(i8*) #6
 
-declare i32 @__cilk_personality_v0(...)
+declare i32 @__cilk_personality_cpp_v0(...)
 
 declare i32 @__gxx_personality_v0(...)
 


### PR DESCRIPTION
This change is paired with elimination of separate personality libraries in cheetah.