### PR TITLE
[LoopSpawning] Continue removing support for legacy pass manager

### DIFF
--- a/llvm/bindings/ocaml/llvm/META.llvm.in
+++ b/llvm/bindings/ocaml/llvm/META.llvm.in
@@ -53,14 +53,6 @@ package "irreader" (
     archive(native) = "llvm_irreader.cmxa"
 )
 
-package "tapir_opts" (
-    requires = "llvm"
-    version = "@PACKAGE_VERSION@"
-    description = "Tapir Transforms for LLVM"
-    archive(byte) = "llvm_tapir_opts.cma"
-    archive(native) = "llvm_tapir_opts.cmxa"
-)
-
 package "transform_utils" (
     requires = "llvm"
     version = "@PACKAGE_VERSION@"

--- a/llvm/bindings/ocaml/transforms/CMakeLists.txt
+++ b/llvm/bindings/ocaml/transforms/CMakeLists.txt
@@ -1,4 +1,3 @@
 add_subdirectory(passbuilder)
-add_subdirectory(tapir_opts)
 add_subdirectory(utils)
 


### PR DESCRIPTION
Removed some leftover references to `tapir_opts` since it was removed in 721ca4980c4379ed8fb4df2cf28b6ed386bc409e.